### PR TITLE
Use CMake FetchContent for Catch2

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -35,5 +35,4 @@ parsers:
       macro: false
 
 ignore:
-  - "external/"
   - "tests/"

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -18,13 +18,13 @@ jobs:
         - clang
         - gcc
     steps:
+    - uses: actions/checkout@v4
+
     - name: Install prerequisites
       run: |
         dnf -y update
         dnf -y install git cmake ninja-build clang gcc gcc-c++ libstdc++-static
         dnf -y clean all
-
-    - uses: actions/checkout@v4
 
     - name: Verify compiler compatibility
       env:
@@ -60,7 +60,6 @@ jobs:
     - name: Build all
       run: |
         cd .build
-        ln -s ../external/catch2/src src # gcov workaround
         cmake --build . --target all
 
     - name: Run tests

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -18,13 +18,13 @@ jobs:
         - clang
         - gcc
     steps:
+    - uses: actions/checkout@v4
+    
     - name: Install prerequisites
       run: |
         dnf -y update
-        dnf -y install git cmake ninja-build clang gcc gcc-c++ libstdc++-static
+        dnf -y install cmake ninja-build clang gcc gcc-c++ libstdc++-static
         dnf -y clean all
-
-    - uses: actions/checkout@v4
 
     - name: Verify compiler compatibility
       env:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -18,13 +18,13 @@ jobs:
         - clang
         - gcc
     steps:
-    - uses: actions/checkout@v4
-    
     - name: Install prerequisites
       run: |
         dnf -y update
-        dnf -y install cmake ninja-build clang gcc gcc-c++ libstdc++-static
+        dnf -y install git cmake ninja-build clang gcc gcc-c++ libstdc++-static
         dnf -y clean all
+
+    - uses: actions/checkout@v4
 
     - name: Verify compiler compatibility
       env:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -24,10 +24,7 @@ jobs:
         dnf -y install git cmake ninja-build clang gcc gcc-c++ libstdc++-static
         dnf -y clean all
 
-    # To enable submodules, git must be installed before actions/checkout@v3
     - uses: actions/checkout@v4
-      with:
-        submodules: 'true'
 
     - name: Verify compiler compatibility
       env:

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -24,8 +24,6 @@ jobs:
 
     steps:
     - uses: actions/checkout@v4
-      with:
-        submodules: 'true'
     - name: Install prerequisites
       env:
         DEBIAN_FRONTEND: noninteractive

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -24,6 +24,7 @@ jobs:
 
     steps:
     - uses: actions/checkout@v4
+
     - name: Install prerequisites
       env:
         DEBIAN_FRONTEND: noninteractive

--- a/.github/workflows/license.yml
+++ b/.github/workflows/license.yml
@@ -10,9 +10,6 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
     - uses: actions/checkout@v4
-      with:
-        submodules: 'true'
-
     - uses: fossas/fossa-action@main
       with:
         api-key: ${{ secrets.FOSSA_API_KEY }}

--- a/.github/workflows/license.yml
+++ b/.github/workflows/license.yml
@@ -10,6 +10,7 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
     - uses: actions/checkout@v4
+
     - uses: fossas/fossa-action@main
       with:
         api-key: ${{ secrets.FOSSA_API_KEY }}

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,0 @@
-[submodule "external/catch2"]
-	path = external/catch2
-	url = git@github.com:catchorg/Catch2.git

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -10,6 +10,8 @@ if(COVERAGE)
   include(Coverage)
 endif()
 
+include(Catch2)
+
 set(CMAKE_CXX_EXTENSIONS OFF)
 set(CMAKE_CXX_STANDARD 23)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -10,8 +10,6 @@ if(COVERAGE)
   include(Coverage)
 endif()
 
-include(Catch2)
-
 set(CMAKE_CXX_EXTENSIONS OFF)
 set(CMAKE_CXX_STANDARD 23)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
@@ -30,5 +28,6 @@ endif()
 
 add_subdirectory(include)
 
+include(Catch2)
 enable_testing()
 add_subdirectory(tests)

--- a/cmake/Catch2.cmake
+++ b/cmake/Catch2.cmake
@@ -1,0 +1,9 @@
+include(FetchContent)
+FetchContent_Declare(
+  Catch2
+  GIT_SHALLOW    TRUE
+  GIT_REPOSITORY https://github.com/catchorg/Catch2.git
+  GIT_TAG        v3.5.4)
+FetchContent_MakeAvailable(Catch2)
+
+list(APPEND CMAKE_MODULE_PATH ${Catch2_SOURCE_DIR}/extras)

--- a/cmake/Coverage.cmake
+++ b/cmake/Coverage.cmake
@@ -21,7 +21,7 @@ setup_target_for_coverage_gcovr(
     FORMAT ${CODE_COVERAGE_FORMAT}
     EXECUTABLE ${CODE_COVERAGE_TEST}
     EXECUTABLE_ARGS ${CODE_COVERAGE_TEST_ARGS}
-    EXCLUDE "tests" "external"
+    EXCLUDE "tests"
     DEPENDENCIES tests
 )
 

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -4,7 +4,6 @@ set(CMAKE_CXX_EXTENSIONS OFF)
 set(CMAKE_CXX_STANDARD 23)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
-add_subdirectory(catch2)
 add_subdirectory(main)
 add_subdirectory(tests)
 add_subdirectory(examples)

--- a/tests/catch2
+++ b/tests/catch2
@@ -1,1 +1,0 @@
-../external/catch2


### PR DESCRIPTION
Submodules are awkward and require the user of the library to clone the repo with special arg (`--recurse-submodules`) in order to fetch dependencies. CMake can do better than that if we use its FetchContent functionality. 

With the changes in this PR one can simply clone the repo and cmake as usual to get a working build without submodules.