### PR TITLE
Update ISC wording

### DIFF
--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,8 +1,8 @@
-ISC License
+# ISC License
 
 Copyright (c) 2024, Bronek Kozicki, Alex Kremer, Gašper Ažman
 
-Permission to use, copy, modify, and distribute this software for any
+Permission to use, copy, modify, and/or distribute this software for any
 purpose with or without fee is hereby granted, provided that the above
 copyright notice and this permission notice appear in all copies.
 


### PR DESCRIPTION
This is for consistency with https://opensource.org/licenses/ISC (which is referred to by all the source files)

The updated wording took effect in 2007, as per https://en.wikipedia.org/wiki/ISC_license

This change requires approval from all the license holders @atomgalaxy @godexsoft 