### PR TITLE
Swap functor arguments

### DIFF
--- a/include/functional/and_then.hpp
+++ b/include/functional/and_then.hpp
@@ -56,7 +56,7 @@ constexpr inline struct and_then_t final {
 } and_then = {};
 
 struct and_then_t::apply final {
-  [[nodiscard]] static constexpr auto operator()(auto &&fn, some_monadic_type auto &&v) noexcept //
+  [[nodiscard]] static constexpr auto operator()(some_monadic_type auto &&v, auto &&fn) noexcept //
       -> same_kind<decltype(v)> auto
     requires invocable_and_then<decltype(fn), decltype(v)>
   {

--- a/include/functional/detail/pack_impl.hpp
+++ b/include/functional/detail/pack_impl.hpp
@@ -50,6 +50,16 @@ template <std::size_t... Is, typename... Ts> struct pack_impl<std::index_sequenc
 
   template <typename Self, typename Fn, typename... Args>
     requires(not(... || (_some_pack<Args> || _some_sum<Args>)))
+  static constexpr auto _swap_invoke(Self &&self, Fn &&fn, Args &&...args) noexcept
+      -> ::std::invoke_result<decltype(fn), decltype(args)..., apply_const_lvalue_t<Self, Ts &&>...>::type
+    requires(::std::is_invocable<decltype(fn), decltype(args)..., apply_const_lvalue_t<Self, Ts &&>...>::value)
+  {
+    return ::std::invoke(FWD(fn), FWD(args)...,
+                         static_cast<apply_const_lvalue_t<Self, Ts &&>>(FWD(self)._element<Is, Ts>::v)...);
+  }
+
+  template <typename Self, typename Fn, typename... Args>
+    requires(not(... || (_some_pack<Args> || _some_sum<Args>)))
   static constexpr auto _invoke(Self &&self, Fn &&fn, Args &&...args) noexcept
       -> _invoke_result<decltype(fn), apply_const_lvalue_t<Self, Ts &&>..., decltype(args)...>::type
     requires(_is_invocable<decltype(fn), apply_const_lvalue_t<Self, Ts &&>..., decltype(args)...>::value)

--- a/include/functional/fail.hpp
+++ b/include/functional/fail.hpp
@@ -39,7 +39,7 @@ constexpr inline struct fail_t final {
 } fail = {};
 
 struct fail_t::apply final {
-  [[nodiscard]] static constexpr auto operator()(auto &&fn, some_expected_non_void auto &&v) noexcept //
+  [[nodiscard]] static constexpr auto operator()(some_expected_non_void auto &&v, auto &&fn) noexcept //
       -> same_monadic_type_as<decltype(v)> auto
     requires invocable_fail<decltype(fn), decltype(v)>
   {
@@ -50,7 +50,7 @@ struct fail_t::apply final {
     return type{std::unexpect, FWD(v).error()};
   }
 
-  [[nodiscard]] static constexpr auto operator()(auto &&fn, some_expected_void auto &&v) noexcept //
+  [[nodiscard]] static constexpr auto operator()(some_expected_void auto &&v, auto &&fn) noexcept //
       -> same_monadic_type_as<decltype(v)> auto
     requires invocable_fail<decltype(fn), decltype(v)>
   {
@@ -61,7 +61,7 @@ struct fail_t::apply final {
     return type{std::unexpect, FWD(v).error()};
   }
 
-  [[nodiscard]] static constexpr auto operator()(auto &&fn, some_optional auto &&v) noexcept
+  [[nodiscard]] static constexpr auto operator()(some_optional auto &&v, auto &&fn) noexcept
       -> same_monadic_type_as<decltype(v)> auto
     requires invocable_fail<decltype(fn), decltype(v)>
   {
@@ -73,7 +73,7 @@ struct fail_t::apply final {
   }
 
   // No support for choice since there's no error to operate on
-  static auto operator()(auto &&, some_choice auto &&) noexcept = delete;
+  static auto operator()(some_choice auto &&v, auto &&...args) noexcept = delete;
 };
 
 } // namespace fn

--- a/include/functional/filter.hpp
+++ b/include/functional/filter.hpp
@@ -48,7 +48,7 @@ constexpr inline struct filter_t final {
 } filter = {};
 
 struct filter_t::apply final {
-  [[nodiscard]] static constexpr auto operator()(auto &&pred, auto &&on_err, some_expected_non_void auto &&v) noexcept
+  [[nodiscard]] static constexpr auto operator()(some_expected_non_void auto &&v, auto &&pred, auto &&on_err) noexcept
       -> same_monadic_type_as<decltype(v)> auto
     requires invocable_filter<decltype(pred), decltype(on_err), decltype(v)>
   {
@@ -61,7 +61,7 @@ struct filter_t::apply final {
     return FWD(v);
   }
 
-  [[nodiscard]] static constexpr auto operator()(auto &&pred, auto &&on_err, some_expected_void auto &&v) noexcept
+  [[nodiscard]] static constexpr auto operator()(some_expected_void auto &&v, auto &&pred, auto &&on_err) noexcept
       -> same_monadic_type_as<decltype(v)> auto
     requires invocable_filter<decltype(pred), decltype(on_err), decltype(v)>
   {
@@ -74,7 +74,7 @@ struct filter_t::apply final {
     return FWD(v);
   }
 
-  [[nodiscard]] static constexpr auto operator()(auto &&pred, some_optional auto &&v) noexcept
+  [[nodiscard]] static constexpr auto operator()(some_optional auto &&v, auto &&pred) noexcept
       -> same_monadic_type_as<decltype(v)> auto
     requires invocable_filter<decltype(pred), void, decltype(v)>
   {
@@ -88,7 +88,7 @@ struct filter_t::apply final {
   }
 
   // No support for choice since there's no error to operate on
-  static auto operator()(auto &&, some_choice auto &&v) noexcept = delete;
+  static auto operator()(some_choice auto &&v, auto &&...args) noexcept = delete;
 };
 
 } // namespace fn

--- a/include/functional/functor.hpp
+++ b/include/functional/functor.hpp
@@ -17,7 +17,7 @@
 namespace fn {
 template <typename Functor, typename V, typename... Args>
 concept monadic_invocable //
-    = some_monadic_type<V> && invocable<typename Functor::apply, Args..., V>;
+    = some_monadic_type<V> && ::std::invocable<typename Functor::apply, V, Args...>;
 
 template <typename Functor, typename... Args> struct functor final {
   using functor_type = Functor;
@@ -34,7 +34,7 @@ template <typename Functor, typename... Args> struct functor final {
     requires std::same_as<std::remove_cvref_t<decltype(self)>, functor>
              && monadic_invocable<functor_type, decltype(v), Args...>
   {
-    return FWD(self).data.invoke(functor_apply{}, FWD(v));
+    return data_t::_swap_invoke(FWD(self).data, functor_apply{}, FWD(v));
   }
 };
 

--- a/include/functional/inspect.hpp
+++ b/include/functional/inspect.hpp
@@ -44,7 +44,7 @@ constexpr inline struct inspect_t final {
 } inspect = {};
 
 struct inspect_t::apply final {
-  [[nodiscard]] static constexpr auto operator()(auto &&fn, some_expected_non_void auto &&v) noexcept -> decltype(v)
+  [[nodiscard]] static constexpr auto operator()(some_expected_non_void auto &&v, auto &&fn) noexcept -> decltype(v)
     requires invocable_inspect<decltype(fn), decltype(v)>
   {
     if (v.has_value()) {
@@ -53,7 +53,7 @@ struct inspect_t::apply final {
     return FWD(v);
   }
 
-  [[nodiscard]] static constexpr auto operator()(auto &&fn, some_expected_void auto &&v) noexcept -> decltype(v)
+  [[nodiscard]] static constexpr auto operator()(some_expected_void auto &&v, auto &&fn) noexcept -> decltype(v)
     requires invocable_inspect<decltype(fn), decltype(v)>
   {
     if (v.has_value()) {
@@ -62,7 +62,7 @@ struct inspect_t::apply final {
     return FWD(v);
   }
 
-  [[nodiscard]] static constexpr auto operator()(auto &&fn, some_optional auto &&v) noexcept -> decltype(v)
+  [[nodiscard]] static constexpr auto operator()(some_optional auto &&v, auto &&fn) noexcept -> decltype(v)
     requires invocable_inspect<decltype(fn), decltype(v)>
   {
     if (v.has_value()) {
@@ -71,7 +71,7 @@ struct inspect_t::apply final {
     return FWD(v);
   }
 
-  [[nodiscard]] static constexpr auto operator()(auto &&fn, some_choice auto &&v) noexcept -> decltype(v)
+  [[nodiscard]] static constexpr auto operator()(some_choice auto &&v, auto &&fn) noexcept -> decltype(v)
     requires invocable_inspect<decltype(fn), decltype(v)>
   {
     ::fn::invoke(FWD(fn), std::as_const(v).value()); // side-effects only

--- a/include/functional/inspect_error.hpp
+++ b/include/functional/inspect_error.hpp
@@ -35,7 +35,7 @@ constexpr inline struct inspect_error_t final {
 } inspect_error = {};
 
 struct inspect_error_t::apply final {
-  [[nodiscard]] static constexpr auto operator()(auto &&fn, some_expected auto &&v) noexcept -> decltype(v)
+  [[nodiscard]] static constexpr auto operator()(some_expected auto &&v, auto &&fn) noexcept -> decltype(v)
     requires invocable_inspect_error<decltype(fn), decltype(v)>
   {
     if (not v.has_value()) {
@@ -44,7 +44,7 @@ struct inspect_error_t::apply final {
     return FWD(v);
   }
 
-  [[nodiscard]] static constexpr auto operator()(auto &&fn, some_optional auto &&v) noexcept -> decltype(v)
+  [[nodiscard]] static constexpr auto operator()(some_optional auto &&v, auto &&fn) noexcept -> decltype(v)
     requires invocable_inspect_error<decltype(fn), decltype(v)>
   {
     if (not v.has_value()) {
@@ -54,7 +54,7 @@ struct inspect_error_t::apply final {
   }
 
   // No support for choice since there's no error to operate on
-  static auto operator()(auto &&, some_choice auto &&) noexcept = delete;
+  static auto operator()(some_choice auto &&v, auto &&...args) noexcept = delete;
 };
 
 } // namespace fn

--- a/include/functional/or_else.hpp
+++ b/include/functional/or_else.hpp
@@ -43,7 +43,7 @@ constexpr inline struct or_else_t final {
 } or_else = {};
 
 struct or_else_t::apply final {
-  [[nodiscard]] static constexpr auto operator()(auto &&fn, some_monadic_type auto &&v) noexcept //
+  [[nodiscard]] static constexpr auto operator()(some_monadic_type auto &&v, auto &&fn) noexcept //
       -> same_value_kind<decltype(v)> auto
     requires invocable_or_else<decltype(fn), decltype(v)>
   {
@@ -51,7 +51,7 @@ struct or_else_t::apply final {
   }
 
   // No support for choice since there's no error to recover from
-  static auto operator()(auto &&, some_choice auto &&) noexcept = delete;
+  static auto operator()(some_choice auto &&v, auto &&...args) noexcept = delete;
 };
 
 } // namespace fn

--- a/include/functional/recover.hpp
+++ b/include/functional/recover.hpp
@@ -40,7 +40,7 @@ constexpr inline struct recover_t final {
 } recover = {};
 
 struct recover_t::apply final {
-  [[nodiscard]] static constexpr auto operator()(auto &&fn, some_expected_non_void auto &&v) noexcept
+  [[nodiscard]] static constexpr auto operator()(some_expected_non_void auto &&v, auto &&fn) noexcept
       -> same_monadic_type_as<decltype(v)> auto
     requires invocable_recover<decltype(fn), decltype(v)>
   {
@@ -51,7 +51,7 @@ struct recover_t::apply final {
     return type{std::in_place, ::fn::invoke(FWD(fn), FWD(v).error())};
   }
 
-  [[nodiscard]] static constexpr auto operator()(auto &&fn, some_expected_void auto &&v) noexcept
+  [[nodiscard]] static constexpr auto operator()(some_expected_void auto &&v, auto &&fn) noexcept
       -> same_monadic_type_as<decltype(v)> auto
     requires invocable_recover<decltype(fn), decltype(v)>
   {
@@ -63,7 +63,7 @@ struct recover_t::apply final {
     return type{std::in_place};
   }
 
-  [[nodiscard]] static constexpr auto operator()(auto &&fn, some_optional auto &&v) noexcept
+  [[nodiscard]] static constexpr auto operator()(some_optional auto &&v, auto &&fn) noexcept
       -> same_monadic_type_as<decltype(v)> auto
     requires invocable_recover<decltype(fn), decltype(v)>
   {
@@ -75,7 +75,7 @@ struct recover_t::apply final {
   }
 
   // No support for choice since there's no error to recover from
-  static auto operator()(auto &&, some_choice auto &&) noexcept = delete;
+  static auto operator()(some_choice auto &&v, auto &&...args) noexcept = delete;
 };
 
 } // namespace fn

--- a/include/functional/transform.hpp
+++ b/include/functional/transform.hpp
@@ -57,7 +57,7 @@ static constexpr struct transform_t final {
 } transform = {};
 
 struct transform_t::apply final {
-  [[nodiscard]] static constexpr auto operator()(auto &&fn, some_monadic_type auto &&v) noexcept
+  [[nodiscard]] static constexpr auto operator()(some_monadic_type auto &&v, auto &&fn) noexcept
       -> same_kind<decltype(v)> auto
     requires invocable_transform<decltype(fn), decltype(v)>
   {

--- a/include/functional/transform_error.hpp
+++ b/include/functional/transform_error.hpp
@@ -33,7 +33,7 @@ constexpr inline struct transform_error_t final {
 } transform_error = {};
 
 struct transform_error_t::apply final {
-  [[nodiscard]] static constexpr auto operator()(auto &&fn, some_expected auto &&v) noexcept
+  [[nodiscard]] static constexpr auto operator()(some_expected auto &&v, auto &&fn) noexcept
       -> same_value_kind<decltype(v)> auto
     requires invocable_transform_error<decltype(fn), decltype(v)>
   {
@@ -41,10 +41,10 @@ struct transform_error_t::apply final {
   }
 
   // No support for optional since there's no error state to operate on
-  static auto operator()(auto &&, some_optional auto &&) noexcept = delete;
+  static auto operator()(some_optional auto &&v, auto &&...args) noexcept = delete;
 
   // No support for choice since there's no error to operate on
-  static auto operator()(auto &&, some_choice auto &&) noexcept = delete;
+  static auto operator()(some_choice auto &&v, auto &&...args) noexcept = delete;
 };
 
 } // namespace fn

--- a/tests/tests/and_then.cpp
+++ b/tests/tests/and_then.cpp
@@ -86,7 +86,7 @@ TEST_CASE("and_then_member", "[and_then][member_functions]")
     {
       static_assert(monadic_static_check<fn::and_then_t, decltype(v)>::invocable_with_any(Xint::efn));
 
-      auto const r = fn::invoke(and_then_t::apply{}, Xint::efn, v);
+      auto const r = fn::invoke(and_then_t::apply{}, v, Xint::efn);
       CHECK(r.value() == 2);
 
       auto const q = v | and_then(&Xint::efn);
@@ -99,7 +99,7 @@ TEST_CASE("and_then_member", "[and_then][member_functions]")
     {
       static_assert(monadic_static_check<fn::and_then_t, decltype(v)>::invocable_with_any(&Xint::efn2));
 
-      auto const r = fn::invoke(and_then_t::apply{}, &Xint::efn2, v);
+      auto const r = fn::invoke(and_then_t::apply{}, v, &Xint::efn2);
       CHECK(r.value() == 4);
 
       auto const q = v | and_then(&Xint::efn2);
@@ -116,7 +116,7 @@ TEST_CASE("and_then_member", "[and_then][member_functions]")
       static_assert(
           monadic_static_check<fn::and_then_t, decltype(v)>::invocable<prvalue, crvalue, cvalue>(&Xint::efn4));
 
-      auto const r = fn::invoke(and_then_t::apply{}, &Xint::efn4, std::move(v));
+      auto const r = fn::invoke(and_then_t::apply{}, std::move(v), &Xint::efn4);
       CHECK(r.value() == 6);
 
       auto const q = std::move(v) | and_then(&Xint::efn4);
@@ -136,7 +136,7 @@ TEST_CASE("and_then_member", "[and_then][member_functions]")
     {
       static_assert(monadic_static_check<fn::and_then_t, decltype(v)>::invocable_with_any(Xint::efn));
 
-      auto const r = fn::invoke(and_then_t::apply{}, Xint::efn, v);
+      auto const r = fn::invoke(and_then_t::apply{}, v, Xint::efn);
       CHECK(r.value() == 2);
 
       auto const q = v | and_then(&Xint::efn);
@@ -147,7 +147,7 @@ TEST_CASE("and_then_member", "[and_then][member_functions]")
     {
       static_assert(monadic_static_check<fn::and_then_t, decltype(v)>::invocable<lvalue>(&Xint::efn1));
 
-      auto const r = fn::invoke(and_then_t::apply{}, &Xint::efn1, v);
+      auto const r = fn::invoke(and_then_t::apply{}, v, &Xint::efn1);
       CHECK(r.value() == 3);
 
       auto const q = v | and_then(&Xint::efn1);
@@ -162,7 +162,7 @@ TEST_CASE("and_then_member", "[and_then][member_functions]")
       static_assert(monadic_static_check<fn::and_then_t, decltype(v)>::invocable_with_any(&Xint::efn2));
 
       // rvalue-ref
-      auto const r = fn::invoke(and_then_t::apply{}, &Xint::efn2, v);
+      auto const r = fn::invoke(and_then_t::apply{}, v, &Xint::efn2);
       CHECK(r.value() == 4);
 
       auto const q = v | and_then(&Xint::efn2);
@@ -176,7 +176,7 @@ TEST_CASE("and_then_member", "[and_then][member_functions]")
     {
       static_assert(monadic_static_check<fn::and_then_t, decltype(v)>::invocable<prvalue, rvalue>(&Xint::efn3));
 
-      auto const r = fn::invoke(and_then_t::apply{}, &Xint::efn3, std::move(v));
+      auto const r = fn::invoke(and_then_t::apply{}, std::move(v), &Xint::efn3);
       CHECK(r.value() == 5);
 
       auto const q = std::move(v) | and_then(&Xint::efn3);
@@ -191,7 +191,7 @@ TEST_CASE("and_then_member", "[and_then][member_functions]")
       static_assert(
           monadic_static_check<fn::and_then_t, decltype(v)>::invocable<prvalue, crvalue, cvalue>(&Xint::efn4));
 
-      auto const r = fn::invoke(and_then_t::apply{}, &Xint::efn4, std::move(v));
+      auto const r = fn::invoke(and_then_t::apply{}, std::move(v), &Xint::efn4);
       CHECK(r.value() == 6);
 
       auto const q = std::move(v) | and_then(&Xint::efn4);
@@ -211,7 +211,7 @@ TEST_CASE("and_then_member", "[and_then][member_functions]")
     {
       static_assert(monadic_static_check<fn::and_then_t, decltype(v)>::invocable_with_any(&Xint::ofn));
 
-      auto const r = fn::invoke(and_then_t::apply{}, Xint::ofn, v);
+      auto const r = fn::invoke(and_then_t::apply{}, v, Xint::ofn);
       CHECK(r.value() == 2);
 
       auto const q = v | and_then(&Xint::ofn);
@@ -224,7 +224,7 @@ TEST_CASE("and_then_member", "[and_then][member_functions]")
     {
       static_assert(monadic_static_check<fn::and_then_t, decltype(v)>::invocable_with_any(&Xint::ofn2));
 
-      auto const r = fn::invoke(and_then_t::apply{}, &Xint::ofn2, v);
+      auto const r = fn::invoke(and_then_t::apply{}, v, &Xint::ofn2);
       CHECK(r.value() == 4);
 
       auto const q = v | and_then(&Xint::ofn2);
@@ -241,7 +241,7 @@ TEST_CASE("and_then_member", "[and_then][member_functions]")
       static_assert(
           monadic_static_check<fn::and_then_t, decltype(v)>::invocable<prvalue, crvalue, cvalue>(&Xint::ofn4));
 
-      auto const r = fn::invoke(and_then_t::apply{}, &Xint::ofn4, std::move(v));
+      auto const r = fn::invoke(and_then_t::apply{}, std::move(v), &Xint::ofn4);
       CHECK(r.value() == 6);
 
       auto const q = std::move(v) | and_then(&Xint::ofn4);
@@ -261,7 +261,7 @@ TEST_CASE("and_then_member", "[and_then][member_functions]")
     {
       static_assert(monadic_static_check<fn::and_then_t, decltype(v)>::invocable_with_any(Xint::ofn));
 
-      auto const r = fn::invoke(and_then_t::apply{}, Xint::ofn, v);
+      auto const r = fn::invoke(and_then_t::apply{}, v, Xint::ofn);
       CHECK(r.value() == 2);
 
       auto const q = v | and_then(&Xint::ofn);
@@ -272,7 +272,7 @@ TEST_CASE("and_then_member", "[and_then][member_functions]")
     {
       static_assert(monadic_static_check<fn::and_then_t, decltype(v)>::invocable<lvalue>(&Xint::ofn1));
 
-      auto const r = fn::invoke(and_then_t::apply{}, &Xint::ofn1, v);
+      auto const r = fn::invoke(and_then_t::apply{}, v, &Xint::ofn1);
       CHECK(r.value() == 3);
 
       auto const q = v | and_then(&Xint::ofn1);
@@ -287,7 +287,7 @@ TEST_CASE("and_then_member", "[and_then][member_functions]")
       static_assert(monadic_static_check<fn::and_then_t, decltype(v)>::invocable_with_any(&Xint::ofn2));
 
       // rvalue-ref
-      auto const r = fn::invoke(and_then_t::apply{}, &Xint::ofn2, v);
+      auto const r = fn::invoke(and_then_t::apply{}, v, &Xint::ofn2);
       CHECK(r.value() == 4);
 
       auto const q = v | and_then(&Xint::ofn2);
@@ -301,7 +301,7 @@ TEST_CASE("and_then_member", "[and_then][member_functions]")
     {
       static_assert(monadic_static_check<fn::and_then_t, decltype(v)>::invocable<prvalue, rvalue>(&Xint::ofn3));
 
-      auto const r = fn::invoke(and_then_t::apply{}, &Xint::ofn3, std::move(v));
+      auto const r = fn::invoke(and_then_t::apply{}, std::move(v), &Xint::ofn3);
       CHECK(r.value() == 5);
 
       auto const q = std::move(v) | and_then(&Xint::ofn3);
@@ -316,7 +316,7 @@ TEST_CASE("and_then_member", "[and_then][member_functions]")
       static_assert(
           monadic_static_check<fn::and_then_t, decltype(v)>::invocable<prvalue, crvalue, cvalue>(&Xint::ofn4));
 
-      auto const r = fn::invoke(and_then_t::apply{}, &Xint::ofn4, std::move(v));
+      auto const r = fn::invoke(and_then_t::apply{}, std::move(v), &Xint::ofn4);
       CHECK(r.value() == 6);
 
       auto const q = std::move(v) | and_then(&Xint::ofn4);

--- a/tests/tests/functor.cpp
+++ b/tests/tests/functor.cpp
@@ -16,7 +16,7 @@ constexpr inline struct dummy_t final {
   auto operator()(auto &&fn) const noexcept -> fn::functor<dummy_t, decltype(fn)> { return {FWD(fn)}; }
 
   struct apply final {
-    static auto operator()(auto &&fn, fn::some_monadic_type auto &&v) noexcept -> decltype(auto)
+    static auto operator()(fn::some_monadic_type auto &&v, auto &&fn) noexcept -> decltype(auto)
       requires requires { fn(v.value()); }
     {
       return FWD(v).transform([&fn](auto &&v) noexcept { return FWD(fn)(FWD(v)); });


### PR DESCRIPTION
This brings back the order of functor arguments as it was before https://github.com/libfn/functional/pull/72 . 