### PR TITLE
Make tooling available thru nix

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,7 +2,7 @@
 .idea_modules/
 .build*/
 build*/
-result/
+result
 .clangd
 .devcontainer/
 .vscode/

--- a/flake.lock
+++ b/flake.lock
@@ -5,11 +5,11 @@
         "nixpkgs-lib": "nixpkgs-lib"
       },
       "locked": {
-        "lastModified": 1712014858,
-        "narHash": "sha256-sB4SWl2lX95bExY2gMFG5HIzvva5AVMJd4Igm+GpZNw=",
+        "lastModified": 1715865404,
+        "narHash": "sha256-/GJvTdTpuDjNn84j82cU6bXztE0MSkdnTWClUCRub78=",
         "owner": "hercules-ci",
         "repo": "flake-parts",
-        "rev": "9126214d0a59633752a136528f5f3b9aa8565b7d",
+        "rev": "8dc45382d5206bd292f9c2768b8058a8fd8311d9",
         "type": "github"
       },
       "original": {
@@ -19,11 +19,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1712791164,
-        "narHash": "sha256-3sbWO1mbpWsLepZGbWaMovSO7ndZeFqDSdX0hZ9nVyw=",
+        "lastModified": 1716137900,
+        "narHash": "sha256-sowPU+tLQv8GlqtVtsXioTKeaQvlMz/pefcdwg8MvfM=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "1042fd8b148a9105f3c0aca3a6177fd1d9360ba5",
+        "rev": "6c0b7a92c30122196a761b440ac0d46d3d9954f1",
         "type": "github"
       },
       "original": {
@@ -35,20 +35,14 @@
     },
     "nixpkgs-lib": {
       "locked": {
-        "dir": "lib",
-        "lastModified": 1711703276,
-        "narHash": "sha256-iMUFArF0WCatKK6RzfUJknjem0H9m4KgorO/p3Dopkk=",
-        "owner": "NixOS",
-        "repo": "nixpkgs",
-        "rev": "d8fe5e6c92d0d190646fb9f1056741a229980089",
-        "type": "github"
+        "lastModified": 1714640452,
+        "narHash": "sha256-QBx10+k6JWz6u7VsohfSw8g8hjdBZEf8CFzXH1/1Z94=",
+        "type": "tarball",
+        "url": "https://github.com/NixOS/nixpkgs/archive/50eb7ecf4cd0a5756d7275c8ba36790e5bd53e33.tar.gz"
       },
       "original": {
-        "dir": "lib",
-        "owner": "NixOS",
-        "ref": "nixos-unstable",
-        "repo": "nixpkgs",
-        "type": "github"
+        "type": "tarball",
+        "url": "https://github.com/NixOS/nixpkgs/archive/50eb7ecf4cd0a5756d7275c8ba36790e5bd53e33.tar.gz"
       }
     },
     "root": {

--- a/nix/README.md
+++ b/nix/README.md
@@ -16,6 +16,7 @@ Software immediately available in the build environment:
 - clangd
 - cmake
 - ccache
+- ninja
 
 The default compiler is gcc.
 

--- a/nix/README.md
+++ b/nix/README.md
@@ -9,6 +9,14 @@ It's as simple as running a command in your terminal.
 > [!NOTE]  
 > First build will trigger multiple downloads. 
 
+Software immediately available in the build environment:
+- Compiler (clang or gcc)
+- clang-format
+- clang-tidy
+- clangd
+- cmake
+- ccache
+
 The default compiler is gcc.
 
 ---

--- a/nix/package.nix
+++ b/nix/package.nix
@@ -4,6 +4,7 @@
 , cmake
 , ccache
 , clang-tools_18
+, ninja
 , enableTests ? true
 }:
 
@@ -22,7 +23,7 @@ stdenv.mkDerivation {
     "LICENSE.md"
   ];
 
-  nativeBuildInputs = [ cmake ccache clang-tools_18 ];
+  nativeBuildInputs = [ cmake ninja ccache clang-tools_18 ];
   buildInputs = [ catch2_local ];
   checkInputs = [ ];
 

--- a/nix/package.nix
+++ b/nix/package.nix
@@ -3,6 +3,7 @@
 , stdenv
 , cmake
 , ccache
+, clang-tools_18
 , enableTests ? true
 }:
 
@@ -21,7 +22,7 @@ stdenv.mkDerivation {
     "LICENSE.md"
   ];
 
-  nativeBuildInputs = [ cmake ccache ];
+  nativeBuildInputs = [ cmake ccache clang-tools_18 ];
   buildInputs = [ catch2_local ];
   checkInputs = [ ];
 


### PR DESCRIPTION
This PR adds clang tooling thru nix. Meaning doing `nix develop .` now will give you not just the compilers and `cmake` with `ccache` but also `ninja`, `clang-format`, `clang-tidy` and `clangd`.