### PR TITLE
Fix Catch2.cmake

### DIFF
--- a/cmake/Catch2.cmake
+++ b/cmake/Catch2.cmake
@@ -4,7 +4,6 @@ else()
   if(DEFINED ENV{CMAKE_FIND_CATCH2})
     find_package(Catch2 3)
   else()
-    find_package(Catch2 3)
     include(FetchContent)
     FetchContent_Declare(
       Catch2


### PR DESCRIPTION
Remove erroneous find_package when we are about to fetch it