### PR TITLE
Add more compilers

### DIFF
--- a/.github/workflows/ci-build.yml
+++ b/.github/workflows/ci-build.yml
@@ -26,8 +26,11 @@ jobs:
       fail-fast: false
       matrix:
         compiler:
+          - gcc:12
           - gcc:13
           - gcc:14
+          - clang:16
+          - clang:17
           - clang:18
           - clang:19
         platform:
@@ -67,8 +70,11 @@ jobs:
     strategy:
       matrix:
         compiler:
+          - gcc:12
           - gcc:13
           - gcc:14
+          - clang:16
+          - clang:17
           - clang:18
           - clang:19
 


### PR DESCRIPTION
This change will create `libfn/ci-build` docker images for gcc:12 clang:16 clang:17 , which in due time we want to support for C++20 compatibility.

Yet to figure out Visual Studio (want to support at least 2022) and MacOS (possibly not needed, overlaps with clang:16) targets.