### PR TITLE
Run coverage on every push to main

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -4,13 +4,6 @@ on:
   push:
     branches:
       - main
-    paths:
-      - '.github/workflows/coverage.yml'
-      - 'include/**'
-      - 'tests/**'
-      - 'CMakeLists.txt'
-      - 'cmake/**'
-      - '.codecov.yml'
   pull_request:
     branches:
       - main


### PR DESCRIPTION
This is needed to avoid [Missing base report](https://docs.codecov.com/docs/error-reference#missing-base-report) error at [codecov.io](https://app.codecov.io/github/libfn/functional)