### PR TITLE
Add `discard` functor

### DIFF
--- a/docs/expected/discard.md
+++ b/docs/expected/discard.md
@@ -1,0 +1,29 @@
+---
+title: fn::discard
+---
+
+##### Defined in {style: "api", badge: "#include <fn/discard.hpp>"}
+
+---
+
+:include-doxygen-doc: fn::discard_t
+
+---
+
+## Call signatures {style: "api"}
+:include-doxygen-member: fn::discard_t::operator() { signatureOnly: false, includeAllMatches: true }
+
+---
+
+## Return value {style: "api"}
+void
+
+---
+
+## Examples {style: "api"}
+
+:include-template: templates/snippet.md {
+    path:  "examples/simple.cpp",
+    surroundedBy: ["// example-error-struct", "// example-expected-discard"],
+    desc:  "`42` is observed by `inspect` and the value is discarded by `discard` (no warning for discarded result of `inspect`)."
+}

--- a/docs/optional/discard.md
+++ b/docs/optional/discard.md
@@ -1,0 +1,29 @@
+---
+title: fn::discard
+---
+
+##### Defined in {style: "api", badge: "#include <fn/discard.hpp>"}
+
+---
+
+:include-doxygen-doc: fn::discard_t
+
+---
+
+## Call signatures {style: "api"}
+:include-doxygen-member: fn::discard_t::operator() { signatureOnly: false, includeAllMatches: true }
+
+---
+
+## Return value {style: "api"}
+void
+
+---
+
+## Examples {style: "api"}
+
+:include-template: templates/snippet.md {
+    path:  "examples/simple.cpp",
+    surroundedBy: ["// example-error-struct", "// example-optional-discard"],
+    desc:  "`42` is observed by `inspect` and the value is discarded by `discard` (no warning for discarded result of `inspect`)."
+}

--- a/docs/toc
+++ b/docs/toc
@@ -1,5 +1,6 @@
 expected
     and_then
+    discard
     fail
     filter
     inspect_error
@@ -11,6 +12,7 @@ expected
     value_or
 optional
     and_then
+    discard
     fail
     filter
     inspect_error

--- a/include/CMakeLists.txt
+++ b/include/CMakeLists.txt
@@ -17,6 +17,7 @@ set(INCLUDE_FN_HEADERS
     fn/and_then.hpp
     fn/choice.hpp
     fn/concepts.hpp
+    fn/discard.hpp
     fn/expected.hpp
     fn/fail.hpp
     fn/filter.hpp

--- a/include/fn/detail/fwd.hpp
+++ b/include/fn/detail/fwd.hpp
@@ -12,6 +12,7 @@ namespace fn {
 
 // functors
 struct and_then_t;
+struct discard_t;
 struct transform_t;
 struct transform_error_t;
 struct or_else_t;

--- a/include/fn/discard.hpp
+++ b/include/fn/discard.hpp
@@ -1,0 +1,38 @@
+// Copyright (c) 2025 Bronek Kozicki, Alex Kremer
+//
+// Distributed under the ISC License. See accompanying file LICENSE.md
+// or copy at https://opensource.org/licenses/ISC
+
+#ifndef INCLUDE_FUNCTIONAL_DISCARD
+#define INCLUDE_FUNCTIONAL_DISCARD
+
+#include <fn/concepts.hpp>
+#include <fn/functor.hpp>
+
+#include <concepts>
+#include <type_traits>
+#include <utility>
+
+namespace fn {
+/**
+ * @brief Discard the value explicitly
+ *
+ * This is useful when only side-effects are desired and the final value is not needed.
+ *
+ * Use through the `fn::discard` nielbloid.
+ */
+constexpr inline struct discard_t final {
+  /**
+   * @brief Unconditionally discards the value
+   * @return A functor that explicitly discards the value
+   */
+  [[nodiscard]] constexpr auto operator()() const noexcept -> functor<discard_t> { return {}; }
+
+  struct apply final {
+    static constexpr auto operator()(some_monadic_type auto &&) noexcept -> void {}
+  };
+} discard = {};
+
+} // namespace fn
+
+#endif // INCLUDE_FUNCTIONAL_DISCARD

--- a/include/fn/functor.hpp
+++ b/include/fn/functor.hpp
@@ -39,7 +39,6 @@ template <typename Functor, typename... Args> struct functor final {
   using data_t = pack<as_value_t<Args>...>;
   data_t data;
 
-  static_assert(sizeof...(Args) > 0); // NOTE Consider relaxing
   static_assert(std::is_empty_v<functor_type> && std::is_empty_v<functor_apply>
                 && std::is_default_constructible_v<functor_type> && std::is_default_constructible_v<functor_apply>);
 

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -22,6 +22,7 @@ set(TESTS_FN_SOURCES
     fn/and_then.cpp
     fn/choice.cpp
     fn/concepts.cpp
+    fn/discard.cpp
     fn/expected.cpp
     fn/fail.cpp
     fn/filter.cpp

--- a/tests/fn/discard.cpp
+++ b/tests/fn/discard.cpp
@@ -1,0 +1,231 @@
+// Copyright (c) 2025 Bronek Kozicki, Alex Kremer
+//
+// Distributed under the ISC License. See accompanying file LICENSE.md
+// or copy at https://opensource.org/licenses/ISC
+
+#include "util/static_check.hpp"
+
+#include <fn/discard.hpp>
+
+#include <catch2/catch_all.hpp>
+
+#include <string>
+#include <utility>
+
+using namespace util;
+
+namespace {
+struct Error {
+  std::string what;
+};
+
+struct DerivedError : Error {};
+struct IncompatibleError {};
+
+struct Value {
+  int v;
+  constexpr bool operator==(Value const &) const = default;
+};
+} // namespace
+
+TEST_CASE("discard", "[discard][expected][expected_value]")
+{
+  using namespace fn;
+
+  using operand_t = fn::expected<int, Error>;
+  using is = monadic_static_check<discard_t, operand_t>;
+
+  static_assert(is::invocable_with_any());
+  static_assert(is::not_invocable_with_any([] {})); // no arguments allowed
+
+  WHEN("operand is lvalue")
+  {
+    WHEN("operand is value")
+    {
+      operand_t a{std::in_place, 42};
+      a | discard();
+
+      REQUIRE(a.value() == 42);
+    }
+
+    WHEN("operand is error")
+    {
+      operand_t a{std::unexpect, Error{"Not good"}};
+      a | discard();
+
+      REQUIRE(a.error().what == "Not good");
+    }
+  }
+
+  WHEN("operand is rvalue")
+  {
+    WHEN("operand is value")
+    {
+      operand_t{std::in_place, 42} | discard();
+      SUCCEED();
+    }
+
+    WHEN("operand is error")
+    {
+      operand_t{std::unexpect, Error{"Not good"}} | discard();
+      SUCCEED();
+    }
+  }
+}
+
+TEST_CASE("discard with pack", "[discard][expected][expected_value][pack]")
+{
+  using namespace fn;
+
+  WHEN("operand is a pack")
+  {
+    using operand_t = fn::expected<fn::pack<int, double>, Error>;
+    constexpr operand_t a{std::in_place, fn::pack{84, 0.5}};
+
+    using is = monadic_static_check<discard_t, operand_t>;
+    static_assert(is::invocable_with_any());
+
+    a | discard();
+
+    REQUIRE(a.has_value());
+
+    WHEN("operand is error")
+    {
+      operand_t b{std::unexpect, Error{"Pack error"}};
+      b | discard();
+
+      REQUIRE(b.error().what == "Pack error");
+    }
+  }
+}
+
+TEST_CASE("discard", "[discard][expected][expected_void]")
+{
+  using namespace fn;
+
+  using operand_t = fn::expected<void, Error>;
+  using is = monadic_static_check<discard_t, operand_t>;
+
+  static_assert(is::invocable_with_any());
+  static_assert(is::not_invocable_with_any([] {})); // no arguments allowed
+
+  WHEN("operand is lvalue")
+  {
+    WHEN("operand is value")
+    {
+      operand_t a{std::in_place};
+      a | discard();
+
+      REQUIRE(a.has_value());
+    }
+
+    WHEN("operand is error")
+    {
+      operand_t a{std::unexpect, Error{"Not good"}};
+      a | discard();
+
+      REQUIRE(a.error().what == "Not good");
+    }
+  }
+
+  WHEN("operand is rvalue")
+  {
+    WHEN("operand is value")
+    {
+      operand_t{std::in_place} | discard();
+      SUCCEED();
+    }
+
+    WHEN("operand is error")
+    {
+      operand_t{std::unexpect, Error{"Not good"}} | discard();
+      SUCCEED();
+    }
+  }
+}
+
+TEST_CASE("discard", "[discard][optional]")
+{
+  using namespace fn;
+
+  using operand_t = fn::optional<int>;
+  using is = monadic_static_check<discard_t, operand_t>;
+
+  static_assert(is::invocable_with_any());
+  static_assert(is::not_invocable_with_any([] {})); // no arguments allowed
+
+  WHEN("operand is lvalue")
+  {
+    WHEN("operand is value")
+    {
+      operand_t a{42};
+      a | discard();
+
+      REQUIRE(a.has_value());
+      REQUIRE(a.value() == 42);
+    }
+
+    WHEN("operand is nullopt")
+    {
+      operand_t a{std::nullopt};
+      a | discard();
+
+      REQUIRE(!a.has_value());
+    }
+  }
+
+  WHEN("operand is rvalue")
+  {
+    WHEN("operand is value")
+    {
+      operand_t{42} | discard();
+      SUCCEED();
+    }
+
+    WHEN("operand is nullopt")
+    {
+      operand_t{std::nullopt} | discard();
+      SUCCEED();
+    }
+  }
+}
+
+TEST_CASE("constexpr discard expected", "[discard][constexpr][expected]")
+{
+  using namespace fn;
+
+  enum class Error { ThresholdExceeded, SomethingElse };
+  using T = fn::expected<int, Error>;
+
+  constexpr auto a = T{42};
+  constexpr auto b = T{std::unexpect, Error::ThresholdExceeded};
+
+  constexpr auto test = [](T v) {
+    v | discard();
+    return true;
+  };
+
+  static_assert(test(a));
+  static_assert(test(b));
+
+  SUCCEED();
+}
+
+TEST_CASE("constexpr discard optional", "[discard][constexpr][optional]")
+{
+  using namespace fn;
+  using T = fn::optional<int>;
+
+  constexpr auto a = T{42};
+  constexpr auto b = T{std::nullopt};
+
+  constexpr auto test = [](T v) {
+    v | discard();
+    return true;
+  };
+
+  static_assert(test(a));
+  static_assert(test(b));
+
+  SUCCEED();
+}


### PR DESCRIPTION
The `discard` functor can be used to prevent compilation warnings when using `functional` for side-effects-only (`[[nodiscard]]`).
- The `apply` struct had to be moved inside the `discard_t` because it fails to compile otherwise (suggestions welcome)
- Tests are in `tests/fn/discard.cpp` but missing any cases for `choice` and friends