### PR TITLE
Refactor `pfn::expected` to move storage to a separate class

### DIFF
--- a/include/pfn/expected.hpp
+++ b/include/pfn/expected.hpp
@@ -372,9 +372,16 @@ template <class T, class E> struct _storage {
   {
   }
 
-  // Leaves `storage_` with no active union member so the derived ctor
-  // body can placement-new the appropriate arm.
-  constexpr explicit _storage(bool s) noexcept : storage_(), set_(s) {}
+  constexpr explicit _storage(bool s, auto &&src) : storage_(), set_(s)
+  {
+    if (set_) {
+      if constexpr (::std::is_void_v<T>)
+        ::std::construct_at(::std::addressof(storage_.v_)); // LCOV_EXCL_LINE trivially constructible
+      else
+        ::std::construct_at(::std::addressof(storage_.v_), FWD(src).v_);
+    } else
+      ::std::construct_at(::std::addressof(storage_.e_), FWD(src).e_);
+  }
 
   constexpr _storage(_storage const &) = default;
   constexpr _storage(_storage &&) = default;
@@ -894,7 +901,7 @@ public:
     requires ::std::is_default_constructible_v<T>
       : _base(::std::in_place)
   {
-  }
+  } // LCOV_EXCL_LINE
 
   constexpr expected(expected const &) = delete;
   constexpr expected(expected const &s)                                                                //
@@ -906,14 +913,9 @@ public:
       noexcept(::std::is_nothrow_copy_constructible_v<T> && ::std::is_nothrow_copy_constructible_v<E>) // extension
     requires(::std::is_copy_constructible_v<T> && ::std::is_copy_constructible_v<E>
              && (not ::std::is_trivially_copy_constructible_v<T> || not ::std::is_trivially_copy_constructible_v<E>))
-      : _base(s.set_)
+      : _base(s.set_, FWD(s).storage_)
   {
-    if (set_)
-      ::std::construct_at(::std::addressof(storage_.v_), s.storage_.v_);
-    else
-      ::std::construct_at(::std::addressof(storage_.e_), s.storage_.e_);
   }
-
   constexpr expected(expected &&s)
     requires(::std::is_move_constructible_v<T> && ::std::is_move_constructible_v<E>
              && ::std::is_trivially_move_constructible_v<T> && ::std::is_trivially_move_constructible_v<E>)
@@ -922,12 +924,8 @@ public:
       noexcept(::std::is_nothrow_move_constructible_v<T> && ::std::is_nothrow_move_constructible_v<E>) // required
     requires(::std::is_move_constructible_v<T> && ::std::is_move_constructible_v<E>
              && (not ::std::is_trivially_move_constructible_v<T> || not ::std::is_trivially_move_constructible_v<E>))
-      : _base(s.set_)
+      : _base(s.set_, FWD(s).storage_)
   {
-    if (set_)
-      ::std::construct_at(::std::addressof(storage_.v_), ::std::move(s.storage_.v_));
-    else
-      ::std::construct_at(::std::addressof(storage_.e_), ::std::move(s.storage_.e_));
   }
 
   template <class U, class G>
@@ -936,25 +934,16 @@ public:
       noexcept(::std::is_nothrow_constructible_v<T, U const &>
                && ::std::is_nothrow_constructible_v<E, G const &>) // extension
     requires(_can_copy_convert<U, G>::value)
-      : _base(s.set_)
+      : _base(s.set_, FWD(s).storage_)
   {
-    if (set_)
-      ::std::construct_at(::std::addressof(storage_.v_), s.storage_.v_);
-    else
-      ::std::construct_at(::std::addressof(storage_.e_), s.storage_.e_);
   }
-
   template <class U, class G>
   constexpr explicit(not ::std::is_convertible_v<U, T> || not ::std::is_convertible_v<G, E>)
       expected(expected<U, G> &&s)                                                                 //
       noexcept(::std::is_nothrow_constructible_v<T, U> && ::std::is_nothrow_constructible_v<E, G>) // extension
     requires(_can_move_convert<U, G>::value)
-      : _base(s.set_)
+      : _base(s.set_, FWD(s).storage_)
   {
-    if (set_)
-      ::std::construct_at(::std::addressof(storage_.v_), ::std::move(s.storage_.v_));
-    else
-      ::std::construct_at(::std::addressof(storage_.e_), ::std::move(s.storage_.e_));
   }
 
   template <class U = ::std::remove_cv_t<T>>
@@ -1374,49 +1363,32 @@ public:
   constexpr expected(expected const &s)                                                            //
       noexcept(::std::is_nothrow_copy_constructible_v<E>)                                          // extension
     requires(::std::is_copy_constructible_v<E> && not ::std::is_trivially_copy_constructible_v<E>) //
-      : _base(s.set_)
+      : _base(s.set_, FWD(s).storage_)
   {
-    if (set_)
-      ::std::construct_at(::std::addressof(storage_.v_)); // LCOV_EXCL_LINE v_ is trivially constructible
-    else
-      ::std::construct_at(::std::addressof(storage_.e_), s.storage_.e_);
   }
-
   constexpr expected(expected &&s)                                                             //
     requires(::std::is_move_constructible_v<E> && ::std::is_trivially_move_constructible_v<E>) //
   = default;
   constexpr expected(expected &&s)                        //
       noexcept(::std::is_nothrow_move_constructible_v<E>) // required
     requires(::std::is_move_constructible_v<E> && not ::std::is_trivially_move_constructible_v<E>)
-      : _base(s.set_)
+      : _base(s.set_, FWD(s).storage_)
   {
-    if (set_)
-      ::std::construct_at(::std::addressof(storage_.v_)); // LCOV_EXCL_LINE v_ is trivially constructible
-    else
-      ::std::construct_at(::std::addressof(storage_.e_), ::std::move(s.storage_.e_));
   }
 
   template <class U, class G>
   constexpr explicit(not ::std::is_convertible_v<G const &, E>) expected(expected<U, G> const &s) //
       noexcept(::std::is_nothrow_constructible_v<E, G const &>)                                   // extension
     requires(_can_copy_convert<U, G>::value)
-      : _base(s.set_)
+      : _base(s.set_, FWD(s).storage_)
   {
-    if (set_)
-      ::std::construct_at(::std::addressof(storage_.v_)); // LCOV_EXCL_LINE v_ is trivially constructible
-    else
-      ::std::construct_at(::std::addressof(storage_.e_), s.storage_.e_);
   }
   template <class U, class G>
   constexpr explicit(not ::std::is_convertible_v<G, E>) expected(expected<U, G> &&s) //
       noexcept(::std::is_nothrow_constructible_v<E, G>)                              // extension
     requires(_can_move_convert<U, G>::value)
-      : _base(s.set_)
+      : _base(s.set_, FWD(s).storage_)
   {
-    if (set_)
-      ::std::construct_at(::std::addressof(storage_.v_)); // LCOV_EXCL_LINE v_ is trivially constructible
-    else
-      ::std::construct_at(::std::addressof(storage_.e_), ::std::move(s.storage_.e_));
   }
 
   template <class G>

--- a/include/pfn/expected.hpp
+++ b/include/pfn/expected.hpp
@@ -681,9 +681,16 @@ template <class T, class E> struct _storage {
       }
     } else if constexpr (::std::is_void_v<T>) {
       // [expected.void.swap] mandates a single E move on cross-state.
+      // On exception from E's move, restore the `_dummy_t` value so the union
+      // always has an active member (required for constant evaluation).
       if (set_) {
         ::std::destroy_at(::std::addressof(storage_.v_));
-        ::std::construct_at(::std::addressof(storage_.e_), ::std::move(rhs.storage_.e_));
+        try {
+          ::std::construct_at(::std::addressof(storage_.e_), ::std::move(rhs.storage_.e_));
+        } catch (...) {
+          ::std::construct_at(::std::addressof(storage_.v_));
+          throw;
+        }
         ::std::destroy_at(::std::addressof(rhs.storage_.e_));
         ::std::construct_at(::std::addressof(rhs.storage_.v_));
         set_ = false;
@@ -1370,7 +1377,7 @@ public:
       : _base(s.set_)
   {
     if (set_)
-      ::std::construct_at(::std::addressof(storage_.v_)); // LCOV_EXCL
+      ::std::construct_at(::std::addressof(storage_.v_)); // LCOV_EXCL_LINE v_ is trivially constructible
     else
       ::std::construct_at(::std::addressof(storage_.e_), s.storage_.e_);
   }
@@ -1384,7 +1391,7 @@ public:
       : _base(s.set_)
   {
     if (set_)
-      ::std::construct_at(::std::addressof(storage_.v_)); // LCOV_EXCL
+      ::std::construct_at(::std::addressof(storage_.v_)); // LCOV_EXCL_LINE v_ is trivially constructible
     else
       ::std::construct_at(::std::addressof(storage_.e_), ::std::move(s.storage_.e_));
   }
@@ -1396,7 +1403,7 @@ public:
       : _base(s.set_)
   {
     if (set_)
-      ::std::construct_at(::std::addressof(storage_.v_)); // LCOV_EXCL
+      ::std::construct_at(::std::addressof(storage_.v_)); // LCOV_EXCL_LINE v_ is trivially constructible
     else
       ::std::construct_at(::std::addressof(storage_.e_), s.storage_.e_);
   }
@@ -1407,7 +1414,7 @@ public:
       : _base(s.set_)
   {
     if (set_)
-      ::std::construct_at(::std::addressof(storage_.v_)); // LCOV_EXCL
+      ::std::construct_at(::std::addressof(storage_.v_)); // LCOV_EXCL_LINE v_ is trivially constructible
     else
       ::std::construct_at(::std::addressof(storage_.e_), ::std::move(s.storage_.e_));
   }

--- a/include/pfn/expected.hpp
+++ b/include/pfn/expected.hpp
@@ -325,15 +325,15 @@ template <class E> union _storage_union_t<void, E> {
   static constexpr void _reinit(New *newp, Old *oldp, Args &&...args) //
       noexcept(::std::is_nothrow_constructible_v<New, Args...>)
   {
-    if constexpr (::std::is_nothrow_constructible_v<New, Args...>) {
+    if constexpr (::std::is_same_v<New, _dummy_t>) {
+      ::std::destroy_at(oldp);
+      ::std::construct_at(newp);
+    } else if constexpr (::std::is_nothrow_constructible_v<New, Args...>) {
       ::std::destroy_at(oldp);
       ::std::construct_at(newp, ::std::forward<Args>(args)...);
     } else {
       // On exception the trivial `_dummy_t` *oldp is reconstructed so the
       // union always has an active member (required for constant evaluation).
-      // If New is not nothrow-constructible then it's not _dummy_t, hence
-      // *oldp must be _dummy_t.
-      static_assert(::std::is_same_v<std::remove_cvref_t<decltype(*oldp)>, _dummy_t>);
       ::std::destroy_at(oldp);
       try {
         ::std::construct_at(newp, ::std::forward<Args>(args)...);

--- a/include/pfn/expected.hpp
+++ b/include/pfn/expected.hpp
@@ -184,288 +184,54 @@ constexpr bool _is_valid_expected =                                   //
     && not _is_some_unexpected<::std::remove_cv_t<T>>                 //
     && detail::_is_valid_unexpected<E>;
 
-static constexpr struct _branch_t {
-  constexpr explicit _branch_t() noexcept = default;
-} _branch{};
+// Internal union wrapper for the value/error storage. Copy/move ctors
+// are defaulted iff both `T` and `E` are trivially copy/move-constructible;
+// otherwise deleted (callers placement-new the appropriate arm).
+// The in_place / unexpect ctors activate `v_` / `e_` respectively.
+template <class T, class E> union _storage_union_t {
+  using _value_t = T;
+  T v_;
+  E e_;
 
-struct _dummy_t final {
-  constexpr _dummy_t() noexcept = default;
-};
+  constexpr _storage_union_t(_storage_union_t const &) = delete;
+  constexpr _storage_union_t(_storage_union_t const &) //
+    requires(::std::is_trivially_copy_constructible_v<T> && ::std::is_trivially_copy_constructible_v<E>)
+  = default;
+  constexpr _storage_union_t(_storage_union_t &&) = delete;
+  constexpr _storage_union_t(_storage_union_t &&) //
+    requires(::std::is_trivially_move_constructible_v<T> && ::std::is_trivially_move_constructible_v<E>)
+  = default;
+  constexpr _storage_union_t &operator=(_storage_union_t const &) = delete;
+  constexpr _storage_union_t &operator=(_storage_union_t &&) = delete;
 
-// Shared storage base for ::pfn::expected. Members are public because the
-// inheritance is private; sibling-instantiation access goes through the
-// `template <class, class> friend class expected;` declaration on the derived.
-template <class T, class E> struct _storage {
-  using _storage_t = ::std::conditional_t<::std::is_same_v<T, void>, _dummy_t, T>;
-  union {
-    _storage_t v_;
-    E e_;
-  };
-  bool set_;
+  constexpr explicit _storage_union_t() noexcept {}
 
   template <class... Args>
-  constexpr explicit _storage(::std::in_place_t, Args &&...a) //
-      noexcept(::std::is_nothrow_constructible_v<_storage_t, Args...>)
-    requires ::std::is_constructible_v<_storage_t, Args...>
-      : v_(FWD(a)...), set_(true)
-  {
-  }
-  template <class U, class... Args>
-  constexpr explicit _storage(::std::in_place_t, ::std::initializer_list<U> il, Args &&...a) //
-      noexcept(::std::is_nothrow_constructible_v<_storage_t, ::std::initializer_list<U> &, Args...>)
-    requires ::std::is_constructible_v<_storage_t, ::std::initializer_list<U> &, Args...>
-      : v_(il, FWD(a)...), set_(true)
+  constexpr explicit _storage_union_t(::std::in_place_t, Args &&...a) //
+      noexcept(::std::is_nothrow_constructible_v<T, Args...>)
+    requires ::std::is_constructible_v<T, Args...>
+      : v_(FWD(a)...)
   {
   }
   template <class... Args>
-  constexpr explicit _storage(unexpect_t, Args &&...a) //
+  constexpr explicit _storage_union_t(unexpect_t, Args &&...a) //
       noexcept(::std::is_nothrow_constructible_v<E, Args...>)
     requires ::std::is_constructible_v<E, Args...>
-      : e_(FWD(a)...), set_(false)
-  {
-  }
-  template <class U, class... Args>
-  constexpr explicit _storage(unexpect_t, ::std::initializer_list<U> il, Args &&...a) //
-      noexcept(::std::is_nothrow_constructible_v<E, ::std::initializer_list<U> &, Args...>)
-    requires ::std::is_constructible_v<E, ::std::initializer_list<U> &, Args...>
-      : e_(il, FWD(a)...), set_(false)
+      : e_(FWD(a)...)
   {
   }
 
-  // Branch tag: initializes only `set_`, leaving the union uninitialized so
-  // the derived ctor body can placement-new into the active arm.
-  constexpr explicit _storage(_branch_t, bool s) noexcept : set_(s) {}
-
-  constexpr _storage(_storage const &) = default;
-  constexpr _storage(_storage &&) = default;
-  constexpr _storage &operator=(_storage const &) = default;
-  constexpr _storage &operator=(_storage &&) = default;
-
-  constexpr ~_storage() noexcept
-    requires(::std::is_trivially_destructible_v<_storage_t> && ::std::is_trivially_destructible_v<E>)
+  constexpr ~_storage_union_t() noexcept
+    requires(::std::is_trivially_destructible_v<T> && ::std::is_trivially_destructible_v<E>)
   = default;
-  constexpr ~_storage() //
-    requires(::std::is_trivially_destructible_v<_storage_t> && not ::std::is_trivially_destructible_v<E>)
-  {
-    if (not set_)
-      ::std::destroy_at(::std::addressof(e_));
-  }
-  constexpr ~_storage() //
-    requires(not ::std::is_trivially_destructible_v<_storage_t> && ::std::is_trivially_destructible_v<E>)
-  {
-    if (set_)
-      ::std::destroy_at(::std::addressof(v_));
-  }
-  constexpr ~_storage() //
-    requires(not ::std::is_trivially_destructible_v<_storage_t> && not ::std::is_trivially_destructible_v<E>)
-  {
-    if (set_)
-      ::std::destroy_at(::std::addressof(v_));
-    else
-      ::std::destroy_at(::std::addressof(e_));
-  }
+  constexpr ~_storage_union_t() noexcept {}
 
-  // [expected.object.obs], observers
-  constexpr _storage_t const *operator->() const noexcept
-    requires(not ::std::is_void_v<T>)
-  {
-    ASSERT(set_);
-    return ::std::addressof(v_);
-  }
-  constexpr _storage_t *operator->() noexcept
-    requires(not ::std::is_void_v<T>)
-  {
-    ASSERT(set_);
-    return ::std::addressof(v_);
-  }
-  constexpr _storage_t const &operator*() const & noexcept
-    requires(not ::std::is_void_v<T>)
-  {
-    return *(this->operator->());
-  }
-  constexpr _storage_t &operator*() & noexcept
-    requires(not ::std::is_void_v<T>)
-  {
-    return *(this->operator->());
-  }
-  constexpr _storage_t const &&operator*() const && noexcept
-    requires(not ::std::is_void_v<T>)
-  {
-    return ::std::move(*(this->operator->()));
-  }
-  constexpr _storage_t &&operator*() && noexcept
-    requires(not ::std::is_void_v<T>)
-  {
-    return ::std::move(*(this->operator->()));
-  }
-  constexpr void operator*() const & noexcept
-    requires(::std::is_void_v<T>)
-  {
-    ASSERT(set_);
-  }
-  constexpr void operator*() & noexcept
-    requires(::std::is_void_v<T>)
-  {
-    ASSERT(set_);
-  }
-  constexpr void operator*() const && noexcept
-    requires(::std::is_void_v<T>)
-  {
-    ASSERT(set_);
-  }
-  constexpr void operator*() && noexcept
-    requires(::std::is_void_v<T>)
-  {
-    ASSERT(set_);
-  }
-  constexpr explicit operator bool() const noexcept { return set_; }
-  constexpr bool has_value() const noexcept { return set_; }
-  constexpr bool has_error() const noexcept { return !set_; } // P3798
-  constexpr _storage_t const &value() const &
-    requires(not ::std::is_void_v<T>)
-  {
-    static_assert(::std::is_copy_constructible_v<E>);
-    if (not set_)
-      throw bad_expected_access<E>(e_);
-    return v_;
-  }
-  constexpr _storage_t &value() &
-    requires(not ::std::is_void_v<T>)
-  {
-    static_assert(::std::is_copy_constructible_v<E>);
-    if (not set_)
-      throw bad_expected_access<E>(::std::as_const(e_));
-    return v_;
-  }
-  constexpr _storage_t const &&value() const &&
-    requires(not ::std::is_void_v<T>)
-  {
-    static_assert(::std::is_copy_constructible_v<E>);
-    static_assert(::std::is_constructible_v<E, E const &&>);
-    if (not set_)
-      throw bad_expected_access<E>(::std::move(e_));
-    return ::std::move(v_);
-  }
-  constexpr _storage_t &&value() &&
-    requires(not ::std::is_void_v<T>)
-  {
-    static_assert(::std::is_copy_constructible_v<E>);
-    static_assert(::std::is_constructible_v<E, E &&>);
-    if (not set_)
-      throw bad_expected_access<E>(::std::move(e_));
-    return ::std::move(v_);
-  }
-  constexpr void value() const &
-    requires(::std::is_void_v<T>)
-  {
-    static_assert(::std::is_copy_constructible_v<E>);
-    if (not set_)
-      throw bad_expected_access<E>(e_);
-  }
-  constexpr void value() &&
-    requires(::std::is_void_v<T>)
-  {
-    static_assert(::std::is_copy_constructible_v<E>);
-    static_assert(::std::is_move_constructible_v<E>);
-    if (not set_)
-      throw bad_expected_access<E>(::std::move(e_));
-  }
-  constexpr E const &error() const & noexcept
-  {
-    ASSERT(not set_);
-    return e_;
-  }
-  constexpr E &error() & noexcept
-  {
-    ASSERT(not set_);
-    return e_;
-  }
-  constexpr E const &&error() const && noexcept
-  {
-    ASSERT(not set_);
-    return ::std::move(e_);
-  }
-  constexpr E &&error() && noexcept
-  {
-    ASSERT(not set_);
-    return ::std::move(e_);
-  }
-
-  template <class U>
-  constexpr T value_or(U &&v) const &                                                              //
-      noexcept(::std::is_nothrow_copy_constructible_v<T> && ::std::is_nothrow_convertible_v<U, T>) // extension
-    requires(not ::std::is_void_v<T>)
-  {
-    static_assert(::std::is_copy_constructible_v<T>);
-    static_assert(::std::is_convertible_v<U, T>);
-    return set_ ? v_ : static_cast<T>(FWD(v));
-  }
-  template <class U>
-  constexpr T value_or(U &&v) &&                                                                   //
-      noexcept(::std::is_nothrow_move_constructible_v<T> && ::std::is_nothrow_convertible_v<U, T>) // extension
-    requires(not ::std::is_void_v<T>)
-  {
-    static_assert(::std::is_move_constructible_v<T>);
-    static_assert(::std::is_convertible_v<U, T>);
-    return set_ ? ::std::move(v_) : static_cast<T>(FWD(v));
-  }
-
-  template <class G = E>
-  constexpr E error_or(G &&e) const &                                                              //
-      noexcept(::std::is_nothrow_copy_constructible_v<E> && ::std::is_nothrow_convertible_v<G, E>) // extension
-  {
-    static_assert(::std::is_copy_constructible_v<E>);
-    static_assert(::std::is_convertible_v<G, E>);
-    if (set_) {
-      return FWD(e);
-    }
-    return e_;
-  }
-  template <class G = E>
-  constexpr E error_or(G &&e) &&                                                                   //
-      noexcept(::std::is_nothrow_move_constructible_v<E> && ::std::is_nothrow_convertible_v<G, E>) // extension
-  {
-    static_assert(::std::is_move_constructible_v<E>);
-    static_assert(::std::is_convertible_v<G, E>);
-    if (set_) {
-      return FWD(e);
-    }
-    return ::std::move(e_);
-  }
-
-  // Internal value accessor used by monadic helpers; `value()` performs the
-  // access check via exception, this one assumes the precondition.
-  constexpr _storage_t const &_value() const & noexcept
-    requires(not ::std::is_void_v<T>)
-  {
-    ASSERT(set_);
-    return v_;
-  }
-  constexpr _storage_t &_value() & noexcept
-    requires(not ::std::is_void_v<T>)
-  {
-    ASSERT(set_);
-    return v_;
-  }
-  constexpr _storage_t const &&_value() const && noexcept
-    requires(not ::std::is_void_v<T>)
-  {
-    ASSERT(set_);
-    return ::std::move(v_);
-  }
-  constexpr _storage_t &&_value() && noexcept
-    requires(not ::std::is_void_v<T>)
-  {
-    ASSERT(set_);
-    return ::std::move(v_);
-  }
-
-  // [expected.object.assign]
+  // Implements the reinit-expected helper from [expected.object.assign].
   template <typename New, typename Old, typename... Args>
   static constexpr void _reinit(New &newval, Old &oldval, Args &&...args) //
       noexcept(::std::is_nothrow_constructible_v<New, Args...>)
   {
-    if constexpr (::std::is_void_v<T> || ::std::is_nothrow_constructible_v<New, Args...>) {
+    if constexpr (::std::is_nothrow_constructible_v<New, Args...>) {
       ::std::destroy_at(::std::addressof(oldval));
       ::std::construct_at(::std::addressof(newval), ::std::forward<Args>(args)...);
     } else if constexpr (::std::is_nothrow_move_constructible_v<New>) {
@@ -479,11 +245,8 @@ template <class T, class E> struct _storage {
       // restoration on catch. A byte-buffer snapshot via std::memcpy is opaque
       // to TBAA, and preserving *oldval in place across the try (no destroy_at)
       // makes the catch a plain byte restore -- which for trivially-copyable
-      // (and therefore trivially-destructible) Old is observationally identical
-      // to the destroy-and-recreate branch below.
-      // (Old is also trivially-destructible -- implied by is_trivially_copyable_v
-      //  per [class.prop]/1 -- so skipping destroy_at is observationally identical
-      //  to the destroy-and-recreate branch below.)
+      // (and therefore trivially-destructible per [class.prop]/1). Old is
+      // observationally identical to the destroy-and-recreate branch below.
       if (not ::std::is_constant_evaluated()) {
         alignas(Old) unsigned char _bytes[sizeof(Old)];
         ::std::memcpy(_bytes, ::std::addressof(oldval), sizeof(Old));
@@ -516,70 +279,387 @@ template <class T, class E> struct _storage {
       }
     }
   }
+};
 
-  // Body helper for the copy/move assignment operators; the public expected
-  // operator= overloads keep their constraints/noexcept clauses and just
-  // delegate here, forwarding `s` as lvalue or rvalue. For T=void the value
-  // side is `_dummy_t` whose destructor and default ctor are trivial; the
-  // cross-state transitions use direct construct_at, matching the
-  // [expected.void.assign] and [expected.object.assign] specification (no strong exception guarantee).
+// Void specialization: value state activates a trivial `_dummy_t v_`
+// placeholder so the union always has an active member (required by
+// constant evaluation). All `v_` operations are no-ops at runtime.
+template <class E> union _storage_union_t<void, E> {
+  struct _dummy_t final {
+    constexpr _dummy_t() noexcept = default;
+  };
+
+  using _value_t = _dummy_t;
+  _dummy_t v_;
+  E e_;
+
+  constexpr _storage_union_t(_storage_union_t const &) = delete;
+  constexpr _storage_union_t(_storage_union_t const &) //
+    requires(::std::is_trivially_copy_constructible_v<E>)
+  = default;
+  constexpr _storage_union_t(_storage_union_t &&) = delete;
+  constexpr _storage_union_t(_storage_union_t &&) //
+    requires(::std::is_trivially_move_constructible_v<E>)
+  = default;
+  constexpr _storage_union_t &operator=(_storage_union_t const &) = delete;
+  constexpr _storage_union_t &operator=(_storage_union_t &&) = delete;
+
+  constexpr explicit _storage_union_t() noexcept {}
+  constexpr explicit _storage_union_t(::std::in_place_t) noexcept : v_{} {}
+
+  template <class... Args>
+  constexpr explicit _storage_union_t(unexpect_t, Args &&...a) //
+      noexcept(::std::is_nothrow_constructible_v<E, Args...>)
+    requires ::std::is_constructible_v<E, Args...>
+      : e_(FWD(a)...)
+  {
+  }
+
+  constexpr ~_storage_union_t() noexcept
+    requires(::std::is_trivially_destructible_v<E>)
+  = default;
+  constexpr ~_storage_union_t() noexcept {}
+
+  // [expected.void.assign] mandates direct construction (no temporary).
+  template <typename New, typename Old, typename... Args>
+  static constexpr void _reinit(New &newval, Old &oldval, Args &&...args) //
+      noexcept(::std::is_nothrow_constructible_v<New, Args...>)
+  {
+    if constexpr (::std::is_nothrow_constructible_v<New, Args...>) {
+      ::std::destroy_at(::std::addressof(oldval));
+      ::std::construct_at(::std::addressof(newval), ::std::forward<Args>(args)...);
+    } else {
+      // On exception the trivial `_dummy_t` oldval is reconstructed so the
+      // union always has an active member (required for constant evaluation).
+      // If New is not nothrow-constructible then it's not _dummy_t, hence
+      // oldval must be _dummy_t.
+      static_assert(::std::is_same_v<std::remove_cvref_t<decltype(oldval)>, _dummy_t>);
+      ::std::destroy_at(::std::addressof(oldval));
+      try {
+        ::std::construct_at(::std::addressof(newval), ::std::forward<Args>(args)...);
+      } catch (...) {
+        ::std::construct_at(::std::addressof(oldval));
+        throw;
+      }
+    }
+  }
+};
+
+// Shared storage base for ::pfn::expected. Members are public because the
+// inheritance is private; sibling-instantiation access goes through the
+// `template <class, class> friend class expected;` declaration on the derived.
+template <class T, class E> struct _storage {
+  using _storage_t = _storage_union_t<T, E>;
+  // `T` for non-void, trivial `_dummy_t` for void; used as observer return
+  // type (void value-returning overloads are requires-disabled, so the
+  // placeholder is never observable) and in destructor constraints.
+  using _value_t = _storage_t::_value_t;
+  _storage_t storage_;
+  bool set_;
+
+  template <class... Args>
+  constexpr explicit _storage(::std::in_place_t, Args &&...a) //
+      noexcept(::std::is_nothrow_constructible_v<_storage_t, ::std::in_place_t, Args...>)
+    requires ::std::is_constructible_v<_storage_t, ::std::in_place_t, Args...>
+      : storage_(::std::in_place, FWD(a)...), set_(true)
+  {
+  }
+  template <class... Args>
+  constexpr explicit _storage(unexpect_t, Args &&...a) //
+      noexcept(::std::is_nothrow_constructible_v<E, Args...>)
+    requires ::std::is_constructible_v<E, Args...>
+      : storage_(unexpect, FWD(a)...), set_(false)
+  {
+  }
+
+  // Leaves `storage_` with no active union member so the derived ctor
+  // body can placement-new the appropriate arm.
+  constexpr explicit _storage(bool s) noexcept : storage_(), set_(s) {}
+
+  constexpr _storage(_storage const &) = default;
+  constexpr _storage(_storage &&) = default;
+  constexpr _storage &operator=(_storage const &) = delete;
+  constexpr _storage &operator=(_storage &&) = delete;
+
+  constexpr ~_storage() noexcept
+    requires(::std::is_trivially_destructible_v<_value_t> && ::std::is_trivially_destructible_v<E>)
+  = default;
+  constexpr ~_storage() //
+    requires(::std::is_trivially_destructible_v<_value_t> && not ::std::is_trivially_destructible_v<E>)
+  {
+    if (not set_)
+      ::std::destroy_at(::std::addressof(storage_.e_));
+  }
+  constexpr ~_storage() //
+    requires(not ::std::is_trivially_destructible_v<_value_t> && ::std::is_trivially_destructible_v<E>)
+  {
+    if (set_)
+      ::std::destroy_at(::std::addressof(storage_.v_));
+  }
+  constexpr ~_storage() //
+    requires(not ::std::is_trivially_destructible_v<_value_t> && not ::std::is_trivially_destructible_v<E>)
+  {
+    if (set_)
+      ::std::destroy_at(::std::addressof(storage_.v_));
+    else
+      ::std::destroy_at(::std::addressof(storage_.e_));
+  }
+
+  constexpr _value_t const *operator->() const noexcept
+    requires(not ::std::is_void_v<T>)
+  {
+    ASSERT(set_);
+    return ::std::addressof(storage_.v_);
+  }
+  constexpr _value_t *operator->() noexcept
+    requires(not ::std::is_void_v<T>)
+  {
+    ASSERT(set_);
+    return ::std::addressof(storage_.v_);
+  }
+  constexpr _value_t const &operator*() const & noexcept
+    requires(not ::std::is_void_v<T>)
+  {
+    return *(this->operator->());
+  }
+  constexpr _value_t &operator*() & noexcept
+    requires(not ::std::is_void_v<T>)
+  {
+    return *(this->operator->());
+  }
+  constexpr _value_t const &&operator*() const && noexcept
+    requires(not ::std::is_void_v<T>)
+  {
+    return ::std::move(*(this->operator->()));
+  }
+  constexpr _value_t &&operator*() && noexcept
+    requires(not ::std::is_void_v<T>)
+  {
+    return ::std::move(*(this->operator->()));
+  }
+  constexpr void operator*() const & noexcept
+    requires(::std::is_void_v<T>)
+  {
+    ASSERT(set_);
+  }
+  constexpr void operator*() & noexcept
+    requires(::std::is_void_v<T>)
+  {
+    ASSERT(set_);
+  }
+  constexpr void operator*() const && noexcept
+    requires(::std::is_void_v<T>)
+  {
+    ASSERT(set_);
+  }
+  constexpr void operator*() && noexcept
+    requires(::std::is_void_v<T>)
+  {
+    ASSERT(set_);
+  }
+  constexpr explicit operator bool() const noexcept { return set_; }
+  constexpr bool has_value() const noexcept { return set_; }
+  constexpr bool has_error() const noexcept { return !set_; } // P3798
+  constexpr _value_t const &value() const &
+    requires(not ::std::is_void_v<T>)
+  {
+    static_assert(::std::is_copy_constructible_v<E>);
+    if (not set_)
+      throw bad_expected_access<E>(storage_.e_);
+    return storage_.v_;
+  }
+  constexpr _value_t &value() &
+    requires(not ::std::is_void_v<T>)
+  {
+    static_assert(::std::is_copy_constructible_v<E>);
+    if (not set_)
+      throw bad_expected_access<E>(::std::as_const(storage_.e_));
+    return storage_.v_;
+  }
+  constexpr _value_t const &&value() const &&
+    requires(not ::std::is_void_v<T>)
+  {
+    static_assert(::std::is_copy_constructible_v<E>);
+    static_assert(::std::is_constructible_v<E, E const &&>);
+    if (not set_)
+      throw bad_expected_access<E>(::std::move(storage_.e_));
+    return ::std::move(storage_.v_);
+  }
+  constexpr _value_t &&value() &&
+    requires(not ::std::is_void_v<T>)
+  {
+    static_assert(::std::is_copy_constructible_v<E>);
+    static_assert(::std::is_constructible_v<E, E &&>);
+    if (not set_)
+      throw bad_expected_access<E>(::std::move(storage_.e_));
+    return ::std::move(storage_.v_);
+  }
+  constexpr void value() const &
+    requires(::std::is_void_v<T>)
+  {
+    static_assert(::std::is_copy_constructible_v<E>);
+    if (not set_)
+      throw bad_expected_access<E>(storage_.e_);
+  }
+  constexpr void value() &&
+    requires(::std::is_void_v<T>)
+  {
+    static_assert(::std::is_copy_constructible_v<E>);
+    static_assert(::std::is_move_constructible_v<E>);
+    if (not set_)
+      throw bad_expected_access<E>(::std::move(storage_.e_));
+  }
+  constexpr E const &error() const & noexcept
+  {
+    ASSERT(not set_);
+    return storage_.e_;
+  }
+  constexpr E &error() & noexcept
+  {
+    ASSERT(not set_);
+    return storage_.e_;
+  }
+  constexpr E const &&error() const && noexcept
+  {
+    ASSERT(not set_);
+    return ::std::move(storage_.e_);
+  }
+  constexpr E &&error() && noexcept
+  {
+    ASSERT(not set_);
+    return ::std::move(storage_.e_);
+  }
+
+  template <class U>
+  constexpr T value_or(U &&v) const &                                                              //
+      noexcept(::std::is_nothrow_copy_constructible_v<T> && ::std::is_nothrow_convertible_v<U, T>) // extension
+    requires(not ::std::is_void_v<T>)
+  {
+    static_assert(::std::is_copy_constructible_v<T>);
+    static_assert(::std::is_convertible_v<U, T>);
+    return set_ ? storage_.v_ : static_cast<T>(FWD(v));
+  }
+  template <class U>
+  constexpr T value_or(U &&v) &&                                                                   //
+      noexcept(::std::is_nothrow_move_constructible_v<T> && ::std::is_nothrow_convertible_v<U, T>) // extension
+    requires(not ::std::is_void_v<T>)
+  {
+    static_assert(::std::is_move_constructible_v<T>);
+    static_assert(::std::is_convertible_v<U, T>);
+    return set_ ? ::std::move(storage_.v_) : static_cast<T>(FWD(v));
+  }
+
+  template <class G = E>
+  constexpr E error_or(G &&e) const &                                                              //
+      noexcept(::std::is_nothrow_copy_constructible_v<E> && ::std::is_nothrow_convertible_v<G, E>) // extension
+  {
+    static_assert(::std::is_copy_constructible_v<E>);
+    static_assert(::std::is_convertible_v<G, E>);
+    if (set_) {
+      return FWD(e);
+    }
+    return storage_.e_;
+  }
+  template <class G = E>
+  constexpr E error_or(G &&e) &&                                                                   //
+      noexcept(::std::is_nothrow_move_constructible_v<E> && ::std::is_nothrow_convertible_v<G, E>) // extension
+  {
+    static_assert(::std::is_move_constructible_v<E>);
+    static_assert(::std::is_convertible_v<G, E>);
+    if (set_) {
+      return FWD(e);
+    }
+    return ::std::move(storage_.e_);
+  }
+
+  // Unchecked value accessor used by monadic helpers; `value()` throws,
+  // this asserts the precondition.
+  constexpr _value_t const &_value() const & noexcept
+    requires(not ::std::is_void_v<T>)
+  {
+    ASSERT(set_);
+    return storage_.v_;
+  }
+  constexpr _value_t &_value() & noexcept
+    requires(not ::std::is_void_v<T>)
+  {
+    ASSERT(set_);
+    return storage_.v_;
+  }
+  constexpr _value_t const &&_value() const && noexcept
+    requires(not ::std::is_void_v<T>)
+  {
+    ASSERT(set_);
+    return ::std::move(storage_.v_);
+  }
+  constexpr _value_t &&_value() && noexcept
+    requires(not ::std::is_void_v<T>)
+  {
+    ASSERT(set_);
+    return ::std::move(storage_.v_);
+  }
+
+  // Assignment body shared by the public expected operator= overloads,
+  // which keep their constraints/noexcept clauses and forward `s` here as
+  // lvalue or rvalue. For T=void all `storage_.v_` operations are no-ops
+  // at runtime (trivial `_dummy_t`) but still track the active union member.
   constexpr void _assign(auto &&s)
   {
     if (set_ && s.set_) {
-      v_ = FWD(s).v_;
+      storage_.v_ = FWD(s).storage_.v_;
     } else if (set_) {
-      _reinit(e_, v_, FWD(s).e_);
+      _storage_t::_reinit(storage_.e_, storage_.v_, FWD(s).storage_.e_);
       set_ = false;
     } else if (s.set_) {
-      _reinit(v_, e_, FWD(s).v_);
+      _storage_t::_reinit(storage_.v_, storage_.e_, FWD(s).storage_.v_);
       set_ = true;
     } else {
-      e_ = FWD(s).e_;
+      storage_.e_ = FWD(s).storage_.e_;
     }
   }
   template <class U> constexpr void _assign_value(U &&s)
   {
     if (set_) {
-      v_ = FWD(s);
+      storage_.v_ = FWD(s);
     } else {
-      _reinit(v_, e_, FWD(s));
+      _storage_t::_reinit(storage_.v_, storage_.e_, FWD(s));
       set_ = true;
     }
   }
   constexpr void _assign_unexpected(auto &&s)
   {
     if (not set_) {
-      e_ = FWD(s).error();
+      storage_.e_ = FWD(s).error();
     } else {
-      _reinit(e_, v_, FWD(s).error());
+      _storage_t::_reinit(storage_.e_, storage_.v_, FWD(s).error());
       set_ = false;
     }
   }
 
-  // [expected.object.swap] cross-state swap helper; lhs holds value, rhs holds error
-  static constexpr void _swap(_storage &lhs, _storage &rhs) //
-      noexcept(::std::is_nothrow_move_constructible_v<_storage_t> && ::std::is_nothrow_move_constructible_v<E>)
+  // Cross-state swap; lhs holds value, rhs holds error.
+  static constexpr void _swap_helper(_storage &lhs, _storage &rhs) //
+      noexcept(::std::is_nothrow_move_constructible_v<T> && ::std::is_nothrow_move_constructible_v<E>)
   {
     if constexpr (::std::is_nothrow_move_constructible_v<E>) {
-      E tmp(::std::move(rhs.e_));
-      ::std::destroy_at(::std::addressof(rhs.e_));
+      E tmp(::std::move(rhs.storage_.e_));
+      ::std::destroy_at(::std::addressof(rhs.storage_.e_));
       try {
-        ::std::construct_at(::std::addressof(rhs.v_), ::std::move(lhs.v_));
-        ::std::destroy_at(::std::addressof(lhs.v_));
-        ::std::construct_at(::std::addressof(lhs.e_), ::std::move(tmp));
+        ::std::construct_at(::std::addressof(rhs.storage_.v_), ::std::move(lhs.storage_.v_));
+        ::std::destroy_at(::std::addressof(lhs.storage_.v_));
+        ::std::construct_at(::std::addressof(lhs.storage_.e_), ::std::move(tmp));
       } catch (...) {
-        ::std::construct_at(::std::addressof(rhs.e_), ::std::move(tmp));
+        ::std::construct_at(::std::addressof(rhs.storage_.e_), ::std::move(tmp));
         throw;
       }
     } else {
-      _storage_t tmp(::std::move(lhs.v_));
-      ::std::destroy_at(::std::addressof(lhs.v_));
+      auto tmp(::std::move(lhs.storage_.v_));
+      ::std::destroy_at(::std::addressof(lhs.storage_.v_));
       try {
-        ::std::construct_at(::std::addressof(lhs.e_), ::std::move(rhs.e_));
-        ::std::destroy_at(::std::addressof(rhs.e_));
-        ::std::construct_at(::std::addressof(rhs.v_), ::std::move(tmp));
+        ::std::construct_at(::std::addressof(lhs.storage_.e_), ::std::move(rhs.storage_.e_));
+        ::std::destroy_at(::std::addressof(rhs.storage_.e_));
+        ::std::construct_at(::std::addressof(rhs.storage_.v_), ::std::move(tmp));
       } catch (...) {
-        ::std::construct_at(::std::addressof(lhs.v_), ::std::move(tmp));
+        ::std::construct_at(::std::addressof(lhs.storage_.v_), ::std::move(tmp));
         throw;
       }
     }
@@ -587,76 +667,69 @@ template <class T, class E> struct _storage {
     rhs.set_ = true;
   }
 
-  // [expected.object.swap] body helper; the public expected::swap keeps its
-  // constraints/noexcept clause and just delegates here.
   constexpr void _swap_with(_storage &rhs)
   {
     if (set_ == rhs.set_) {
       if (set_) {
         if constexpr (not ::std::is_void_v<T>) {
           using ::std::swap;
-          swap(v_, rhs.v_);
+          swap(storage_.v_, rhs.storage_.v_);
         }
       } else {
         using ::std::swap;
-        swap(e_, rhs.e_);
+        swap(storage_.e_, rhs.storage_.e_);
       }
     } else if constexpr (::std::is_void_v<T>) {
-      // Direct cross-state transition: only one E move, matching the
-      // [expected.void.swap] specification.
+      // [expected.void.swap] mandates a single E move on cross-state.
       if (set_) {
-        ::std::destroy_at(::std::addressof(v_));
-        ::std::construct_at(::std::addressof(e_), ::std::move(rhs.e_));
-        ::std::destroy_at(::std::addressof(rhs.e_));
-        ::std::construct_at(::std::addressof(rhs.v_));
+        ::std::destroy_at(::std::addressof(storage_.v_));
+        ::std::construct_at(::std::addressof(storage_.e_), ::std::move(rhs.storage_.e_));
+        ::std::destroy_at(::std::addressof(rhs.storage_.e_));
+        ::std::construct_at(::std::addressof(rhs.storage_.v_));
         set_ = false;
         rhs.set_ = true;
       } else {
         rhs._swap_with(*this);
       }
+    } else if (set_) {
+      _swap_helper(*this, rhs);
     } else {
-      if (set_) {
-        _swap(*this, rhs);
-      } else {
-        _swap(rhs, *this);
-      }
+      _swap_helper(rhs, *this);
     }
   }
 
-  // [expected.object.emplace], emplace
   template <class... Args>
-  constexpr _storage_t &emplace(Args &&...args) noexcept
+  constexpr _value_t &emplace(Args &&...args) noexcept
     requires(not ::std::is_void_v<T> && ::std::is_nothrow_constructible_v<T, Args...>)
   {
     if (set_) {
-      ::std::destroy_at(::std::addressof(v_));
+      ::std::destroy_at(::std::addressof(storage_.v_));
     } else {
-      ::std::destroy_at(::std::addressof(e_));
+      ::std::destroy_at(::std::addressof(storage_.e_));
       set_ = true;
     }
-    return *::std::construct_at(::std::addressof(v_), std::forward<Args>(args)...);
+    return *::std::construct_at(::std::addressof(storage_.v_), std::forward<Args>(args)...);
   }
 
   template <class U, class... Args>
-  constexpr _storage_t &emplace(::std::initializer_list<U> il, Args &&...args) noexcept
+  constexpr _value_t &emplace(::std::initializer_list<U> il, Args &&...args) noexcept
     requires(not ::std::is_void_v<T> && ::std::is_nothrow_constructible_v<T, ::std::initializer_list<U> &, Args...>)
   {
     if (set_) {
-      ::std::destroy_at(::std::addressof(v_));
+      ::std::destroy_at(::std::addressof(storage_.v_));
     } else {
-      ::std::destroy_at(::std::addressof(e_));
+      ::std::destroy_at(::std::addressof(storage_.e_));
       set_ = true;
     }
-    return *::std::construct_at(::std::addressof(v_), il, std::forward<Args>(args)...);
+    return *::std::construct_at(::std::addressof(storage_.v_), il, std::forward<Args>(args)...);
   }
 
-  // [expected.void.emplace], emplace
   constexpr void emplace() noexcept
     requires(::std::is_void_v<T>)
   {
     if (not set_) {
-      ::std::destroy_at(::std::addressof(e_));
-      ::std::construct_at(::std::addressof(v_));
+      ::std::destroy_at(::std::addressof(storage_.e_));
+      ::std::construct_at(::std::addressof(storage_.v_));
       set_ = true;
     }
   }
@@ -700,9 +773,8 @@ template <class T, class E> class expected : private detail::_storage<T, E> {
   // through the dependent base, and to document the inherited surface.
   using _base = detail::_storage<T, E>;
   using _base::_value;
-  using _base::e_;
   using _base::set_;
-  using _base::v_;
+  using _base::storage_;
 
   template <class U>
   using _can_convert = ::std::bool_constant<                            //
@@ -827,12 +899,12 @@ public:
       noexcept(::std::is_nothrow_copy_constructible_v<T> && ::std::is_nothrow_copy_constructible_v<E>) // extension
     requires(::std::is_copy_constructible_v<T> && ::std::is_copy_constructible_v<E>
              && (not ::std::is_trivially_copy_constructible_v<T> || not ::std::is_trivially_copy_constructible_v<E>))
-      : _base(detail::_branch, s.set_)
+      : _base(s.set_)
   {
     if (set_)
-      ::std::construct_at(::std::addressof(v_), s.v_);
+      ::std::construct_at(::std::addressof(storage_.v_), s.storage_.v_);
     else
-      ::std::construct_at(::std::addressof(e_), s.e_);
+      ::std::construct_at(::std::addressof(storage_.e_), s.storage_.e_);
   }
 
   constexpr expected(expected &&s)
@@ -843,12 +915,12 @@ public:
       noexcept(::std::is_nothrow_move_constructible_v<T> && ::std::is_nothrow_move_constructible_v<E>) // required
     requires(::std::is_move_constructible_v<T> && ::std::is_move_constructible_v<E>
              && (not ::std::is_trivially_move_constructible_v<T> || not ::std::is_trivially_move_constructible_v<E>))
-      : _base(detail::_branch, s.set_)
+      : _base(s.set_)
   {
     if (set_)
-      ::std::construct_at(::std::addressof(v_), ::std::move(s.v_));
+      ::std::construct_at(::std::addressof(storage_.v_), ::std::move(s.storage_.v_));
     else
-      ::std::construct_at(::std::addressof(e_), ::std::move(s.e_));
+      ::std::construct_at(::std::addressof(storage_.e_), ::std::move(s.storage_.e_));
   }
 
   template <class U, class G>
@@ -857,12 +929,12 @@ public:
       noexcept(::std::is_nothrow_constructible_v<T, U const &>
                && ::std::is_nothrow_constructible_v<E, G const &>) // extension
     requires(_can_copy_convert<U, G>::value)
-      : _base(detail::_branch, s.set_)
+      : _base(s.set_)
   {
     if (set_)
-      ::std::construct_at(::std::addressof(v_), s.v_);
+      ::std::construct_at(::std::addressof(storage_.v_), s.storage_.v_);
     else
-      ::std::construct_at(::std::addressof(e_), s.e_);
+      ::std::construct_at(::std::addressof(storage_.e_), s.storage_.e_);
   }
 
   template <class U, class G>
@@ -870,12 +942,12 @@ public:
       expected(expected<U, G> &&s)                                                                 //
       noexcept(::std::is_nothrow_constructible_v<T, U> && ::std::is_nothrow_constructible_v<E, G>) // extension
     requires(_can_move_convert<U, G>::value)
-      : _base(detail::_branch, s.set_)
+      : _base(s.set_)
   {
     if (set_)
-      ::std::construct_at(::std::addressof(v_), ::std::move(s.v_));
+      ::std::construct_at(::std::addressof(storage_.v_), ::std::move(s.storage_.v_));
     else
-      ::std::construct_at(::std::addressof(e_), ::std::move(s.e_));
+      ::std::construct_at(::std::addressof(storage_.e_), ::std::move(s.storage_.e_));
   }
 
   template <class U = ::std::remove_cv_t<T>>
@@ -1203,11 +1275,12 @@ class expected<T, E> : private detail::_storage<T, E> {
   template <class U, class G> friend class expected;
 
   // Bring the storage members into scope so unqualified lookup resolves them
-  // through the dependent base, and to document the inherited surface.
+  // through the dependent base, and to document the inherited surface. For
+  // T=void the storage union has only `e_`; the value state has no active
+  // member.
   using _base = detail::_storage<T, E>;
-  using _base::e_;
   using _base::set_;
-  using _base::v_;
+  using _base::storage_;
 
   template <typename Self, typename Fn>
   static constexpr auto _and_then(Self &&self, Fn &&fn) //
@@ -1291,19 +1364,15 @@ public:
   constexpr expected(expected const &)                                                         //
     requires(::std::is_copy_constructible_v<E> && ::std::is_trivially_copy_constructible_v<E>) //
   = default;
-  // Delegate to the in_place ctor of `_storage`, which default-initialises the
-  // value arm (`_dummy_t`) and sets `set_` to true; the body then switches to
-  // the error arm when the source holds an error.
   constexpr expected(expected const &s)                                                            //
       noexcept(::std::is_nothrow_copy_constructible_v<E>)                                          // extension
     requires(::std::is_copy_constructible_v<E> && not ::std::is_trivially_copy_constructible_v<E>) //
-      : _base(::std::in_place)
+      : _base(s.set_)
   {
-    if (not s.set_) {
-      ::std::destroy_at(::std::addressof(v_));
-      ::std::construct_at(::std::addressof(e_), s.e_);
-      set_ = false;
-    }
+    if (set_)
+      ::std::construct_at(::std::addressof(storage_.v_));
+    else
+      ::std::construct_at(::std::addressof(storage_.e_), s.storage_.e_);
   }
 
   constexpr expected(expected &&s)                                                             //
@@ -1312,38 +1381,35 @@ public:
   constexpr expected(expected &&s)                        //
       noexcept(::std::is_nothrow_move_constructible_v<E>) // required
     requires(::std::is_move_constructible_v<E> && not ::std::is_trivially_move_constructible_v<E>)
-      : _base(::std::in_place)
+      : _base(s.set_)
   {
-    if (not s.set_) {
-      ::std::destroy_at(::std::addressof(v_));
-      ::std::construct_at(::std::addressof(e_), ::std::move(s.e_));
-      set_ = false;
-    }
+    if (set_)
+      ::std::construct_at(::std::addressof(storage_.v_));
+    else
+      ::std::construct_at(::std::addressof(storage_.e_), ::std::move(s.storage_.e_));
   }
 
   template <class U, class G>
   constexpr explicit(not ::std::is_convertible_v<G const &, E>) expected(expected<U, G> const &s) //
       noexcept(::std::is_nothrow_constructible_v<E, G const &>)                                   // extension
     requires(_can_copy_convert<U, G>::value)
-      : _base(::std::in_place)
+      : _base(s.set_)
   {
-    if (not s.set_) {
-      ::std::destroy_at(::std::addressof(v_));
-      ::std::construct_at(::std::addressof(e_), s.e_);
-      set_ = false;
-    }
+    if (set_)
+      ::std::construct_at(::std::addressof(storage_.v_));
+    else
+      ::std::construct_at(::std::addressof(storage_.e_), s.storage_.e_);
   }
   template <class U, class G>
   constexpr explicit(not ::std::is_convertible_v<G, E>) expected(expected<U, G> &&s) //
       noexcept(::std::is_nothrow_constructible_v<E, G>)                              // extension
     requires(_can_move_convert<U, G>::value)
-      : _base(::std::in_place)
+      : _base(s.set_)
   {
-    if (not s.set_) {
-      ::std::destroy_at(::std::addressof(v_));
-      ::std::construct_at(::std::addressof(e_), ::std::move(s.e_));
-      set_ = false;
-    }
+    if (set_)
+      ::std::construct_at(::std::addressof(storage_.v_));
+    else
+      ::std::construct_at(::std::addressof(storage_.e_), ::std::move(s.storage_.e_));
   }
 
   template <class G>

--- a/include/pfn/expected.hpp
+++ b/include/pfn/expected.hpp
@@ -228,53 +228,53 @@ template <class T, class E> union _storage_union_t {
 
   // Implements the reinit-expected helper from [expected.object.assign].
   template <typename New, typename Old, typename... Args>
-  static constexpr void _reinit(New &newval, Old &oldval, Args &&...args) //
+  static constexpr void _reinit(New *newp, Old *oldp, Args &&...args) //
       noexcept(::std::is_nothrow_constructible_v<New, Args...>)
   {
     if constexpr (::std::is_nothrow_constructible_v<New, Args...>) {
-      ::std::destroy_at(::std::addressof(oldval));
-      ::std::construct_at(::std::addressof(newval), ::std::forward<Args>(args)...);
+      ::std::destroy_at(oldp);
+      ::std::construct_at(newp, ::std::forward<Args>(args)...);
     } else if constexpr (::std::is_nothrow_move_constructible_v<New>) {
       New tmp(::std::forward<Args>(args)...);
-      ::std::destroy_at(::std::addressof(oldval));
-      ::std::construct_at(::std::addressof(newval), std::move(tmp));
+      ::std::destroy_at(oldp);
+      ::std::construct_at(newp, std::move(tmp));
     } else if constexpr (::std::is_trivially_copyable_v<Old>) {
       // Workaround for https://github.com/llvm/llvm-project/issues/196520:
-      // clang on aarch64 sinks the snapshot load past the store-through-newval
+      // clang on aarch64 sinks the snapshot load past the store-through-newp
       // when Old's TBAA tag differs from New's, corrupting the strong-EG
       // restoration on catch. A byte-buffer snapshot via std::memcpy is opaque
-      // to TBAA, and preserving *oldval in place across the try (no destroy_at)
+      // to TBAA, and preserving *oldp in place across the try (no destroy_at)
       // makes the catch a plain byte restore -- which for trivially-copyable
       // (and therefore trivially-destructible per [class.prop]/1). Old is
       // observationally identical to the destroy-and-recreate branch below.
       if (not ::std::is_constant_evaluated()) {
         alignas(Old) unsigned char _bytes[sizeof(Old)];
-        ::std::memcpy(_bytes, ::std::addressof(oldval), sizeof(Old));
+        ::std::memcpy(_bytes, oldp, sizeof(Old));
         try {
-          ::std::construct_at(::std::addressof(newval), ::std::forward<Args>(args)...);
+          ::std::construct_at(newp, ::std::forward<Args>(args)...);
         } catch (...) {
-          ::std::memcpy(::std::addressof(oldval), _bytes, sizeof(Old));
+          ::std::memcpy(oldp, _bytes, sizeof(Old));
           throw;
         }
       } else {
         // LCOV_EXCL_START constant-evaluated only; runtime branches are above and below
-        Old tmp(std::move(oldval));
-        ::std::destroy_at(::std::addressof(oldval));
+        Old tmp(std::move(*oldp));
+        ::std::destroy_at(oldp);
         try {
-          ::std::construct_at(::std::addressof(newval), ::std::forward<Args>(args)...);
+          ::std::construct_at(newp, ::std::forward<Args>(args)...);
         } catch (...) {
-          ::std::construct_at(::std::addressof(oldval), std::move(tmp));
+          ::std::construct_at(oldp, std::move(tmp));
           throw;
         }
         // LCOV_EXCL_STOP
       }
     } else {
-      Old tmp(std::move(oldval));
-      ::std::destroy_at(::std::addressof(oldval));
+      Old tmp(std::move(*oldp));
+      ::std::destroy_at(oldp);
       try {
-        ::std::construct_at(::std::addressof(newval), ::std::forward<Args>(args)...);
+        ::std::construct_at(newp, ::std::forward<Args>(args)...);
       } catch (...) {
-        ::std::construct_at(::std::addressof(oldval), std::move(tmp));
+        ::std::construct_at(oldp, std::move(tmp));
         throw;
       }
     }
@@ -322,23 +322,23 @@ template <class E> union _storage_union_t<void, E> {
 
   // [expected.void.assign] mandates direct construction (no temporary).
   template <typename New, typename Old, typename... Args>
-  static constexpr void _reinit(New &newval, Old &oldval, Args &&...args) //
+  static constexpr void _reinit(New *newp, Old *oldp, Args &&...args) //
       noexcept(::std::is_nothrow_constructible_v<New, Args...>)
   {
     if constexpr (::std::is_nothrow_constructible_v<New, Args...>) {
-      ::std::destroy_at(::std::addressof(oldval));
-      ::std::construct_at(::std::addressof(newval), ::std::forward<Args>(args)...);
+      ::std::destroy_at(oldp);
+      ::std::construct_at(newp, ::std::forward<Args>(args)...);
     } else {
-      // On exception the trivial `_dummy_t` oldval is reconstructed so the
+      // On exception the trivial `_dummy_t` *oldp is reconstructed so the
       // union always has an active member (required for constant evaluation).
       // If New is not nothrow-constructible then it's not _dummy_t, hence
-      // oldval must be _dummy_t.
-      static_assert(::std::is_same_v<std::remove_cvref_t<decltype(oldval)>, _dummy_t>);
-      ::std::destroy_at(::std::addressof(oldval));
+      // *oldp must be _dummy_t.
+      static_assert(::std::is_same_v<std::remove_cvref_t<decltype(*oldp)>, _dummy_t>);
+      ::std::destroy_at(oldp);
       try {
-        ::std::construct_at(::std::addressof(newval), ::std::forward<Args>(args)...);
+        ::std::construct_at(newp, ::std::forward<Args>(args)...);
       } catch (...) {
-        ::std::construct_at(::std::addressof(oldval));
+        ::std::construct_at(oldp);
         throw;
       }
     }
@@ -608,10 +608,10 @@ template <class T, class E> struct _storage {
     if (set_ && s.set_) {
       storage_.v_ = FWD(s).storage_.v_;
     } else if (set_) {
-      _storage_t::_reinit(storage_.e_, storage_.v_, FWD(s).storage_.e_);
+      _storage_t::_reinit(::std::addressof(storage_.e_), ::std::addressof(storage_.v_), FWD(s).storage_.e_);
       set_ = false;
     } else if (s.set_) {
-      _storage_t::_reinit(storage_.v_, storage_.e_, FWD(s).storage_.v_);
+      _storage_t::_reinit(::std::addressof(storage_.v_), ::std::addressof(storage_.e_), FWD(s).storage_.v_);
       set_ = true;
     } else {
       storage_.e_ = FWD(s).storage_.e_;
@@ -622,7 +622,7 @@ template <class T, class E> struct _storage {
     if (set_) {
       storage_.v_ = FWD(s);
     } else {
-      _storage_t::_reinit(storage_.v_, storage_.e_, FWD(s));
+      _storage_t::_reinit(::std::addressof(storage_.v_), ::std::addressof(storage_.e_), FWD(s));
       set_ = true;
     }
   }
@@ -631,7 +631,7 @@ template <class T, class E> struct _storage {
     if (not set_) {
       storage_.e_ = FWD(s).error();
     } else {
-      _storage_t::_reinit(storage_.e_, storage_.v_, FWD(s).error());
+      _storage_t::_reinit(::std::addressof(storage_.e_), ::std::addressof(storage_.v_), FWD(s).error());
       set_ = false;
     }
   }

--- a/include/pfn/expected.hpp
+++ b/include/pfn/expected.hpp
@@ -170,11 +170,7 @@ private:
 
 template <class E> unexpected(E) -> unexpected<E>;
 
-template <class T, class E> class expected;
 namespace detail {
-template <typename> constexpr bool _is_some_expected = false;
-template <typename T, typename E> constexpr bool _is_some_expected<::pfn::expected<T, E>> = true;
-
 template <typename T, typename E>
 constexpr bool _is_valid_expected =                                   //
     not ::std::is_reference_v<T>                                      //
@@ -751,13 +747,17 @@ template <class T, class E> struct _storage {
 
 } // namespace detail
 
-// declare void specialization
-template <class T, class E>
-  requires ::std::is_void_v<T>
-class expected<T, E>;
+template <class T, class E> class expected;
+template <class E> class expected<void, E>;
+
+namespace detail {
+template <typename> constexpr bool _is_some_expected = false;
+template <typename T, typename E> constexpr bool _is_some_expected<::pfn::expected<T, E>> = true;
+} // namespace detail
 
 template <class T, class E> class expected : private detail::_storage<T, E> {
   static_assert(detail::_is_valid_expected<T, E>);
+  using _base = detail::_storage<T, E>;
 
   template <class U, class G, class UF, class GF>
   using _can_convert_detail = ::std::bool_constant<                           //
@@ -782,13 +782,6 @@ template <class T, class E> class expected : private detail::_storage<T, E> {
   template <class U, class G> using _can_copy_convert = _can_convert_detail<U, G, U const &, G const &>;
   template <class U, class G> using _can_move_convert = _can_convert_detail<U, G, U, G>;
   template <class U, class G> friend class expected;
-
-  // Bring the storage members into scope so unqualified lookup resolves them
-  // through the dependent base, and to document the inherited surface.
-  using _base = detail::_storage<T, E>;
-  using _base::_value;
-  using _base::set_;
-  using _base::storage_;
 
   template <class U>
   using _can_convert = ::std::bool_constant<                            //
@@ -1253,10 +1246,9 @@ requires {
   }
 };
 
-template <class T, class E>
-  requires ::std::is_void_v<T>
-class expected<T, E> : private detail::_storage<T, E> {
+template <class E> class expected<void, E> : private detail::_storage<void, E> {
   static_assert(detail::_is_valid_unexpected<E>);
+  using _base = detail::_storage<void, E>;
 
   template <class U, class G, class GF>
   using _can_convert_detail = ::std::bool_constant<                           //
@@ -1269,14 +1261,6 @@ class expected<T, E> : private detail::_storage<T, E> {
   template <class U, class G> using _can_copy_convert = _can_convert_detail<U, G, G const &>;
   template <class U, class G> using _can_move_convert = _can_convert_detail<U, G, G>;
   template <class U, class G> friend class expected;
-
-  // Bring the storage members into scope so unqualified lookup resolves them
-  // through the dependent base, and to document the inherited surface. For
-  // T=void the storage union has only `e_`; the value state has no active
-  // member.
-  using _base = detail::_storage<T, E>;
-  using _base::set_;
-  using _base::storage_;
 
   template <typename Self, typename Fn>
   static constexpr auto _and_then(Self &&self, Fn &&fn) //
@@ -1340,7 +1324,7 @@ class expected<T, E> : private detail::_storage<T, E> {
     using error_t = ::std::remove_cv_t<::std::invoke_result_t<Fn, decltype(FWD(self).error())>>;
     static_assert(detail::_is_valid_unexpected<error_t>);
     static_assert(::std::is_constructible_v<error_t, ::std::invoke_result_t<Fn, decltype(FWD(self).error())>>);
-    using result_t = expected<T, error_t>;
+    using result_t = expected<void, error_t>;
     if (not self.has_value()) {
       return result_t(unexpect, ::std::invoke(FWD(fn), FWD(self).error()));
     }
@@ -1348,7 +1332,7 @@ class expected<T, E> : private detail::_storage<T, E> {
   }
 
 public:
-  using value_type = T;
+  using value_type = void;
   using error_type = E;
   using unexpected_type = unexpected<E>;
 

--- a/include/pfn/expected.hpp
+++ b/include/pfn/expected.hpp
@@ -183,66 +183,289 @@ constexpr bool _is_valid_expected =                                   //
     && not ::std::is_same_v<::std::remove_cv_t<T>, unexpect_t>        //
     && not _is_some_unexpected<::std::remove_cv_t<T>>                 //
     && detail::_is_valid_unexpected<E>;
-} // namespace detail
 
-// declare void specialization
-template <class T, class E>
-  requires ::std::is_void_v<T>
-class expected<T, E>;
+static constexpr struct _branch_t {
+  constexpr explicit _branch_t() noexcept = default;
+} _branch{};
 
-template <class T, class E> class expected {
-  static_assert(detail::_is_valid_expected<T, E>);
+struct _dummy_t final {
+  constexpr _dummy_t() noexcept = default;
+};
 
-  template <class U, class G, class UF, class GF>
-  using _can_convert_detail = ::std::bool_constant<                           //
-      not(::std::is_same_v<T, U> && ::std::is_same_v<E, G>)                   //
-      && ::std::is_constructible_v<T, UF>                                     //
-      && ::std::is_constructible_v<E, GF>                                     //
-      && not ::std::is_constructible_v<unexpected<E>, expected<U, G> &>       //
-      && not ::std::is_constructible_v<unexpected<E>, expected<U, G>>         //
-      && not ::std::is_constructible_v<unexpected<E>, expected<U, G> const &> //
-      && not ::std::is_constructible_v<unexpected<E>, expected<U, G> const>   //
-      && (::std::is_same_v<bool, ::std::remove_cv_t<T>>                       //
-          || (                                                                //
-              not ::std::is_constructible_v<T, expected<U, G> &>              //
-              && not ::std::is_constructible_v<T, expected<U, G>>             //
-              && not ::std::is_constructible_v<T, expected<U, G> const &>     //
-              && not ::std::is_constructible_v<T, expected<U, G> const>       //
-              && not ::std::is_convertible_v<expected<U, G> &, T>             //
-              && not ::std::is_convertible_v<expected<U, G> &&, T>            //
-              && not ::std::is_convertible_v<expected<U, G> const &, T>       //
-              && not ::std::is_convertible_v<expected<U, G> const &&, T>))>;
+// Shared storage base for ::pfn::expected. Members are public because the
+// inheritance is private; sibling-instantiation access goes through the
+// `template <class, class> friend class expected;` declaration on the derived.
+template <class T, class E> struct _storage {
+  using _storage_t = ::std::conditional_t<::std::is_same_v<T, void>, _dummy_t, T>;
+  union {
+    _storage_t v_;
+    E e_;
+  };
+  bool set_;
 
-  template <class U, class G> using _can_copy_convert = _can_convert_detail<U, G, U const &, G const &>;
-  template <class U, class G> using _can_move_convert = _can_convert_detail<U, G, U, G>;
-  template <class U, class G> friend class expected;
+  template <class... Args>
+  constexpr explicit _storage(::std::in_place_t, Args &&...a) //
+      noexcept(::std::is_nothrow_constructible_v<_storage_t, Args...>)
+    requires ::std::is_constructible_v<_storage_t, Args...>
+      : v_(FWD(a)...), set_(true)
+  {
+  }
+  template <class U, class... Args>
+  constexpr explicit _storage(::std::in_place_t, ::std::initializer_list<U> il, Args &&...a) //
+      noexcept(::std::is_nothrow_constructible_v<_storage_t, ::std::initializer_list<U> &, Args...>)
+    requires ::std::is_constructible_v<_storage_t, ::std::initializer_list<U> &, Args...>
+      : v_(il, FWD(a)...), set_(true)
+  {
+  }
+  template <class... Args>
+  constexpr explicit _storage(unexpect_t, Args &&...a) //
+      noexcept(::std::is_nothrow_constructible_v<E, Args...>)
+    requires ::std::is_constructible_v<E, Args...>
+      : e_(FWD(a)...), set_(false)
+  {
+  }
+  template <class U, class... Args>
+  constexpr explicit _storage(unexpect_t, ::std::initializer_list<U> il, Args &&...a) //
+      noexcept(::std::is_nothrow_constructible_v<E, ::std::initializer_list<U> &, Args...>)
+    requires ::std::is_constructible_v<E, ::std::initializer_list<U> &, Args...>
+      : e_(il, FWD(a)...), set_(false)
+  {
+  }
+
+  // Branch tag: initializes only `set_`, leaving the union uninitialized so
+  // the derived ctor body can placement-new into the active arm.
+  constexpr explicit _storage(_branch_t, bool s) noexcept : set_(s) {}
+
+  constexpr _storage(_storage const &) = default;
+  constexpr _storage(_storage &&) = default;
+  constexpr _storage &operator=(_storage const &) = default;
+  constexpr _storage &operator=(_storage &&) = default;
+
+  constexpr ~_storage() noexcept
+    requires(::std::is_trivially_destructible_v<_storage_t> && ::std::is_trivially_destructible_v<E>)
+  = default;
+  constexpr ~_storage() //
+    requires(::std::is_trivially_destructible_v<_storage_t> && not ::std::is_trivially_destructible_v<E>)
+  {
+    if (not set_)
+      ::std::destroy_at(::std::addressof(e_));
+  }
+  constexpr ~_storage() //
+    requires(not ::std::is_trivially_destructible_v<_storage_t> && ::std::is_trivially_destructible_v<E>)
+  {
+    if (set_)
+      ::std::destroy_at(::std::addressof(v_));
+  }
+  constexpr ~_storage() //
+    requires(not ::std::is_trivially_destructible_v<_storage_t> && not ::std::is_trivially_destructible_v<E>)
+  {
+    if (set_)
+      ::std::destroy_at(::std::addressof(v_));
+    else
+      ::std::destroy_at(::std::addressof(e_));
+  }
+
+  // [expected.object.obs], observers
+  constexpr _storage_t const *operator->() const noexcept
+    requires(not ::std::is_void_v<T>)
+  {
+    ASSERT(set_);
+    return ::std::addressof(v_);
+  }
+  constexpr _storage_t *operator->() noexcept
+    requires(not ::std::is_void_v<T>)
+  {
+    ASSERT(set_);
+    return ::std::addressof(v_);
+  }
+  constexpr _storage_t const &operator*() const & noexcept
+    requires(not ::std::is_void_v<T>)
+  {
+    return *(this->operator->());
+  }
+  constexpr _storage_t &operator*() & noexcept
+    requires(not ::std::is_void_v<T>)
+  {
+    return *(this->operator->());
+  }
+  constexpr _storage_t const &&operator*() const && noexcept
+    requires(not ::std::is_void_v<T>)
+  {
+    return ::std::move(*(this->operator->()));
+  }
+  constexpr _storage_t &&operator*() && noexcept
+    requires(not ::std::is_void_v<T>)
+  {
+    return ::std::move(*(this->operator->()));
+  }
+  constexpr void operator*() const & noexcept
+    requires(::std::is_void_v<T>)
+  {
+    ASSERT(set_);
+  }
+  constexpr void operator*() & noexcept
+    requires(::std::is_void_v<T>)
+  {
+    ASSERT(set_);
+  }
+  constexpr void operator*() const && noexcept
+    requires(::std::is_void_v<T>)
+  {
+    ASSERT(set_);
+  }
+  constexpr void operator*() && noexcept
+    requires(::std::is_void_v<T>)
+  {
+    ASSERT(set_);
+  }
+  constexpr explicit operator bool() const noexcept { return set_; }
+  constexpr bool has_value() const noexcept { return set_; }
+  constexpr bool has_error() const noexcept { return !set_; } // P3798
+  constexpr _storage_t const &value() const &
+    requires(not ::std::is_void_v<T>)
+  {
+    static_assert(::std::is_copy_constructible_v<E>);
+    if (not set_)
+      throw bad_expected_access<E>(e_);
+    return v_;
+  }
+  constexpr _storage_t &value() &
+    requires(not ::std::is_void_v<T>)
+  {
+    static_assert(::std::is_copy_constructible_v<E>);
+    if (not set_)
+      throw bad_expected_access<E>(::std::as_const(e_));
+    return v_;
+  }
+  constexpr _storage_t const &&value() const &&
+    requires(not ::std::is_void_v<T>)
+  {
+    static_assert(::std::is_copy_constructible_v<E>);
+    static_assert(::std::is_constructible_v<E, E const &&>);
+    if (not set_)
+      throw bad_expected_access<E>(::std::move(e_));
+    return ::std::move(v_);
+  }
+  constexpr _storage_t &&value() &&
+    requires(not ::std::is_void_v<T>)
+  {
+    static_assert(::std::is_copy_constructible_v<E>);
+    static_assert(::std::is_constructible_v<E, E &&>);
+    if (not set_)
+      throw bad_expected_access<E>(::std::move(e_));
+    return ::std::move(v_);
+  }
+  constexpr void value() const &
+    requires(::std::is_void_v<T>)
+  {
+    static_assert(::std::is_copy_constructible_v<E>);
+    if (not set_)
+      throw bad_expected_access<E>(e_);
+  }
+  constexpr void value() &&
+    requires(::std::is_void_v<T>)
+  {
+    static_assert(::std::is_copy_constructible_v<E>);
+    static_assert(::std::is_move_constructible_v<E>);
+    if (not set_)
+      throw bad_expected_access<E>(::std::move(e_));
+  }
+  constexpr E const &error() const & noexcept
+  {
+    ASSERT(not set_);
+    return e_;
+  }
+  constexpr E &error() & noexcept
+  {
+    ASSERT(not set_);
+    return e_;
+  }
+  constexpr E const &&error() const && noexcept
+  {
+    ASSERT(not set_);
+    return ::std::move(e_);
+  }
+  constexpr E &&error() && noexcept
+  {
+    ASSERT(not set_);
+    return ::std::move(e_);
+  }
 
   template <class U>
-  using _can_convert = ::std::bool_constant<                            //
-      not ::std::is_same_v<::std::remove_cvref_t<U>, ::std::in_place_t> //
-      && not ::std::is_same_v<::std::remove_cvref_t<U>, unexpect_t>     // LWG4222
-      && not ::std::is_same_v<expected, ::std::remove_cvref_t<U>>       //
-      && not detail::_is_some_unexpected<::std::remove_cvref_t<U>>      //
-      && ::std::is_constructible_v<T, U>                                //
-      && (not ::std::is_same_v<bool, ::std::remove_cv_t<T>>             //
-          || not detail::_is_some_expected<::std::remove_cvref_t<U>>)>;
-
+  constexpr T value_or(U &&v) const &                                                              //
+      noexcept(::std::is_nothrow_copy_constructible_v<T> && ::std::is_nothrow_convertible_v<U, T>) // extension
+    requires(not ::std::is_void_v<T>)
+  {
+    static_assert(::std::is_copy_constructible_v<T>);
+    static_assert(::std::is_convertible_v<U, T>);
+    return set_ ? v_ : static_cast<T>(FWD(v));
+  }
   template <class U>
-  using _can_convert_assign = ::std::bool_constant<                //
-      not ::std::is_same_v<expected, ::std::remove_cvref_t<U>>     //
-      && not detail::_is_some_unexpected<::std::remove_cvref_t<U>> //
-      && ::std::is_constructible_v<T, U>                           //
-      && ::std::is_assignable_v<T &, U>                            //
-      && (::std::is_nothrow_constructible_v<T, U>                  //
-          || ::std::is_nothrow_move_constructible_v<T>             //
-          || ::std::is_nothrow_move_constructible_v<E>)>;
+  constexpr T value_or(U &&v) &&                                                                   //
+      noexcept(::std::is_nothrow_move_constructible_v<T> && ::std::is_nothrow_convertible_v<U, T>) // extension
+    requires(not ::std::is_void_v<T>)
+  {
+    static_assert(::std::is_move_constructible_v<T>);
+    static_assert(::std::is_convertible_v<U, T>);
+    return set_ ? ::std::move(v_) : static_cast<T>(FWD(v));
+  }
+
+  template <class G = E>
+  constexpr E error_or(G &&e) const &                                                              //
+      noexcept(::std::is_nothrow_copy_constructible_v<E> && ::std::is_nothrow_convertible_v<G, E>) // extension
+  {
+    static_assert(::std::is_copy_constructible_v<E>);
+    static_assert(::std::is_convertible_v<G, E>);
+    if (set_) {
+      return FWD(e);
+    }
+    return e_;
+  }
+  template <class G = E>
+  constexpr E error_or(G &&e) &&                                                                   //
+      noexcept(::std::is_nothrow_move_constructible_v<E> && ::std::is_nothrow_convertible_v<G, E>) // extension
+  {
+    static_assert(::std::is_move_constructible_v<E>);
+    static_assert(::std::is_convertible_v<G, E>);
+    if (set_) {
+      return FWD(e);
+    }
+    return ::std::move(e_);
+  }
+
+  // Internal value accessor used by monadic helpers; `value()` performs the
+  // access check via exception, this one assumes the precondition.
+  constexpr _storage_t const &_value() const & noexcept
+    requires(not ::std::is_void_v<T>)
+  {
+    ASSERT(set_);
+    return v_;
+  }
+  constexpr _storage_t &_value() & noexcept
+    requires(not ::std::is_void_v<T>)
+  {
+    ASSERT(set_);
+    return v_;
+  }
+  constexpr _storage_t const &&_value() const && noexcept
+    requires(not ::std::is_void_v<T>)
+  {
+    ASSERT(set_);
+    return ::std::move(v_);
+  }
+  constexpr _storage_t &&_value() && noexcept
+    requires(not ::std::is_void_v<T>)
+  {
+    ASSERT(set_);
+    return ::std::move(v_);
+  }
 
   // [expected.object.assign]
   template <typename New, typename Old, typename... Args>
   static constexpr void _reinit(New &newval, Old &oldval, Args &&...args) //
       noexcept(::std::is_nothrow_constructible_v<New, Args...>)
   {
-    if constexpr (::std::is_nothrow_constructible_v<New, Args...>) {
+    if constexpr (::std::is_void_v<T> || ::std::is_nothrow_constructible_v<New, Args...>) {
       ::std::destroy_at(::std::addressof(oldval));
       ::std::construct_at(::std::addressof(newval), ::std::forward<Args>(args)...);
     } else if constexpr (::std::is_nothrow_move_constructible_v<New>) {
@@ -294,8 +517,48 @@ template <class T, class E> class expected {
     }
   }
 
-  static constexpr void _swap(expected &lhs, expected &rhs) //
-      noexcept(::std::is_nothrow_move_constructible_v<T> && ::std::is_nothrow_move_constructible_v<E>)
+  // Body helper for the copy/move assignment operators; the public expected
+  // operator= overloads keep their constraints/noexcept clauses and just
+  // delegate here, forwarding `s` as lvalue or rvalue. For T=void the value
+  // side is `_dummy_t` whose destructor and default ctor are trivial; the
+  // cross-state transitions use direct construct_at, matching the
+  // [expected.void.assign] and [expected.object.assign] specification (no strong exception guarantee).
+  constexpr void _assign(auto &&s)
+  {
+    if (set_ && s.set_) {
+      v_ = FWD(s).v_;
+    } else if (set_) {
+      _reinit(e_, v_, FWD(s).e_);
+      set_ = false;
+    } else if (s.set_) {
+      _reinit(v_, e_, FWD(s).v_);
+      set_ = true;
+    } else {
+      e_ = FWD(s).e_;
+    }
+  }
+  template <class U> constexpr void _assign_value(U &&s)
+  {
+    if (set_) {
+      v_ = FWD(s);
+    } else {
+      _reinit(v_, e_, FWD(s));
+      set_ = true;
+    }
+  }
+  constexpr void _assign_unexpected(auto &&s)
+  {
+    if (not set_) {
+      e_ = FWD(s).error();
+    } else {
+      _reinit(e_, v_, FWD(s).error());
+      set_ = false;
+    }
+  }
+
+  // [expected.object.swap] cross-state swap helper; lhs holds value, rhs holds error
+  static constexpr void _swap(_storage &lhs, _storage &rhs) //
+      noexcept(::std::is_nothrow_move_constructible_v<_storage_t> && ::std::is_nothrow_move_constructible_v<E>)
   {
     if constexpr (::std::is_nothrow_move_constructible_v<E>) {
       E tmp(::std::move(rhs.e_));
@@ -309,7 +572,7 @@ template <class T, class E> class expected {
         throw;
       }
     } else {
-      T tmp(::std::move(lhs.v_));
+      _storage_t tmp(::std::move(lhs.v_));
       ::std::destroy_at(::std::addressof(lhs.v_));
       try {
         ::std::construct_at(::std::addressof(lhs.e_), ::std::move(rhs.e_));
@@ -324,26 +587,142 @@ template <class T, class E> class expected {
     rhs.set_ = true;
   }
 
-  constexpr T const &_value() const & noexcept
+  // [expected.object.swap] body helper; the public expected::swap keeps its
+  // constraints/noexcept clause and just delegates here.
+  constexpr void _swap_with(_storage &rhs)
   {
-    ASSERT(set_);
-    return v_;
+    if (set_ == rhs.set_) {
+      if (set_) {
+        if constexpr (not ::std::is_void_v<T>) {
+          using ::std::swap;
+          swap(v_, rhs.v_);
+        }
+      } else {
+        using ::std::swap;
+        swap(e_, rhs.e_);
+      }
+    } else if constexpr (::std::is_void_v<T>) {
+      // Direct cross-state transition: only one E move, matching the
+      // [expected.void.swap] specification.
+      if (set_) {
+        ::std::destroy_at(::std::addressof(v_));
+        ::std::construct_at(::std::addressof(e_), ::std::move(rhs.e_));
+        ::std::destroy_at(::std::addressof(rhs.e_));
+        ::std::construct_at(::std::addressof(rhs.v_));
+        set_ = false;
+        rhs.set_ = true;
+      } else {
+        rhs._swap_with(*this);
+      }
+    } else {
+      if (set_) {
+        _swap(*this, rhs);
+      } else {
+        _swap(rhs, *this);
+      }
+    }
   }
-  constexpr T &_value() & noexcept
+
+  // [expected.object.emplace], emplace
+  template <class... Args>
+  constexpr _storage_t &emplace(Args &&...args) noexcept
+    requires(not ::std::is_void_v<T> && ::std::is_nothrow_constructible_v<T, Args...>)
   {
-    ASSERT(set_);
-    return v_;
+    if (set_) {
+      ::std::destroy_at(::std::addressof(v_));
+    } else {
+      ::std::destroy_at(::std::addressof(e_));
+      set_ = true;
+    }
+    return *::std::construct_at(::std::addressof(v_), std::forward<Args>(args)...);
   }
-  constexpr T const &&_value() const && noexcept
+
+  template <class U, class... Args>
+  constexpr _storage_t &emplace(::std::initializer_list<U> il, Args &&...args) noexcept
+    requires(not ::std::is_void_v<T> && ::std::is_nothrow_constructible_v<T, ::std::initializer_list<U> &, Args...>)
   {
-    ASSERT(set_);
-    return ::std::move(v_);
+    if (set_) {
+      ::std::destroy_at(::std::addressof(v_));
+    } else {
+      ::std::destroy_at(::std::addressof(e_));
+      set_ = true;
+    }
+    return *::std::construct_at(::std::addressof(v_), il, std::forward<Args>(args)...);
   }
-  constexpr T &&_value() && noexcept
+
+  // [expected.void.emplace], emplace
+  constexpr void emplace() noexcept
+    requires(::std::is_void_v<T>)
   {
-    ASSERT(set_);
-    return ::std::move(v_);
+    if (not set_) {
+      ::std::destroy_at(::std::addressof(e_));
+      ::std::construct_at(::std::addressof(v_));
+      set_ = true;
+    }
   }
+};
+
+} // namespace detail
+
+// declare void specialization
+template <class T, class E>
+  requires ::std::is_void_v<T>
+class expected<T, E>;
+
+template <class T, class E> class expected : private detail::_storage<T, E> {
+  static_assert(detail::_is_valid_expected<T, E>);
+
+  template <class U, class G, class UF, class GF>
+  using _can_convert_detail = ::std::bool_constant<                           //
+      not(::std::is_same_v<T, U> && ::std::is_same_v<E, G>)                   //
+      && ::std::is_constructible_v<T, UF>                                     //
+      && ::std::is_constructible_v<E, GF>                                     //
+      && not ::std::is_constructible_v<unexpected<E>, expected<U, G> &>       //
+      && not ::std::is_constructible_v<unexpected<E>, expected<U, G>>         //
+      && not ::std::is_constructible_v<unexpected<E>, expected<U, G> const &> //
+      && not ::std::is_constructible_v<unexpected<E>, expected<U, G> const>   //
+      && (::std::is_same_v<bool, ::std::remove_cv_t<T>>                       //
+          || (                                                                //
+              not ::std::is_constructible_v<T, expected<U, G> &>              //
+              && not ::std::is_constructible_v<T, expected<U, G>>             //
+              && not ::std::is_constructible_v<T, expected<U, G> const &>     //
+              && not ::std::is_constructible_v<T, expected<U, G> const>       //
+              && not ::std::is_convertible_v<expected<U, G> &, T>             //
+              && not ::std::is_convertible_v<expected<U, G> &&, T>            //
+              && not ::std::is_convertible_v<expected<U, G> const &, T>       //
+              && not ::std::is_convertible_v<expected<U, G> const &&, T>))>;
+
+  template <class U, class G> using _can_copy_convert = _can_convert_detail<U, G, U const &, G const &>;
+  template <class U, class G> using _can_move_convert = _can_convert_detail<U, G, U, G>;
+  template <class U, class G> friend class expected;
+
+  // Bring the storage members into scope so unqualified lookup resolves them
+  // through the dependent base, and to document the inherited surface.
+  using _base = detail::_storage<T, E>;
+  using _base::_value;
+  using _base::e_;
+  using _base::set_;
+  using _base::v_;
+
+  template <class U>
+  using _can_convert = ::std::bool_constant<                            //
+      not ::std::is_same_v<::std::remove_cvref_t<U>, ::std::in_place_t> //
+      && not ::std::is_same_v<::std::remove_cvref_t<U>, unexpect_t>     // LWG4222
+      && not ::std::is_same_v<expected, ::std::remove_cvref_t<U>>       //
+      && not detail::_is_some_unexpected<::std::remove_cvref_t<U>>      //
+      && ::std::is_constructible_v<T, U>                                //
+      && (not ::std::is_same_v<bool, ::std::remove_cv_t<T>>             //
+          || not detail::_is_some_expected<::std::remove_cvref_t<U>>)>;
+
+  template <class U>
+  using _can_convert_assign = ::std::bool_constant<                //
+      not ::std::is_same_v<expected, ::std::remove_cvref_t<U>>     //
+      && not detail::_is_some_unexpected<::std::remove_cvref_t<U>> //
+      && ::std::is_constructible_v<T, U>                           //
+      && ::std::is_assignable_v<T &, U>                            //
+      && (::std::is_nothrow_constructible_v<T, U>                  //
+          || ::std::is_nothrow_move_constructible_v<T>             //
+          || ::std::is_nothrow_move_constructible_v<E>)>;
 
   template <typename Self, typename Fn>
   static constexpr auto _and_then(Self &&self, Fn &&fn) //
@@ -434,7 +813,7 @@ public:
   constexpr expected()                                       //
       noexcept(::std::is_nothrow_default_constructible_v<T>) // extension
     requires ::std::is_default_constructible_v<T>
-      : v_(), set_(true)
+      : _base(::std::in_place)
   {
   }
 
@@ -448,7 +827,7 @@ public:
       noexcept(::std::is_nothrow_copy_constructible_v<T> && ::std::is_nothrow_copy_constructible_v<E>) // extension
     requires(::std::is_copy_constructible_v<T> && ::std::is_copy_constructible_v<E>
              && (not ::std::is_trivially_copy_constructible_v<T> || not ::std::is_trivially_copy_constructible_v<E>))
-      : set_(s.set_)
+      : _base(detail::_branch, s.set_)
   {
     if (set_)
       ::std::construct_at(::std::addressof(v_), s.v_);
@@ -464,7 +843,7 @@ public:
       noexcept(::std::is_nothrow_move_constructible_v<T> && ::std::is_nothrow_move_constructible_v<E>) // required
     requires(::std::is_move_constructible_v<T> && ::std::is_move_constructible_v<E>
              && (not ::std::is_trivially_move_constructible_v<T> || not ::std::is_trivially_move_constructible_v<E>))
-      : set_(s.set_)
+      : _base(detail::_branch, s.set_)
   {
     if (set_)
       ::std::construct_at(::std::addressof(v_), ::std::move(s.v_));
@@ -478,7 +857,7 @@ public:
       noexcept(::std::is_nothrow_constructible_v<T, U const &>
                && ::std::is_nothrow_constructible_v<E, G const &>) // extension
     requires(_can_copy_convert<U, G>::value)
-      : set_(s.set_)
+      : _base(detail::_branch, s.set_)
   {
     if (set_)
       ::std::construct_at(::std::addressof(v_), s.v_);
@@ -491,7 +870,7 @@ public:
       expected(expected<U, G> &&s)                                                                 //
       noexcept(::std::is_nothrow_constructible_v<T, U> && ::std::is_nothrow_constructible_v<E, G>) // extension
     requires(_can_move_convert<U, G>::value)
-      : set_(s.set_)
+      : _base(detail::_branch, s.set_)
   {
     if (set_)
       ::std::construct_at(::std::addressof(v_), ::std::move(s.v_));
@@ -503,7 +882,7 @@ public:
   constexpr explicit(not ::std::is_convertible_v<U, T>) expected(U &&v) //
       noexcept(::std::is_nothrow_constructible_v<T, U>)                 // extension
     requires(_can_convert<U>::value)
-      : v_(FWD(v)), set_(true)
+      : _base(::std::in_place, FWD(v))
   {
   }
 
@@ -511,7 +890,7 @@ public:
   constexpr explicit(!::std::is_convertible_v<G const &, E>) expected(unexpected<G> const &g) //
       noexcept(::std::is_nothrow_constructible_v<E, G const &>)                               // extension
     requires(::std::is_constructible_v<E, G const &>)
-      : e_(::std::forward<G const &>(g.error())), set_(false)
+      : _base(unexpect, ::std::forward<G const &>(g.error()))
   {
   }
 
@@ -519,7 +898,7 @@ public:
   constexpr explicit(!::std::is_convertible_v<G, E>) expected(unexpected<G> &&g) //
       noexcept(::std::is_nothrow_constructible_v<E, G>)                          // extension
     requires(::std::is_constructible_v<E, G>)
-      : e_(::std::forward<G>(g.error())), set_(false)
+      : _base(unexpect, ::std::forward<G>(g.error()))
   {
   }
 
@@ -527,59 +906,34 @@ public:
   constexpr explicit expected(::std::in_place_t, Args &&...a) //
       noexcept(::std::is_nothrow_constructible_v<T, Args...>) // extension
     requires ::std::is_constructible_v<T, Args...>
-      : v_(FWD(a)...), set_(true)
+      : _base(::std::in_place, FWD(a)...)
   {
   }
   template <class U, class... Args>
   constexpr explicit expected(::std::in_place_t, ::std::initializer_list<U> il, Args &&...a) //
       noexcept(::std::is_nothrow_constructible_v<T, ::std::initializer_list<U> &, Args...>)  // extension
     requires ::std::is_constructible_v<T, ::std::initializer_list<U> &, Args...>
-      : v_(il, FWD(a)...), set_(true)
+      : _base(::std::in_place, il, FWD(a)...)
   {
   }
   template <class... Args>
   constexpr explicit expected(unexpect_t, Args &&...a)        //
       noexcept(::std::is_nothrow_constructible_v<E, Args...>) // extension
     requires ::std::is_constructible_v<E, Args...>
-      : e_(FWD(a)...), set_(false)
+      : _base(unexpect, FWD(a)...)
   {
   }
   template <class U, class... Args>
   constexpr explicit expected(unexpect_t, ::std::initializer_list<U> il, Args &&...a)       //
       noexcept(::std::is_nothrow_constructible_v<E, ::std::initializer_list<U> &, Args...>) // extension
     requires ::std::is_constructible_v<E, ::std::initializer_list<U> &, Args...>
-      : e_(il, FWD(a)...), set_(false)
+      : _base(unexpect, il, FWD(a)...)
   {
   }
 
-  // [expected.object.dtor], destructor
-  constexpr ~expected() noexcept
-    requires(::std::is_trivially_destructible_v<T> && ::std::is_trivially_destructible_v<E>)
-  = default;
-  constexpr ~expected() //
-    requires(::std::is_trivially_destructible_v<T> && not ::std::is_trivially_destructible_v<E>)
-  {
-    if (not set_)
-      ::std::destroy_at(::std::addressof(e_));
-    // else T is trivially destructible, no need to do anything
-  }
-  constexpr ~expected() //
-    requires(not ::std::is_trivially_destructible_v<T> && ::std::is_trivially_destructible_v<E>)
-  {
-    if (set_)
-      ::std::destroy_at(::std::addressof(v_));
-    // else E is trivially destructible, no need to do anything
-  }
-  constexpr ~expected() //
-    requires(not ::std::is_trivially_destructible_v<T> && not ::std::is_trivially_destructible_v<E>)
-  {
-    if (set_)
-      ::std::destroy_at(::std::addressof(v_));
-    else
-      ::std::destroy_at(::std::addressof(e_));
-  }
+  // [expected.object.dtor], destructor inherited from _storage
 
-  // [expected.object.assign], assignment
+  // [expected.object.assign], assignment; bodies delegate to _storage helpers
   constexpr expected &operator=(expected const &) = delete;
   constexpr expected &operator=(expected const &s) //
       noexcept(::std::is_nothrow_copy_assignable_v<T> && ::std::is_nothrow_copy_constructible_v<T>
@@ -588,17 +942,7 @@ public:
              && ::std::is_copy_constructible_v<E>
              && (::std::is_nothrow_move_constructible_v<T> || ::std::is_nothrow_move_constructible_v<E>))
   {
-    if (set_ && s.set_) {
-      v_ = s.v_;
-    } else if (set_) {
-      _reinit(e_, v_, s.e_);
-      set_ = false;
-    } else if (s.set_) {
-      _reinit(v_, e_, s.v_);
-      set_ = true;
-    } else {
-      e_ = s.e_;
-    }
+    this->_assign(static_cast<_base const &>(s));
     return *this;
   }
 
@@ -609,17 +953,7 @@ public:
              && ::std::is_move_assignable_v<E>
              && (::std::is_nothrow_move_constructible_v<T> || ::std::is_nothrow_move_constructible_v<E>))
   {
-    if (set_ && s.set_) {
-      v_ = ::std::move(s.v_);
-    } else if (set_) {
-      _reinit(e_, v_, ::std::move(s.e_));
-      set_ = false;
-    } else if (s.set_) {
-      _reinit(v_, e_, ::std::move(s.v_));
-      set_ = true;
-    } else {
-      e_ = ::std::move(s.e_);
-    }
+    this->_assign(static_cast<_base &&>(s));
     return *this;
   }
 
@@ -628,12 +962,7 @@ public:
       noexcept(::std::is_nothrow_assignable_v<T &, U> && ::std::is_nothrow_constructible_v<T, U>) // extension
     requires(_can_convert_assign<U>::value)
   {
-    if (set_) {
-      v_ = FWD(s);
-    } else {
-      _reinit(v_, e_, FWD(s));
-      set_ = true;
-    }
+    this->_assign_value(FWD(s));
     return *this;
   }
 
@@ -645,12 +974,7 @@ public:
              && (::std::is_nothrow_constructible_v<E, G const &> || ::std::is_nothrow_move_constructible_v<T>
                  || ::std::is_nothrow_move_constructible_v<E>))
   {
-    if (not set_) {
-      e_ = ::std::forward<G const &>(s.error());
-    } else {
-      _reinit(e_, v_, ::std::forward<G const &>(s.error()));
-      set_ = false;
-    }
+    this->_assign_unexpected(s);
     return *this;
   }
 
@@ -661,42 +985,14 @@ public:
              && (::std::is_nothrow_constructible_v<E, G> || ::std::is_nothrow_move_constructible_v<T>
                  || ::std::is_nothrow_move_constructible_v<E>))
   {
-    if (not set_) {
-      e_ = ::std::forward<G>(s.error());
-    } else {
-      _reinit(e_, v_, ::std::forward<G>(s.error()));
-      set_ = false;
-    }
+    this->_assign_unexpected(::std::move(s));
     return *this;
   }
 
-  template <class... Args>
-  constexpr T &emplace(Args &&...args) noexcept
-    requires(::std::is_nothrow_constructible_v<T, Args...>)
-  {
-    if (set_) {
-      ::std::destroy_at(::std::addressof(v_));
-    } else {
-      ::std::destroy_at(::std::addressof(e_));
-      set_ = true;
-    }
-    return *::std::construct_at(::std::addressof(v_), std::forward<Args>(args)...);
-  }
+  // [expected.object.emplace], emplace inherited from _storage
+  using _base::emplace;
 
-  template <class U, class... Args>
-  constexpr T &emplace(::std::initializer_list<U> il, Args &&...args) noexcept
-    requires(::std::is_nothrow_constructible_v<T, ::std::initializer_list<U> &, Args...>)
-  {
-    if (set_) {
-      ::std::destroy_at(::std::addressof(v_));
-    } else {
-      ::std::destroy_at(::std::addressof(e_));
-      set_ = true;
-    }
-    return *::std::construct_at(::std::addressof(v_), il, std::forward<Args>(args)...);
-  }
-
-  // [expected.object.swap], swap
+  // [expected.object.swap], swap; body delegates to _storage helper
   constexpr void
   swap(expected &rhs) noexcept(::std::is_nothrow_move_constructible_v<T> && ::std::is_nothrow_swappable_v<T>
                                && ::std::is_nothrow_move_constructible_v<E> && ::std::is_nothrow_swappable_v<E>)
@@ -704,23 +1000,7 @@ public:
              && ::std::is_move_constructible_v<E>
              && (::std::is_nothrow_move_constructible_v<T> || ::std::is_nothrow_move_constructible_v<E>))
   {
-    bool const lhset = has_value();
-    bool const rhset = rhs.has_value();
-    if (lhset == rhset) {
-      if (lhset) {
-        using ::std::swap;
-        swap(v_, rhs.v_);
-      } else {
-        using ::std::swap;
-        swap(e_, rhs.e_);
-      }
-    } else {
-      if (lhset) {
-        _swap(*this, rhs);
-      } else {
-        _swap(rhs, *this);
-      }
-    }
+    this->_swap_with(rhs);
   }
 
   constexpr friend void swap(expected &x, expected &y) noexcept(noexcept(x.swap(y)))
@@ -729,114 +1009,16 @@ public:
     x.swap(y);
   }
 
-  // [expected.object.obs], observers
-  constexpr T const *operator->() const noexcept
-  {
-    ASSERT(set_);
-    return ::std::addressof(v_);
-  }
-  constexpr T *operator->() noexcept
-  {
-    ASSERT(set_);
-    return ::std::addressof(v_);
-  }
-  constexpr T const &operator*() const & noexcept { return *(this->operator->()); }
-  constexpr T &operator*() & noexcept { return *(this->operator->()); }
-  constexpr T const &&operator*() const && noexcept { return ::std::move(*(this->operator->())); }
-  constexpr T &&operator*() && noexcept { return ::std::move(*(this->operator->())); }
-  constexpr explicit operator bool() const noexcept { return set_; }
-  constexpr bool has_value() const noexcept { return set_; }
-  constexpr bool has_error() const noexcept { return !set_; } // P3798
-  constexpr T const &value() const &
-  {
-    static_assert(::std::is_copy_constructible_v<E>);
-    if (not set_)
-      throw bad_expected_access<E>(e_);
-    return v_;
-  }
-  constexpr T &value() &
-  {
-    static_assert(::std::is_copy_constructible_v<E>);
-    if (not set_)
-      throw bad_expected_access<E>(::std::as_const(e_));
-    return v_;
-  }
-  constexpr T const &&value() const &&
-  {
-    static_assert(::std::is_copy_constructible_v<E>);
-    static_assert(::std::is_constructible_v<E, E const &&>);
-    if (not set_)
-      throw bad_expected_access<E>(::std::move(e_));
-    return ::std::move(v_);
-  }
-  constexpr T &&value() &&
-  {
-    static_assert(::std::is_copy_constructible_v<E>);
-    static_assert(::std::is_constructible_v<E, E &&>);
-    if (not set_)
-      throw bad_expected_access<E>(::std::move(e_));
-    return ::std::move(v_);
-  }
-  constexpr E const &error() const & noexcept
-  {
-    ASSERT(not set_);
-    return e_;
-  }
-  constexpr E &error() & noexcept
-  {
-    ASSERT(not set_);
-    return e_;
-  }
-  constexpr E const &&error() const && noexcept
-  {
-    ASSERT(not set_);
-    return ::std::move(e_);
-  }
-  constexpr E &&error() && noexcept
-  {
-    ASSERT(not set_);
-    return ::std::move(e_);
-  }
-
-  template <class U>
-  constexpr T value_or(U &&v) const &                                                              //
-      noexcept(::std::is_nothrow_copy_constructible_v<T> && ::std::is_nothrow_convertible_v<U, T>) // extension
-  {
-    static_assert(::std::is_copy_constructible_v<T>);
-    static_assert(::std::is_convertible_v<U, T>);
-    return set_ ? v_ : static_cast<T>(FWD(v));
-  }
-  template <class U>
-  constexpr T value_or(U &&v) &&                                                                   //
-      noexcept(::std::is_nothrow_move_constructible_v<T> && ::std::is_nothrow_convertible_v<U, T>) // extension
-  {
-    static_assert(::std::is_move_constructible_v<T>);
-    static_assert(::std::is_convertible_v<U, T>);
-    return set_ ? ::std::move(v_) : static_cast<T>(FWD(v));
-  }
-
-  template <class G = E>
-  constexpr E error_or(G &&e) const &                                                              //
-      noexcept(::std::is_nothrow_copy_constructible_v<E> && ::std::is_nothrow_convertible_v<G, E>) // extension
-  {
-    static_assert(::std::is_copy_constructible_v<E>);
-    static_assert(::std::is_convertible_v<G, E>);
-    if (set_) {
-      return FWD(e);
-    }
-    return e_;
-  }
-  template <class G = E>
-  constexpr E error_or(G &&e) &&                                                                   //
-      noexcept(::std::is_nothrow_move_constructible_v<E> && ::std::is_nothrow_convertible_v<G, E>) // extension
-  {
-    static_assert(::std::is_move_constructible_v<E>);
-    static_assert(::std::is_convertible_v<G, E>);
-    if (set_) {
-      return FWD(e);
-    }
-    return ::std::move(e_);
-  }
+  // [expected.object.obs], observers inherited from _storage
+  using _base::operator*;
+  using _base::operator->;
+  using _base::operator bool;
+  using _base::error;
+  using _base::error_or;
+  using _base::has_error;
+  using _base::has_value;
+  using _base::value;
+  using _base::value_or;
 
   // [expected.object.monadic], monadic operations
   template <class F>
@@ -1001,18 +1183,11 @@ requires {
     }
     return x.error() == e.error();
   }
-
-private:
-  union {
-    T v_;
-    E e_;
-  };
-  bool set_;
 };
 
 template <class T, class E>
   requires ::std::is_void_v<T>
-class expected<T, E> {
+class expected<T, E> : private detail::_storage<T, E> {
   static_assert(detail::_is_valid_unexpected<E>);
 
   template <class U, class G, class GF>
@@ -1026,6 +1201,13 @@ class expected<T, E> {
   template <class U, class G> using _can_copy_convert = _can_convert_detail<U, G, G const &>;
   template <class U, class G> using _can_move_convert = _can_convert_detail<U, G, G>;
   template <class U, class G> friend class expected;
+
+  // Bring the storage members into scope so unqualified lookup resolves them
+  // through the dependent base, and to document the inherited surface.
+  using _base = detail::_storage<T, E>;
+  using _base::e_;
+  using _base::set_;
+  using _base::v_;
 
   template <typename Self, typename Fn>
   static constexpr auto _and_then(Self &&self, Fn &&fn) //
@@ -1104,19 +1286,23 @@ public:
   template <class U> using rebind = expected<U, error_type>;
 
   // [expected.void.cons], constructors
-  constexpr expected() noexcept : d_(), set_(true) {}
+  constexpr expected() noexcept : _base(::std::in_place) {}
   constexpr expected(expected const &) = delete;
   constexpr expected(expected const &)                                                         //
     requires(::std::is_copy_constructible_v<E> && ::std::is_trivially_copy_constructible_v<E>) //
   = default;
+  // Delegate to the in_place ctor of `_storage`, which default-initialises the
+  // value arm (`_dummy_t`) and sets `set_` to true; the body then switches to
+  // the error arm when the source holds an error.
   constexpr expected(expected const &s)                                                            //
       noexcept(::std::is_nothrow_copy_constructible_v<E>)                                          // extension
     requires(::std::is_copy_constructible_v<E> && not ::std::is_trivially_copy_constructible_v<E>) //
-      : d_(), set_(s.set_)
+      : _base(::std::in_place)
   {
-    if (not set_) {
-      ::std::destroy_at(::std::addressof(d_));
+    if (not s.set_) {
+      ::std::destroy_at(::std::addressof(v_));
       ::std::construct_at(::std::addressof(e_), s.e_);
+      set_ = false;
     }
   }
 
@@ -1126,11 +1312,12 @@ public:
   constexpr expected(expected &&s)                        //
       noexcept(::std::is_nothrow_move_constructible_v<E>) // required
     requires(::std::is_move_constructible_v<E> && not ::std::is_trivially_move_constructible_v<E>)
-      : d_(), set_(s.set_)
+      : _base(::std::in_place)
   {
-    if (not set_) {
-      ::std::destroy_at(::std::addressof(d_));
+    if (not s.set_) {
+      ::std::destroy_at(::std::addressof(v_));
       ::std::construct_at(::std::addressof(e_), ::std::move(s.e_));
+      set_ = false;
     }
   }
 
@@ -1138,22 +1325,24 @@ public:
   constexpr explicit(not ::std::is_convertible_v<G const &, E>) expected(expected<U, G> const &s) //
       noexcept(::std::is_nothrow_constructible_v<E, G const &>)                                   // extension
     requires(_can_copy_convert<U, G>::value)
-      : d_(), set_(s.set_)
+      : _base(::std::in_place)
   {
-    if (not set_) {
-      ::std::destroy_at(::std::addressof(d_));
+    if (not s.set_) {
+      ::std::destroy_at(::std::addressof(v_));
       ::std::construct_at(::std::addressof(e_), s.e_);
+      set_ = false;
     }
   }
   template <class U, class G>
   constexpr explicit(not ::std::is_convertible_v<G, E>) expected(expected<U, G> &&s) //
       noexcept(::std::is_nothrow_constructible_v<E, G>)                              // extension
     requires(_can_move_convert<U, G>::value)
-      : d_(), set_(s.set_)
+      : _base(::std::in_place)
   {
-    if (not set_) {
-      ::std::destroy_at(::std::addressof(d_));
+    if (not s.set_) {
+      ::std::destroy_at(::std::addressof(v_));
       ::std::construct_at(::std::addressof(e_), ::std::move(s.e_));
+      set_ = false;
     }
   }
 
@@ -1161,66 +1350,43 @@ public:
   constexpr explicit(!::std::is_convertible_v<G const &, E>) expected(unexpected<G> const &g) //
       noexcept(::std::is_nothrow_constructible_v<E, G const &>)                               // extension
     requires(::std::is_constructible_v<E, G const &>)
-      : e_(::std::forward<G const &>(g.error())), set_(false)
+      : _base(unexpect, ::std::forward<G const &>(g.error()))
   {
   }
   template <class G>
   constexpr explicit(!::std::is_convertible_v<G, E>) expected(unexpected<G> &&g) //
       noexcept(::std::is_nothrow_constructible_v<E, G>)                          // extension
     requires(::std::is_constructible_v<E, G>)
-      : e_(::std::forward<G>(g.error())), set_(false)
+      : _base(unexpect, ::std::forward<G>(g.error()))
   {
   }
 
-  constexpr explicit expected(::std::in_place_t) noexcept : d_(), set_(true) {}
+  constexpr explicit expected(::std::in_place_t) noexcept : _base(::std::in_place) {}
 
   template <class... Args>
   constexpr explicit expected(unexpect_t, Args &&...a)        //
       noexcept(::std::is_nothrow_constructible_v<E, Args...>) // extension
     requires ::std::is_constructible_v<E, Args...>
-      : e_(FWD(a)...), set_(false)
+      : _base(unexpect, FWD(a)...)
   {
   }
   template <class U, class... Args>
   constexpr explicit expected(unexpect_t, ::std::initializer_list<U> il, Args &&...a)       //
       noexcept(::std::is_nothrow_constructible_v<E, ::std::initializer_list<U> &, Args...>) // extension
     requires ::std::is_constructible_v<E, ::std::initializer_list<U> &, Args...>
-      : e_(il, FWD(a)...), set_(false)
+      : _base(unexpect, il, FWD(a)...)
   {
   }
 
-  // [expected.void.dtor], destructor
-  constexpr ~expected() noexcept
-    requires(::std::is_trivially_destructible_v<E>)
-  = default;
-  constexpr ~expected() //
-    requires(not ::std::is_trivially_destructible_v<E>)
-  {
-    if (not set_)
-      ::std::destroy_at(::std::addressof(e_));
-    else
-      ::std::destroy_at(::std::addressof(d_));
-  }
+  // [expected.void.dtor], destructor inherited from _storage
 
-  // [expected.void.assign], assignment
+  // [expected.void.assign], assignment; bodies delegate to _storage helpers
   constexpr expected &operator=(expected const &) = delete;
   constexpr expected &operator=(expected const &s)                                                  //
       noexcept(::std::is_nothrow_copy_assignable_v<E> && ::std::is_nothrow_copy_constructible_v<E>) // extension
     requires(::std::is_copy_assignable_v<E> && ::std::is_copy_constructible_v<E>)
   {
-    if (set_ && s.set_) {
-      ;
-    } else if (set_) {
-      ::std::destroy_at(::std::addressof(d_));
-      ::std::construct_at(::std::addressof(e_), s.e_);
-      set_ = false;
-    } else if (s.set_) {
-      ::std::destroy_at(::std::addressof(e_));
-      ::std::construct_at(::std::addressof(d_));
-      set_ = true;
-    } else {
-      e_ = s.e_;
-    }
+    this->_assign(static_cast<_base const &>(s));
     return *this;
   }
 
@@ -1228,19 +1394,7 @@ public:
       noexcept(::std::is_nothrow_move_assignable_v<E> && ::std::is_nothrow_move_constructible_v<E>) // required
     requires(::std::is_move_constructible_v<E> && ::std::is_move_assignable_v<E>)
   {
-    if (set_ && s.set_) {
-      ;
-    } else if (set_) {
-      ::std::destroy_at(::std::addressof(d_));
-      ::std::construct_at(::std::addressof(e_), ::std::move(s.e_));
-      set_ = false;
-    } else if (s.set_) {
-      ::std::destroy_at(::std::addressof(e_));
-      ::std::construct_at(::std::addressof(d_));
-      set_ = true;
-    } else {
-      e_ = ::std::move(s.e_);
-    }
+    this->_assign(static_cast<_base &&>(s));
     return *this;
   }
 
@@ -1250,13 +1404,7 @@ public:
                && ::std::is_nothrow_constructible_v<E, G const &>) // extension
     requires(::std::is_constructible_v<E, G const &> && ::std::is_assignable_v<E &, G const &>)
   {
-    if (set_) {
-      ::std::destroy_at(::std::addressof(d_));
-      ::std::construct_at(::std::addressof(e_), ::std::forward<G const &>(s.error()));
-      set_ = false;
-    } else {
-      e_ = ::std::forward<G const &>(s.error());
-    }
+    this->_assign_unexpected(s);
     return *this;
   }
 
@@ -1265,49 +1413,19 @@ public:
       noexcept(::std::is_nothrow_assignable_v<E &, G> && ::std::is_nothrow_constructible_v<E, G>) // extension
     requires(::std::is_constructible_v<E, G> && ::std::is_assignable_v<E &, G>)
   {
-    if (set_) {
-      ::std::destroy_at(::std::addressof(d_));
-      ::std::construct_at(::std::addressof(e_), ::std::forward<G>(s.error()));
-      set_ = false;
-    } else {
-      e_ = ::std::forward<G>(s.error());
-    }
+    this->_assign_unexpected(::std::move(s));
     return *this;
   }
 
-  constexpr void emplace() noexcept
-  {
-    if (not set_) {
-      ::std::destroy_at(::std::addressof(e_));
-      ::std::construct_at(::std::addressof(d_));
-      set_ = true;
-    }
-  }
+  // [expected.void.emplace], emplace inherited from _storage
+  using _base::emplace;
 
-  // [expected.void.swap], swap
+  // [expected.void.swap], swap; body delegates to _storage helper
   constexpr void swap(expected &rhs) //
       noexcept(::std::is_nothrow_move_constructible_v<E> && ::std::is_nothrow_swappable_v<E>)
     requires(::std::is_swappable_v<E> && ::std::is_move_constructible_v<E>)
   {
-    bool const lhset = has_value();
-    bool const rhset = rhs.has_value();
-    if (lhset == rhset) {
-      if (not lhset) {
-        using ::std::swap;
-        swap(e_, rhs.e_);
-      }
-    } else {
-      if (lhset) {
-        ::std::destroy_at(::std::addressof(d_));
-        ::std::construct_at(::std::addressof(e_), ::std::move(rhs.e_));
-        ::std::destroy_at(::std::addressof(rhs.e_));
-        ::std::construct_at(::std::addressof(rhs.d_));
-        set_ = false;
-        rhs.set_ = true;
-      } else {
-        rhs.swap(*this);
-      }
-    }
+    this->_swap_with(rhs);
   }
 
   constexpr friend void swap(expected &x, expected &y) noexcept(noexcept(x.swap(y)))
@@ -1316,67 +1434,14 @@ public:
     x.swap(y);
   }
 
-  // [expected.void.obs], observers
-  constexpr explicit operator bool() const noexcept { return set_; }
-  constexpr bool has_value() const noexcept { return set_; }
-  constexpr bool has_error() const noexcept { return !set_; } // P3798
-  constexpr void operator*() const noexcept { ASSERT(set_); }
-  constexpr void value() const &
-  {
-    static_assert(::std::is_copy_constructible_v<E>);
-    if (not set_)
-      throw bad_expected_access<E>(e_);
-  }
-  constexpr void value() &&
-  {
-    static_assert(::std::is_copy_constructible_v<E>);
-    static_assert(::std::is_move_constructible_v<E>);
-    if (not set_)
-      throw bad_expected_access<E>(::std::move(e_));
-  }
-  constexpr E const &error() const & noexcept
-  {
-    ASSERT(not set_);
-    return e_;
-  }
-  constexpr E &error() & noexcept
-  {
-    ASSERT(not set_);
-    return e_;
-  }
-  constexpr E const &&error() const && noexcept
-  {
-    ASSERT(not set_);
-    return ::std::move(e_);
-  }
-  constexpr E &&error() && noexcept
-  {
-    ASSERT(not set_);
-    return ::std::move(e_);
-  }
-
-  template <class G = E>
-  constexpr E error_or(G &&e) const &                                                              //
-      noexcept(::std::is_nothrow_copy_constructible_v<E> && ::std::is_nothrow_convertible_v<G, E>) // extension
-  {
-    static_assert(::std::is_copy_constructible_v<E>);
-    static_assert(::std::is_convertible_v<G, E>);
-    if (set_) {
-      return FWD(e);
-    }
-    return e_;
-  }
-  template <class G = E>
-  constexpr E error_or(G &&e) &&                                                                   //
-      noexcept(::std::is_nothrow_move_constructible_v<E> && ::std::is_nothrow_convertible_v<G, E>) // extension
-  {
-    static_assert(::std::is_move_constructible_v<E>);
-    static_assert(::std::is_convertible_v<G, E>);
-    if (set_) {
-      return FWD(e);
-    }
-    return ::std::move(e_);
-  }
+  // [expected.void.obs], observers inherited from _storage
+  using _base::operator*;
+  using _base::operator bool;
+  using _base::error;
+  using _base::error_or;
+  using _base::has_error;
+  using _base::has_value;
+  using _base::value;
 
   // [expected.void.monadic], monadic operations
   template <class F>
@@ -1524,18 +1589,6 @@ public:
     }
     return x.error() == e.error();
   }
-
-private:
-  struct dummy final {
-    constexpr dummy() noexcept = default;
-    constexpr ~dummy() noexcept = default;
-  };
-
-  union {
-    [[no_unique_address]] dummy d_;
-    E e_;
-  };
-  bool set_;
 };
 
 } // namespace pfn

--- a/include/pfn/expected.hpp
+++ b/include/pfn/expected.hpp
@@ -1370,7 +1370,7 @@ public:
       : _base(s.set_)
   {
     if (set_)
-      ::std::construct_at(::std::addressof(storage_.v_));
+      ::std::construct_at(::std::addressof(storage_.v_)); // LCOV_EXCL
     else
       ::std::construct_at(::std::addressof(storage_.e_), s.storage_.e_);
   }
@@ -1384,7 +1384,7 @@ public:
       : _base(s.set_)
   {
     if (set_)
-      ::std::construct_at(::std::addressof(storage_.v_));
+      ::std::construct_at(::std::addressof(storage_.v_)); // LCOV_EXCL
     else
       ::std::construct_at(::std::addressof(storage_.e_), ::std::move(s.storage_.e_));
   }
@@ -1396,7 +1396,7 @@ public:
       : _base(s.set_)
   {
     if (set_)
-      ::std::construct_at(::std::addressof(storage_.v_));
+      ::std::construct_at(::std::addressof(storage_.v_)); // LCOV_EXCL
     else
       ::std::construct_at(::std::addressof(storage_.e_), s.storage_.e_);
   }
@@ -1407,7 +1407,7 @@ public:
       : _base(s.set_)
   {
     if (set_)
-      ::std::construct_at(::std::addressof(storage_.v_));
+      ::std::construct_at(::std::addressof(storage_.v_)); // LCOV_EXCL
     else
       ::std::construct_at(::std::addressof(storage_.e_), ::std::move(s.storage_.e_));
   }

--- a/tests/pfn/expected.cpp
+++ b/tests/pfn/expected.cpp
@@ -2672,6 +2672,11 @@ TEST_CASE("expected non void", "[expected][polyfill]")
         CHECK(std::as_const(a).value().v == 11);
         CHECK(std::move(std::as_const(a)).value().v == 11);
         CHECK(std::move(a).value().v == 11);
+
+        static_assert(std::is_same_v<decltype(a.value()), helper &>);
+        static_assert(std::is_same_v<decltype(std::as_const(a).value()), helper const &>);
+        static_assert(std::is_same_v<decltype(std::move(a).value()), helper &&>);
+        static_assert(std::is_same_v<decltype(std::move(std::as_const(a)).value()), helper const &&>);
       }
 
       {
@@ -4857,6 +4862,19 @@ TEST_CASE("expected void", "[expected_void][polyfill]")
 
       T a;
       static_assert(std::is_same_v<decltype(a.value()), void>);
+
+      {
+        T a;
+        a.value();
+        std::as_const(a).value();
+        std::move(std::as_const(a)).value();
+        std::move(a).value();
+
+        static_assert(std::is_same_v<decltype(a.value()), void>);
+        static_assert(std::is_same_v<decltype(std::as_const(a).value()), void>);
+        static_assert(std::is_same_v<decltype(std::move(a).value()), void>);
+        static_assert(std::is_same_v<decltype(std::move(std::as_const(a)).value()), void>);
+      }
 
       SECTION("operators")
       {


### PR DESCRIPTION
This refactor is needed to allow the change of the base class of `fn::expected` from `std::expected` to the newly defined `detail::_storage` (in a PR to follow).