### PR TITLE
Fix `_invoke_type_result_result` fallback name in `variadic_union.hpp`

### DIFF
--- a/include/fn/detail/variadic_union.hpp
+++ b/include/fn/detail/variadic_union.hpp
@@ -50,7 +50,7 @@ template <typename T, typename Fn, typename... Args>
 constexpr auto _invoke_type_result_result(Fn &&, Args &&...)
     -> std::type_identity<decltype(_invoke_type<T>(std::declval<Fn>(), std::declval<Args>()...))>;
 template <typename T, typename Fn, typename... Args>
-constexpr auto _invoke_result_result(auto &&...) -> std::type_identity<void>;
+constexpr auto _invoke_type_result_result(auto &&...) -> std::type_identity<void>;
 
 template <typename T, typename Fn, typename... Args> struct _invoke_type_result {
   using type = decltype(_invoke_type_result_result<T, Fn, Args...>(std::declval<Fn>(), std::declval<Args>()...))::type;


### PR DESCRIPTION
The fallback overload was accidentally named `_invoke_result_result` (without the `_type_` infix), so it joined the unrelated overload set of the same name in `detail/functional.hpp` instead of becoming the fallback for `_invoke_type_result_result` above. Effect:

  (a) the intended fallback was dead code from the `_invoke_type_result`
      side — only the explicit overload was ever selected;
  (b) it polluted the unrelated `_invoke_result_result` overload set with
      a third candidate whose parameter pack differs (`T,Fn,Args...` vs
      `Fn,Args...`).

Clang ≥21 evidently disambiguates (b) via the differing template parameter packs. Clang <21 reports "call to `_invoke_result_result` is ambiguous" on every monadic-invocability constraint check that flows through `sum/choice`, which broke the `tests_fn_*` targets.

Assisted-by: Claude:claude-opus-4-7