### PR TITLE
Migrate build jobs to WarpBuild

### DIFF
--- a/.github/actionlint.yaml
+++ b/.github/actionlint.yaml
@@ -1,10 +1,9 @@
 # Custom self-hosted runner labels — WarpBuild cloud runners.
 self-hosted-runner:
   labels:
-    - warp-ubuntu-latest-arm64-4x
+    - warp-ubuntu-latest-arm64-2x
     - warp-ubuntu-latest-x64-4x
     - warp-macos-14-arm64-6x
     - warp-macos-15-arm64-6x
     - warp-macos-26-arm64-6x
     - warp-windows-latest-x64-4x
-    - warp-windows-2025-x64-4x

--- a/.github/actionlint.yaml
+++ b/.github/actionlint.yaml
@@ -1,0 +1,12 @@
+# Custom self-hosted runner labels — WarpBuild cloud runners.
+# actionlint doesn't ship these in its built-in list and would otherwise warn
+# "label is unknown" on every runs-on that uses them.
+self-hosted-runner:
+  labels:
+    - warp-ubuntu-latest-arm64-4x
+    - warp-ubuntu-latest-x64-4x
+    - warp-macos-14-arm64-6x
+    - warp-macos-15-arm64-6x
+    - warp-macos-26-arm64-6x
+    - warp-windows-latest-x64-4x
+    - warp-windows-2025-x64-4x

--- a/.github/actionlint.yaml
+++ b/.github/actionlint.yaml
@@ -1,6 +1,4 @@
 # Custom self-hosted runner labels — WarpBuild cloud runners.
-# actionlint doesn't ship these in its built-in list and would otherwise warn
-# "label is unknown" on every runs-on that uses them.
 self-hosted-runner:
   labels:
     - warp-ubuntu-latest-arm64-4x

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -103,7 +103,7 @@ jobs:
 
   macos:
     timeout-minutes: 10
-    runs-on: macos-${{ matrix.compiler.osver }}
+    runs-on: warp-macos-${{ matrix.compiler.osver }}-arm64-6x
     env:
       # Silence clang -Woverriding-deployment-version warnings.
       MACOSX_DEPLOYMENT_TARGET: ${{ matrix.compiler.osver }}.0
@@ -211,9 +211,9 @@ jobs:
             - Release
           vs:
             - generator: "Visual Studio 17 2022"
-              runner: "windows-2022"
+              runner: "warp-windows-latest-x64-4x"
             - generator: "Visual Studio 18 2026"
-              runner: "windows-2025-vs2026"
+              runner: "warp-windows-2025-x64-4x"
 
       steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -212,7 +212,7 @@ jobs:
             - generator: "Visual Studio 17 2022"
               runner: "warp-windows-latest-x64-4x"
             - generator: "Visual Studio 18 2026"
-              runner: "warp-windows-2025-x64-4x"
+              runner: "windows-2025-vs2026"
 
       steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -31,7 +31,7 @@ on:
 jobs:
   linux:
     timeout-minutes: 10
-    runs-on: warp-ubuntu-latest-arm64-4x
+    runs-on: warp-ubuntu-latest-arm64-2x
     strategy:
       fail-fast: false
       matrix:
@@ -107,6 +107,7 @@ jobs:
       # Silence clang -Woverriding-deployment-version warnings.
       MACOSX_DEPLOYMENT_TARGET: ${{ matrix.compiler.osver }}.0
     strategy:
+      max-parallel: 5
       fail-fast: false
       matrix:
         mode:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -107,7 +107,7 @@ jobs:
       # Silence clang -Woverriding-deployment-version warnings.
       MACOSX_DEPLOYMENT_TARGET: ${{ matrix.compiler.osver }}.0
     strategy:
-      max-parallel: 5
+      max-parallel: 10
       fail-fast: false
       matrix:
         mode:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -31,8 +31,7 @@ on:
 jobs:
   linux:
     timeout-minutes: 10
-    runs-on:
-      group: runners-arm64
+    runs-on: warp-ubuntu-latest-arm64-4x
     strategy:
       fail-fast: false
       matrix:
@@ -239,8 +238,7 @@ jobs:
 
   nixos:
     timeout-minutes: 10
-    runs-on:
-      group: runners-intel
+    runs-on: warp-ubuntu-latest-x64-4x
     strategy:
       fail-fast: false
       matrix:


### PR DESCRIPTION
All other workflows / jobs stay on the current selection of runners, for now.