### PR TITLE
Always construct `_storage_union_t` via explicit ctor; remove uninitialized default

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,7 @@ result*
 .devcontainer/
 .venv/
 .vscode/
+.claude*/
 *.iws
 *.swp
 *.swo

--- a/include/pfn/expected.hpp
+++ b/include/pfn/expected.hpp
@@ -199,7 +199,20 @@ template <class T, class E> union _storage_union_t {
   T v_;
   E e_;
 
-  constexpr explicit _storage_union_t() noexcept {} // Warning, uinitialized union
+  // Runtime-dispatch ctor: chooses which member to construct based on `s`.
+  // The union always exits a constructor with exactly one active member, so no
+  // "uninitialized union" intermediate state is observable to the optimizer.
+  // The outer _storage(bool, S&&) ctor constrains S to be a _storage_union_t.
+  template <typename S>
+  constexpr _storage_union_t(bool s, S &&src) //
+      noexcept(::std::is_nothrow_constructible_v<T, decltype(FWD(src).v_)>
+               && ::std::is_nothrow_constructible_v<E, decltype(FWD(src).e_)>)
+  {
+    if (s)
+      ::std::construct_at(::std::addressof(v_), FWD(src).v_);
+    else
+      ::std::construct_at(::std::addressof(e_), FWD(src).e_);
+  }
 
   constexpr _storage_union_t(_storage_union_t const &) = delete;
   constexpr _storage_union_t(_storage_union_t const &) //
@@ -297,7 +310,19 @@ template <class E> union _storage_union_t<void, E> {
   _dummy_t v_;
   E e_;
 
-  constexpr explicit _storage_union_t() noexcept {} // Warning, uinitialized union
+  // Runtime-dispatch ctor: chooses which member to construct based on `s`.
+  // The union always exits a constructor with exactly one active member, so no
+  // "uninitialized union" intermediate state is observable to the optimizer.
+  // The outer _storage(bool, S&&) ctor constrains S to be a _storage_union_t.
+  template <typename S>
+  constexpr _storage_union_t(bool s, S &&src) //
+      noexcept(::std::is_nothrow_constructible_v<E, decltype(FWD(src).e_)>)
+  {
+    if (s)
+      ::std::construct_at(::std::addressof(v_));
+    else
+      ::std::construct_at(::std::addressof(e_), FWD(src).e_);
+  }
 
   constexpr _storage_union_t(_storage_union_t const &) = delete;
   constexpr _storage_union_t(_storage_union_t const &) //
@@ -420,19 +445,15 @@ template <class T, class E, class Policy> struct _storage {
           || ::std::is_nothrow_move_constructible_v<E>)>;
 
   // Shared construction helper used by both the converting copy/move ctors
-  // and same-type non-trivial copy/move ctors
+  // and same-type non-trivial copy/move ctors. Delegates the union's
+  // member selection to _storage_union_t(bool, S&&), so storage_ is fully
+  // constructed by exactly one constructor call (no default-uninitialized
+  // intermediate state).
   template <typename S>
   constexpr explicit _storage(bool s, S &&src)
     requires(_is_storage_union<std::remove_cvref_t<S>>)
-      : storage_(), set_(s)
+      : storage_(s, FWD(src)), set_(s)
   {
-    if (set_) {
-      if constexpr (::std::is_void_v<T>)
-        ::std::construct_at(::std::addressof(storage_.v_)); // LCOV_EXCL_LINE trivially constructible
-      else
-        ::std::construct_at(::std::addressof(storage_.v_), FWD(src).v_);
-    } else
-      ::std::construct_at(::std::addressof(storage_.e_), FWD(src).e_);
   }
 
   // The wrapper's default, value (U&&) and unexpected<G> converting ctors forward directly to the

--- a/include/pfn/expected.hpp
+++ b/include/pfn/expected.hpp
@@ -201,8 +201,8 @@ template <class T, class E> union _storage_union_t {
 
   template <typename S>
   constexpr explicit _storage_union_t(bool s, S &&src) //
-      noexcept(::std::is_nothrow_constructible_v<T, decltype(FWD(src).v_)>
-               && ::std::is_nothrow_constructible_v<E, decltype(FWD(src).e_)>)
+      noexcept(::std::is_nothrow_constructible_v<T, decltype((FWD(src).v_))>
+               && ::std::is_nothrow_constructible_v<E, decltype((FWD(src).e_))>)
   {
     if (s)
       ::std::construct_at(::std::addressof(v_), FWD(src).v_);
@@ -308,7 +308,7 @@ template <class E> union _storage_union_t<void, E> {
 
   template <typename S>
   constexpr explicit _storage_union_t(bool s, S &&src) //
-      noexcept(::std::is_nothrow_constructible_v<E, decltype(FWD(src).e_)>)
+      noexcept(::std::is_nothrow_constructible_v<E, decltype((FWD(src).e_))>)
   {
     if (s)
       ::std::construct_at(::std::addressof(v_));

--- a/include/pfn/expected.hpp
+++ b/include/pfn/expected.hpp
@@ -199,12 +199,8 @@ template <class T, class E> union _storage_union_t {
   T v_;
   E e_;
 
-  // Runtime-dispatch ctor: chooses which member to construct based on `s`.
-  // The union always exits a constructor with exactly one active member, so no
-  // "uninitialized union" intermediate state is observable to the optimizer.
-  // The outer _storage(bool, S&&) ctor constrains S to be a _storage_union_t.
   template <typename S>
-  constexpr _storage_union_t(bool s, S &&src) //
+  constexpr explicit _storage_union_t(bool s, S &&src) //
       noexcept(::std::is_nothrow_constructible_v<T, decltype(FWD(src).v_)>
                && ::std::is_nothrow_constructible_v<E, decltype(FWD(src).e_)>)
   {
@@ -310,12 +306,8 @@ template <class E> union _storage_union_t<void, E> {
   _dummy_t v_;
   E e_;
 
-  // Runtime-dispatch ctor: chooses which member to construct based on `s`.
-  // The union always exits a constructor with exactly one active member, so no
-  // "uninitialized union" intermediate state is observable to the optimizer.
-  // The outer _storage(bool, S&&) ctor constrains S to be a _storage_union_t.
   template <typename S>
-  constexpr _storage_union_t(bool s, S &&src) //
+  constexpr explicit _storage_union_t(bool s, S &&src) //
       noexcept(::std::is_nothrow_constructible_v<E, decltype(FWD(src).e_)>)
   {
     if (s)
@@ -446,9 +438,7 @@ template <class T, class E, class Policy> struct _storage {
 
   // Shared construction helper used by both the converting copy/move ctors
   // and same-type non-trivial copy/move ctors. Delegates the union's
-  // member selection to _storage_union_t(bool, S&&), so storage_ is fully
-  // constructed by exactly one constructor call (no default-uninitialized
-  // intermediate state).
+  // member selection to _storage_union_t(bool, S&&), based on first parameter.
   template <typename S>
   constexpr explicit _storage(bool s, S &&src)
     requires(_is_storage_union<std::remove_cvref_t<S>>)

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -70,6 +70,7 @@ endforeach()
 
 set(TESTS_PFN_SOURCES
     pfn/expected.cpp
+    pfn/expected_validation.cpp
 )
 
 include(TargetGenerator)
@@ -105,33 +106,6 @@ foreach(mode 20 23)
         set_property(TEST "${target}" PROPERTY LABELS tests_pfn "cxx${mode}" "${root_name}")
 
         unset(target)
-
-        # pfn tests have a "validation" mode, where the unit tests intended for polyfill
-        # are run against the "real" thing. This validates the tests.
-        if (${mode} EQUAL 23)
-            set(target "tests_${root_name}_validation_cxx${mode}")
-
-            create_target_for_file(
-                NAME "${target}"
-                SOURCE "${source}"
-                DEPENDENCIES include_pfn tests_util Catch2::Catch2WithMain
-            )
-            append_compilation_options("${target}" WARNINGS OPTIMIZATION TESTS)
-            add_dependencies("cxx${mode}" "${target}")
-            add_dependencies("tests" "${target}")
-            set_property(TARGET "${target}" PROPERTY CXX_STANDARD "${mode}")
-            target_compile_definitions("${target}" PRIVATE LIBFN_MODE=${mode} PFN_TEST_VALIDATION)
-
-            add_test(
-                NAME "${target}"
-                COMMAND "${target}" -r console
-                WORKING_DIRECTORY ${CMAKE_BINARY_DIR}
-            )
-            set_property(TEST "${target}" PROPERTY LABELS tests_pfn "cxx${mode}" "${root_name}")
-
-            unset(target)
-        endif()
-
         unset(root_name)
     endforeach()
 endforeach()

--- a/tests/pfn/expected.cpp
+++ b/tests/pfn/expected.cpp
@@ -4,23 +4,23 @@
 // or copy at https://opensource.org/licenses/ISC
 
 #include "catch2/catch_test_macros.hpp"
-#ifndef PFN_TEST_VALIDATION
-// TODO: Add death tests. Until then, empty definition to avoid false "no coverage" reports
+
+#ifndef PFN_TEST_NESTED
+
+// TODO : Add death tests.Until then, empty definition to avoid false "no coverage" reports
 #define LIBFN_ASSERT(...)
 #include <pfn/expected.hpp>
+
 using pfn::bad_expected_access;
 using pfn::expected;
 using pfn::unexpect;
 using pfn::unexpect_t;
 using pfn::unexpected;
-#else
-#include <expected>
-using std::bad_expected_access;
-using std::expected;
-using std::unexpect;
-using std::unexpect_t;
-using std::unexpected;
+
 #endif
+// When nested via PFN_TEST_NESTED (e.g expected_validation.cpp), the wrapper TU
+// already includes the necessary header(s) and brings the relevant aliases into the
+// global namespace to select right set of types expected as the subject under test.
 
 #include <util/helper_types.hpp>
 

--- a/tests/pfn/expected_validation.cpp
+++ b/tests/pfn/expected_validation.cpp
@@ -1,0 +1,29 @@
+// Copyright (c) 2026 Bronek Kozicki
+//
+// Distributed under the ISC License. See accompanying file LICENSE.md
+// or copy at https://opensource.org/licenses/ISC
+
+#if LIBFN_MODE >= 23
+
+#include <expected>
+using std::bad_expected_access;
+using std::expected;
+using std::unexpect;
+using std::unexpect_t;
+using std::unexpected;
+
+#define PFN_TEST_VALIDATION
+#define PFN_TEST_NESTED
+#include "expected.cpp"
+
+#else
+
+#include "catch2/catch_test_macros.hpp"
+
+// Placeholder so the C++20 binary is not empty; Catch2 fails when no tests run.
+TEST_CASE("expected validation", "[expected][validation]") //
+{
+  SUCCEED("expected validation is skipped in C++20 mode");
+}
+
+#endif


### PR DESCRIPTION
Both `_storage_union_t<T, E>` and the void specialization had an explicitly empty default constructor (commented "Warning, uninitialized union") whose sole consumer was `_storage(bool, S&&)` — which then patched up the union via `construct_at` in its body.

Replaces that pattern: the union now provides a single `_storage_union_t(bool, S&&)` ctor that runs the `construct_at` dispatch in its own body, and the default ctor is removed. `_storage(bool, S&&)` delegates to it via the member-init-list, so `storage_` is fully constructed by exactly one constructor call and the union never has an observable "no active member" intermediate state.

Pure structural cleanup; behaviour is identical (same `noexcept` profile, same `constexpr` fitness, same dispatch). pfn unit tests pass.

Assisted-by: Claude:claude-opus-4-7