### PR TITLE
Install Node.js 24 from nodesource

### DIFF
--- a/.github/workflows/ci-build.yml
+++ b/.github/workflows/ci-build.yml
@@ -28,6 +28,7 @@ env:
   REGISTRY_IMAGE_ROOT: libfn.azurecr.io/ci-build
   CATCH_RELEASE: 3.14.0
   BAZEL_RELEASE: 8.7.0
+  NODE_RELEASE: 24
 
 jobs:
   build:
@@ -106,6 +107,7 @@ jobs:
             DEBIAN_VERSION=${{ env.DEBIAN_VERSION }}
             CATCH_RELEASE=${{ env.CATCH_RELEASE }}
             BAZEL_RELEASE=${{ env.BAZEL_RELEASE }}
+            NODE_RELEASE=${{ env.NODE_RELEASE }}
           context: "ci"
           file: "${{ env.COMPILER }}/Dockerfile"
           title: "build-${{ env.IMAGE }}-${{ env.RELEASE }}"

--- a/.github/workflows/ci-build.yml
+++ b/.github/workflows/ci-build.yml
@@ -17,6 +17,7 @@ on:
       - 'ci/clang/**'
       - 'ci/build-catch.sh'
       - 'ci/fetch-bazel.sh'
+      - 'ci/fetch-node.sh'
   workflow_dispatch:
 
 env:

--- a/.github/workflows/ci-docs.yml
+++ b/.github/workflows/ci-docs.yml
@@ -25,6 +25,7 @@ env:
   DOXYGEN_RELEASE: 1.12.0
   ZNAI_RELEASE: 1.73
   CATCH_RELEASE: 3.14.0
+  NODE_RELEASE: 24
 
 jobs:
   build:
@@ -60,6 +61,7 @@ jobs:
             DOXYGEN_RELEASE=${{ env.DOXYGEN_RELEASE }}
             ZNAI_RELEASE=${{ env.ZNAI_RELEASE }}
             CATCH_RELEASE=${{ env.CATCH_RELEASE }}
+            NODE_RELEASE=${{ env.NODE_RELEASE }}
           context: "ci"
           file: "docs/Dockerfile"
           title: "docs"

--- a/.github/workflows/ci-docs.yml
+++ b/.github/workflows/ci-docs.yml
@@ -15,6 +15,7 @@ on:
       - '.github/workflows/ci-docs.yml'
       - 'ci/docs/**'
       - 'ci/build-catch.sh'
+      - 'ci/fetch-node.sh'
   workflow_dispatch:
 
 env:

--- a/.github/workflows/ci-pre-commit.yml
+++ b/.github/workflows/ci-pre-commit.yml
@@ -19,6 +19,7 @@ on:
 
 env:
   REGISTRY_IMAGE: libfn.azurecr.io/ci-pre-commit
+  NODE_RELEASE: 24
 
 jobs:
   build:
@@ -48,6 +49,8 @@ jobs:
           registry: libfn.azurecr.io
           username: ${{ secrets.AZURECR_NAME }}
           password: ${{ secrets.AZURECR_PASS }}
+          build_args: |
+            NODE_RELEASE=${{ env.NODE_RELEASE }}
           context: "ci"
           file: "pre-commit/Dockerfile"
           title: "pre-commit"

--- a/.github/workflows/ci-pre-commit.yml
+++ b/.github/workflows/ci-pre-commit.yml
@@ -14,6 +14,7 @@ on:
       - '.github/actions/merge-ci-images/**'
       - '.github/workflows/ci-pre-commit.yml'
       - 'ci/pre-commit/**'
+      - 'ci/fetch-node.sh'
   workflow_dispatch:
 
 env:

--- a/.github/workflows/ci-pre-commit.yml
+++ b/.github/workflows/ci-pre-commit.yml
@@ -47,7 +47,8 @@ jobs:
           registry: libfn.azurecr.io
           username: ${{ secrets.AZURECR_NAME }}
           password: ${{ secrets.AZURECR_PASS }}
-          context: "ci/pre-commit"
+          context: "ci"
+          file: "pre-commit/Dockerfile"
           title: "pre-commit"
           push: ${{ github.ref_type == 'branch' && github.ref_name == 'main' }}
 

--- a/ci/build-catch.sh
+++ b/ci/build-catch.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 set -ex
 : "${CATCH_RELEASE:?CATCH_RELEASE is not set}"
 

--- a/ci/clang/Dockerfile
+++ b/ci/clang/Dockerfile
@@ -1,8 +1,11 @@
 ARG DEBIAN_VERSION=trixie
 FROM debian:${DEBIAN_VERSION} AS base
 
-ARG CLANG_RELEASE
+ARG NODE_RELEASE=24
+ARG CLANG_RELEASE=22
 ARG DEBIAN_FRONTEND=noninteractive
+WORKDIR /work
+COPY fetch-node.sh /work/fetch-node.sh
 RUN set -ex ;\
     : "${CLANG_RELEASE:?CLANG_RELEASE is not set}" ;\
     apt-get update ;\
@@ -19,6 +22,8 @@ RUN set -ex ;\
     apt-get install -t llvm-toolchain-${CODENAME}-${CLANG_RELEASE} -y --no-install-recommends \
       clang++-${CLANG_RELEASE} clang-${CLANG_RELEASE} libc++-${CLANG_RELEASE}-dev \
       libc++abi-${CLANG_RELEASE}-dev libclang-rt-${CLANG_RELEASE}-dev ;\
+    sh /work/fetch-node.sh ;\
+    rm /work/fetch-node.sh ;\
     apt-get clean && rm -rf /var/lib/apt/lists/*
 
 RUN set -ex ;\
@@ -43,7 +48,7 @@ ENV CMAKE_BUILD_TYPE=Debug
 # ---- Build Catch2 with libc++ as `clang` target ----
 
 FROM base AS clang
-ARG CATCH_RELEASE
+ARG CATCH_RELEASE=3.14.0
 
 WORKDIR /work
 COPY build-catch.sh /work/build-catch.sh
@@ -56,7 +61,7 @@ ENV CMAKE_FIND_CATCH2=1
 # ---- Build Catch2 with libstdc++ based on gcc-14, as `clang-libstdcxx` target ----
 
 FROM base AS clang-libstdcxx
-ARG CATCH_RELEASE
+ARG CATCH_RELEASE=3.14.0
 ARG DEBIAN_FRONTEND=noninteractive
 RUN set -ex ;\
     apt-get update ;\
@@ -74,7 +79,7 @@ ENV CMAKE_FIND_CATCH2=1
 # ---- Bazel + system clang as `clang-bazel` target ----
 
 FROM base AS clang-bazel
-ARG BAZEL_RELEASE
+ARG BAZEL_RELEASE=8.7.0
 ARG DEBIAN_FRONTEND=noninteractive
 # Install libstdc++ so clang libstdc++ (i.e. default) Bazel builds work; base has only libc++
 RUN set -ex ;\

--- a/ci/clang/Dockerfile
+++ b/ci/clang/Dockerfile
@@ -6,6 +6,7 @@ ARG CLANG_RELEASE=22
 ARG DEBIAN_FRONTEND=noninteractive
 WORKDIR /work
 COPY fetch-node.sh /work/fetch-node.sh
+COPY clang/fetch-clang.sh /work/fetch-clang.sh
 RUN set -ex ;\
     : "${CLANG_RELEASE:?CLANG_RELEASE is not set}" ;\
     apt-get update ;\
@@ -13,15 +14,9 @@ RUN set -ex ;\
       ca-certificates gnupg unzip wget vim curl jq python3-venv python3-pip \
       cmake ninja-build binutils libc6-dev git valgrind ;\
     CODENAME=$( . /etc/os-release && echo $VERSION_CODENAME ) ;\
-    wget -O - https://apt.llvm.org/llvm-snapshot.gpg.key | gpg --dearmor -o /etc/apt/keyrings/llvm.gpg ;\
-    printf "%s\n%s\n" \
-      "deb [signed-by=/etc/apt/keyrings/llvm.gpg] https://apt.llvm.org/${CODENAME}/ llvm-toolchain-${CODENAME}-${CLANG_RELEASE} main" \
-      "deb-src [signed-by=/etc/apt/keyrings/llvm.gpg] https://apt.llvm.org/${CODENAME}/ llvm-toolchain-${CODENAME}-${CLANG_RELEASE} main" \
-      | tee /etc/apt/sources.list.d/llvm.list ;\
-    apt-get update ;\
-    apt-get install -t llvm-toolchain-${CODENAME}-${CLANG_RELEASE} -y --no-install-recommends \
-      clang++-${CLANG_RELEASE} clang-${CLANG_RELEASE} libc++-${CLANG_RELEASE}-dev \
-      libc++abi-${CLANG_RELEASE}-dev libclang-rt-${CLANG_RELEASE}-dev ;\
+    export CODENAME ;\
+    bash /work/fetch-clang.sh ;\
+    rm /work/fetch-clang.sh ;\
     bash /work/fetch-node.sh ;\
     rm /work/fetch-node.sh ;\
     apt-get clean && rm -rf /var/lib/apt/lists/*

--- a/ci/clang/Dockerfile
+++ b/ci/clang/Dockerfile
@@ -22,7 +22,7 @@ RUN set -ex ;\
     apt-get install -t llvm-toolchain-${CODENAME}-${CLANG_RELEASE} -y --no-install-recommends \
       clang++-${CLANG_RELEASE} clang-${CLANG_RELEASE} libc++-${CLANG_RELEASE}-dev \
       libc++abi-${CLANG_RELEASE}-dev libclang-rt-${CLANG_RELEASE}-dev ;\
-    sh /work/fetch-node.sh ;\
+    bash /work/fetch-node.sh ;\
     rm /work/fetch-node.sh ;\
     apt-get clean && rm -rf /var/lib/apt/lists/*
 
@@ -54,7 +54,7 @@ WORKDIR /work
 COPY build-catch.sh /work/build-catch.sh
 ENV CXXFLAGS="-stdlib=libc++"
 RUN set -ex ;\
-    sh /work/build-catch.sh ;\
+    bash /work/build-catch.sh ;\
     rm /work/build-catch.sh
 ENV CMAKE_FIND_CATCH2=1
 
@@ -72,7 +72,7 @@ WORKDIR /work
 COPY build-catch.sh /work/build-catch.sh
 ENV CXXFLAGS="-stdlib=libstdc++"
 RUN set -ex ;\
-    sh /work/build-catch.sh ;\
+    bash /work/build-catch.sh ;\
     rm /work/build-catch.sh
 ENV CMAKE_FIND_CATCH2=1
 
@@ -90,6 +90,6 @@ RUN set -ex ;\
 WORKDIR /work
 COPY fetch-bazel.sh /work/fetch-bazel.sh
 RUN set -ex ;\
-    sh /work/fetch-bazel.sh ;\
+    bash /work/fetch-bazel.sh ;\
     rm /work/fetch-bazel.sh
 ENV USE_BAZEL_FALLBACK_VERSION="warn:${BAZEL_RELEASE}"

--- a/ci/clang/fetch-clang.sh
+++ b/ci/clang/fetch-clang.sh
@@ -1,0 +1,17 @@
+#!/bin/bash
+set -ex
+set -o pipefail
+: "${CLANG_RELEASE:?CLANG_RELEASE is not set}"
+: "${CODENAME:?CODENAME is not set}"
+
+mkdir -p /etc/apt/keyrings
+curl --proto '=https' --tlsv1.2 -fsSL https://apt.llvm.org/llvm-snapshot.gpg.key \
+  | gpg --dearmor -o /etc/apt/keyrings/llvm.gpg
+printf "%s\n%s\n" \
+  "deb [signed-by=/etc/apt/keyrings/llvm.gpg] https://apt.llvm.org/${CODENAME}/ llvm-toolchain-${CODENAME}-${CLANG_RELEASE} main" \
+  "deb-src [signed-by=/etc/apt/keyrings/llvm.gpg] https://apt.llvm.org/${CODENAME}/ llvm-toolchain-${CODENAME}-${CLANG_RELEASE} main" \
+  | tee /etc/apt/sources.list.d/llvm.list
+apt-get update
+apt-get install -t llvm-toolchain-${CODENAME}-${CLANG_RELEASE} -y --no-install-recommends \
+  clang++-${CLANG_RELEASE} clang-${CLANG_RELEASE} libc++-${CLANG_RELEASE}-dev \
+  libc++abi-${CLANG_RELEASE}-dev libclang-rt-${CLANG_RELEASE}-dev

--- a/ci/docs/Dockerfile
+++ b/ci/docs/Dockerfile
@@ -10,8 +10,8 @@ RUN set -ex ;\
 
 ARG DEBIAN_VERSION=trixie
 FROM debian:${DEBIAN_VERSION} AS build
-ARG DOXYGEN_RELEASE
-ARG ZNAI_RELEASE
+ARG DOXYGEN_RELEASE=1.12.0
+ARG ZNAI_RELEASE=1.73
 
 ARG DEBIAN_FRONTEND=noninteractive
 WORKDIR /work
@@ -53,7 +53,6 @@ COPY --from=upstream /etc/ld.so.conf.d/ /etc/ld.so.conf.d/
 COPY --from=build /usr/local/ /usr/local/
 COPY --from=build /opt/znai /opt/znai
 
-WORKDIR /root
 RUN set -ex ;\
     rm -rf /usr/local/lib/python3.11 ;\
     find /usr/local -type d -empty -exec rm -r {} + ;\
@@ -75,22 +74,26 @@ RUN set -ex ;\
     update-alternatives --auto cc ;\
     update-alternatives --auto gcc
 
+ARG NODE_RELEASE=24
 ARG JAVA_VERSION=openjdk-21-jdk
 ARG DEBIAN_FRONTEND=noninteractive
+WORKDIR /work
+COPY fetch-node.sh /work/fetch-node.sh
 RUN set -ex ;\
     apt-get update ;\
     apt-get install -y --no-install-recommends \
       ca-certificates gnupg unzip wget vim curl jq \
       cmake ninja-build binutils libc6-dev git \
       ${JAVA_VERSION} graphviz  ;\
-    apt-get clean
+    sh /work/fetch-node.sh ;\
+    rm /work/fetch-node.sh ;\
+    apt-get clean && rm -rf /var/lib/apt/lists/*
 
 ENV CC=/usr/bin/gcc
 ENV CXX=/usr/bin/g++
 ENV CMAKE_GENERATOR=Ninja
 ENV CMAKE_BUILD_TYPE=Debug
-ARG CATCH_RELEASE
-WORKDIR /work
+ARG CATCH_RELEASE=3.14.0
 COPY build-catch.sh /work/build-catch.sh
 RUN set -ex ;\
     sh /work/build-catch.sh ;\

--- a/ci/docs/Dockerfile
+++ b/ci/docs/Dockerfile
@@ -85,7 +85,7 @@ RUN set -ex ;\
       ca-certificates gnupg unzip wget vim curl jq \
       cmake ninja-build binutils libc6-dev git \
       ${JAVA_VERSION} graphviz  ;\
-    sh /work/fetch-node.sh ;\
+    bash /work/fetch-node.sh ;\
     rm /work/fetch-node.sh ;\
     apt-get clean && rm -rf /var/lib/apt/lists/*
 
@@ -96,7 +96,7 @@ ENV CMAKE_BUILD_TYPE=Debug
 ARG CATCH_RELEASE=3.14.0
 COPY build-catch.sh /work/build-catch.sh
 RUN set -ex ;\
-    sh /work/build-catch.sh ;\
+    bash /work/build-catch.sh ;\
     rm /work/build-catch.sh
 ENV CMAKE_FIND_CATCH2=1
 ENV PATH=${PATH}:/opt/znai

--- a/ci/fetch-bazel.sh
+++ b/ci/fetch-bazel.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 # Install bazelisk (pinned + checksum-verified) and pre-fetch the pinned Bazel
 # release so the test container can run Bazel. The system toolchain (CC/CXX) is
 # used, so no in-image MODULE.bazel file.

--- a/ci/fetch-node.sh
+++ b/ci/fetch-node.sh
@@ -1,0 +1,16 @@
+#!/bin/bash
+: "${NODE_RELEASE:?NODE_RELEASE is not set}"
+
+curl --proto '=https' --tlsv1.2 -fsSL https://deb.nodesource.com/gpgkey/nodesource-repo.gpg.key | \
+	gpg --dearmor -o /etc/apt/keyrings/nodesource.gpg
+printf "%s\n%s\n" \
+	"deb [signed-by=/etc/apt/keyrings/nodesource.gpg] https://deb.nodesource.com/node_${NODE_RELEASE}.x nodistro main" \
+	"deb-src [signed-by=/etc/apt/keyrings/nodesource.gpg] https://deb.nodesource.com/node_${NODE_RELEASE}.x nodistro main" \
+	| tee /etc/apt/sources.list.d/nodesource.list
+printf "%s\n%s\n%s\n" \
+	"Package: nodejs" \
+	"Pin: origin deb.nodesource.com" \
+	"Pin-Priority: 600" \
+	| tee /etc/apt/preferences.d/nodejs
+apt-get update
+apt-get install -y --no-install-recommends nodejs

--- a/ci/fetch-node.sh
+++ b/ci/fetch-node.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 set -ex
 set -o pipefail
 : "${NODE_RELEASE:?NODE_RELEASE is not set}"

--- a/ci/fetch-node.sh
+++ b/ci/fetch-node.sh
@@ -1,5 +1,6 @@
-#!/bin/bash
-set -e
+#!/bin/sh
+set -ex
+set -o pipefail
 : "${NODE_RELEASE:?NODE_RELEASE is not set}"
 
 mkdir -p /etc/apt/keyrings

--- a/ci/fetch-node.sh
+++ b/ci/fetch-node.sh
@@ -4,16 +4,16 @@ set -o pipefail
 : "${NODE_RELEASE:?NODE_RELEASE is not set}"
 
 mkdir -p /etc/apt/keyrings
-curl --proto '=https' --tlsv1.2 -fsSL https://deb.nodesource.com/gpgkey/nodesource-repo.gpg.key | \
-	gpg --dearmor -o /etc/apt/keyrings/nodesource.gpg
+curl --proto '=https' --tlsv1.2 -fsSL https://deb.nodesource.com/gpgkey/nodesource-repo.gpg.key \
+  | gpg --dearmor -o /etc/apt/keyrings/nodesource.gpg
 printf "%s\n%s\n" \
-	"deb [signed-by=/etc/apt/keyrings/nodesource.gpg] https://deb.nodesource.com/node_${NODE_RELEASE}.x nodistro main" \
-	"deb-src [signed-by=/etc/apt/keyrings/nodesource.gpg] https://deb.nodesource.com/node_${NODE_RELEASE}.x nodistro main" \
-	| tee /etc/apt/sources.list.d/nodesource.list
+  "deb [signed-by=/etc/apt/keyrings/nodesource.gpg] https://deb.nodesource.com/node_${NODE_RELEASE}.x nodistro main" \
+  "deb-src [signed-by=/etc/apt/keyrings/nodesource.gpg] https://deb.nodesource.com/node_${NODE_RELEASE}.x nodistro main" \
+  | tee /etc/apt/sources.list.d/nodesource.list
 printf "%s\n%s\n%s\n" \
-	"Package: nodejs" \
-	"Pin: origin deb.nodesource.com" \
-	"Pin-Priority: 600" \
-	| tee /etc/apt/preferences.d/nodejs
+  "Package: nodejs" \
+  "Pin: origin deb.nodesource.com" \
+  "Pin-Priority: 600" \
+  | tee /etc/apt/preferences.d/nodejs
 apt-get update
 apt-get install -y --no-install-recommends nodejs

--- a/ci/fetch-node.sh
+++ b/ci/fetch-node.sh
@@ -8,7 +8,6 @@ curl --proto '=https' --tlsv1.2 -fsSL https://deb.nodesource.com/gpgkey/nodesour
   | gpg --dearmor -o /etc/apt/keyrings/nodesource.gpg
 printf "%s\n%s\n" \
   "deb [signed-by=/etc/apt/keyrings/nodesource.gpg] https://deb.nodesource.com/node_${NODE_RELEASE}.x nodistro main" \
-  "deb-src [signed-by=/etc/apt/keyrings/nodesource.gpg] https://deb.nodesource.com/node_${NODE_RELEASE}.x nodistro main" \
   | tee /etc/apt/sources.list.d/nodesource.list
 printf "%s\n%s\n%s\n" \
   "Package: nodejs" \

--- a/ci/fetch-node.sh
+++ b/ci/fetch-node.sh
@@ -1,6 +1,8 @@
 #!/bin/bash
+set -e
 : "${NODE_RELEASE:?NODE_RELEASE is not set}"
 
+mkdir -p /etc/apt/keyrings
 curl --proto '=https' --tlsv1.2 -fsSL https://deb.nodesource.com/gpgkey/nodesource-repo.gpg.key | \
 	gpg --dearmor -o /etc/apt/keyrings/nodesource.gpg
 printf "%s\n%s\n" \

--- a/ci/gcc/Dockerfile
+++ b/ci/gcc/Dockerfile
@@ -33,13 +33,18 @@ RUN set -ex ;\
     update-alternatives --auto cc ;\
     update-alternatives --auto gcc
 
+ARG NODE_RELEASE=24
 ARG DEBIAN_FRONTEND=noninteractive
+WORKDIR /work
+COPY fetch-node.sh /work/fetch-node.sh
 RUN set -ex ;\
     apt-get update ;\
     apt-get install -y --no-install-recommends \
       ca-certificates gnupg unzip wget vim curl jq python3-venv python3-pip \
       cmake ninja-build binutils libc6-dev git valgrind ;\
-    apt-get clean
+    sh /work/fetch-node.sh ;\
+    rm /work/fetch-node.sh ;\
+    apt-get clean && rm -rf /var/lib/apt/lists/*
 
 COPY gcc/requirements.txt /requirements.txt
 ENV VENV=/venv
@@ -57,7 +62,7 @@ ENV CMAKE_BUILD_TYPE=Debug
 # ---- Build Catch2 with libstdc++ as `gcc` target ----
 
 FROM base AS gcc
-ARG CATCH_RELEASE
+ARG CATCH_RELEASE=3.14.0
 WORKDIR /work
 COPY build-catch.sh /work/build-catch.sh
 RUN set -ex ;\
@@ -68,7 +73,7 @@ ENV CMAKE_FIND_CATCH2=1
 # ---- Bazel + system gcc as `gcc-bazel` target ----
 
 FROM base AS gcc-bazel
-ARG BAZEL_RELEASE
+ARG BAZEL_RELEASE=8.7.0
 WORKDIR /work
 COPY fetch-bazel.sh /work/fetch-bazel.sh
 RUN set -ex ;\

--- a/ci/gcc/Dockerfile
+++ b/ci/gcc/Dockerfile
@@ -42,7 +42,7 @@ RUN set -ex ;\
     apt-get install -y --no-install-recommends \
       ca-certificates gnupg unzip wget vim curl jq python3-venv python3-pip \
       cmake ninja-build binutils libc6-dev git valgrind ;\
-    sh /work/fetch-node.sh ;\
+    bash /work/fetch-node.sh ;\
     rm /work/fetch-node.sh ;\
     apt-get clean && rm -rf /var/lib/apt/lists/*
 
@@ -66,7 +66,7 @@ ARG CATCH_RELEASE=3.14.0
 WORKDIR /work
 COPY build-catch.sh /work/build-catch.sh
 RUN set -ex ;\
-    sh /work/build-catch.sh ;\
+    bash /work/build-catch.sh ;\
     rm /work/build-catch.sh
 ENV CMAKE_FIND_CATCH2=1
 
@@ -77,6 +77,6 @@ ARG BAZEL_RELEASE=8.7.0
 WORKDIR /work
 COPY fetch-bazel.sh /work/fetch-bazel.sh
 RUN set -ex ;\
-    sh /work/fetch-bazel.sh ;\
+    bash /work/fetch-bazel.sh ;\
     rm /work/fetch-bazel.sh
 ENV USE_BAZEL_FALLBACK_VERSION="warn:${BAZEL_RELEASE}"

--- a/ci/pre-commit/Dockerfile
+++ b/ci/pre-commit/Dockerfile
@@ -1,16 +1,21 @@
 FROM debian:trixie-slim
 
+ARG NODE_RELEASE=24
 ARG DEBIAN_FRONTEND=noninteractive
+WORKDIR /work
+COPY fetch-node.sh /work/fetch-node.sh
 RUN set -ex ;\
     echo "deb http://deb.debian.org/debian trixie-backports main" > /etc/apt/sources.list.d/backports.list ;\
     apt-get update ;\
     apt-get install -y --no-install-recommends \
       python3 python3-pip python3-venv \
-      ca-certificates wget vim git ;\
+      ca-certificates wget vim git curl gpg ;\
     apt-get install -y --no-install-recommends -t trixie-backports shellcheck ;\
-    apt-get clean
+    sh /work/fetch-node.sh ;\
+    rm /work/fetch-node.sh ;\
+    apt-get clean && rm -rf /var/lib/apt/lists/*
 
-COPY requirements.txt /requirements.txt
+COPY pre-commit/requirements.txt /requirements.txt
 ENV VENV=/venv
 ENV PATH=${VENV}/bin:${PATH}
 RUN set -ex ;\

--- a/ci/pre-commit/Dockerfile
+++ b/ci/pre-commit/Dockerfile
@@ -11,7 +11,7 @@ RUN set -ex ;\
       python3 python3-pip python3-venv \
       ca-certificates wget vim git curl gpg ;\
     apt-get install -y --no-install-recommends -t trixie-backports shellcheck ;\
-    sh /work/fetch-node.sh ;\
+    bash /work/fetch-node.sh ;\
     rm /work/fetch-node.sh ;\
     apt-get clean && rm -rf /var/lib/apt/lists/*
 


### PR DESCRIPTION
Node.js 24 is required by recently upgraded actions (e.g. #231 )