### PR TITLE
ci: make non-ci workflows fork-friendly

### DIFF
--- a/.github/actionlint.yaml
+++ b/.github/actionlint.yaml
@@ -2,6 +2,7 @@
 self-hosted-runner:
   labels:
     - warp-ubuntu-latest-arm64-2x
+    - warp-ubuntu-latest-arm64-4x
     - warp-ubuntu-latest-x64-4x
     - warp-macos-14-arm64-6x
     - warp-macos-15-arm64-6x

--- a/.github/actionlint.yaml
+++ b/.github/actionlint.yaml
@@ -6,4 +6,3 @@ self-hosted-runner:
     - warp-macos-14-arm64-6x
     - warp-macos-15-arm64-6x
     - warp-macos-26-arm64-6x
-    - warp-windows-latest-x64-4x

--- a/.github/actions/restore-pr-workspace/action.yml
+++ b/.github/actions/restore-pr-workspace/action.yml
@@ -1,0 +1,98 @@
+name: restore-pr-workspace
+description: >
+  Validate a downstream-scan inputs artifact, read the pull request metadata it carries, check out the
+  pull request head and restore the `.build` outputs from the artifact into the workspace.
+
+inputs:
+  archive:
+    required: true
+    description: Path to the downloaded `*-inputs.tar.gz` artifact produced by the triggering workflow.
+
+outputs:
+  number:
+    description: Pull request number.
+    value: ${{ steps.pr.outputs.number }}
+  head_sha:
+    description: Pull request head commit SHA.
+    value: ${{ steps.pr.outputs.head_sha }}
+  head_ref:
+    description: Pull request head branch name.
+    value: ${{ steps.pr.outputs.head_ref }}
+  base_ref:
+    description: Pull request base branch name (empty when not recorded in the artifact).
+    value: ${{ steps.pr.outputs.base_ref }}
+
+runs:
+  using: composite
+  steps:
+    - name: Validate artifact and read pull request metadata
+      # The artifact is a tarball containing the `.build` outputs and a metadata directory with PR fields.
+      # Validate the tarball contents before extracting to prevent path traversal etc. security issues.
+      id: pr
+      shell: bash
+      env:
+        ARCHIVE: ${{ inputs.archive }}
+        # Fixed artifact contract: triggering workflows write PR metadata into `.pr-meta`.
+        META_DIR: .pr-meta
+      run: |
+        list=$(tar -tvzf "$ARCHIVE")
+        bad_type=$(printf '%s\n' "$list" | grep -vE '^[-d]' || true)
+        if [ -n "$bad_type" ]; then
+          printf '::error::Disallowed entry types in artifact:\n%s\n' "$bad_type" >&2
+          exit 1
+        fi
+        names=$(printf '%s\n' "$list" | awk '{print $NF}')
+        if printf '%s\n' "$names" | grep -qE '(^/|(^|/)\.\.(/|$))'; then
+          printf '::error::Unsafe path traversal in artifact:\n%s\n' "$names" >&2
+          exit 1
+        fi
+        bad=$(printf '%s\n' "$names" | grep -vE "^(\.build|${META_DIR//./\\.})(/|\$)" || true)
+        if [ -n "$bad" ]; then
+          printf '::error::Unexpected entries in artifact:\n%s\n' "$bad" >&2
+          exit 1
+        fi
+        EXTRACT_DIR=$(dirname "$ARCHIVE")
+        tar -xzf "$ARCHIVE" -C "$EXTRACT_DIR" "$META_DIR"
+        META="$EXTRACT_DIR/$META_DIR"
+        read_field() {
+          local name=$1 pattern=$2 value
+          IFS= read -r value < "$META/$name" || true
+          if ! printf '%s' "$value" | grep -qE "$pattern"; then
+            printf '::error::Invalid %s in artifact metadata\n' "$name" >&2
+            return 1
+          fi
+          printf '%s' "$value"
+        }
+        # Branch names are attacker-controlled (fork PRs) and are interpolated into the privileged
+        # downstream job, so accept a shell-safe subset of Git's refname grammar rather than mirroring
+        # it: Git also permits shell metacharacters (e.g. ; & $ ` ( ) ! ') which must not pass here.
+        ref='^[A-Za-z0-9._/+@-]+$'
+        number=$(read_field number   '^[0-9]+$')         || exit 1
+        head_sha=$(read_field head_sha '^[0-9a-f]{40}$') || exit 1
+        head_ref=$(read_field head_ref "$ref")           || exit 1
+        {
+          echo "number=$number"
+          echo "head_sha=$head_sha"
+          echo "head_ref=$head_ref"
+        } >> "$GITHUB_OUTPUT"
+        # base_ref is optional; only some triggering workflows record it.
+        if [ -f "$META/base_ref" ]; then
+          base_ref=$(read_field base_ref "$ref") || exit 1
+          echo "base_ref=$base_ref" >> "$GITHUB_OUTPUT"
+        fi
+
+    - name: Check out pull request head
+      uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+      with:
+        ref: ${{ steps.pr.outputs.head_sha }}
+        fetch-depth: 0  # Full history for blame info
+
+    - name: Restore build outputs from artifact
+      shell: bash
+      env:
+        ARCHIVE: ${{ inputs.archive }}
+      run: |
+        # Refuse to merge into anything the checkout might have produced.
+        rm -rf .build
+        tar -xzf "$ARCHIVE" .build
+        rm -f "$ARCHIVE"

--- a/.github/actions/restore-pr-workspace/action.yml
+++ b/.github/actions/restore-pr-workspace/action.yml
@@ -35,13 +35,15 @@ runs:
         # Fixed artifact contract: triggering workflows write PR metadata into `.pr-meta`.
         META_DIR: .pr-meta
       run: |
-        list=$(tar -tvzf "$ARCHIVE")
-        bad_type=$(printf '%s\n' "$list" | grep -vE '^[-d]' || true)
+        # Entry types come from the verbose listing (first column); names come from the name-only
+        # listing so paths with spaces are handled correctly and we do not parse `tar -v` formatting.
+        types=$(tar -tvzf "$ARCHIVE")
+        bad_type=$(printf '%s\n' "$types" | grep -vE '^[-d]' || true)
         if [ -n "$bad_type" ]; then
           printf '::error::Disallowed entry types in artifact:\n%s\n' "$bad_type" >&2
           exit 1
         fi
-        names=$(printf '%s\n' "$list" | awk '{print $NF}')
+        names=$(tar -tzf "$ARCHIVE")
         if printf '%s\n' "$names" | grep -qE '(^/|(^|/)\.\.(/|$))'; then
           printf '::error::Unsafe path traversal in artifact:\n%s\n' "$names" >&2
           exit 1

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -31,7 +31,7 @@ on:
 jobs:
   linux:
     timeout-minutes: 10
-    runs-on: warp-ubuntu-latest-arm64-2x
+    runs-on: ${{ github.repository == 'libfn/functional' && 'warp-ubuntu-latest-arm64-2x' || 'ubuntu-latest' }}
     strategy:
       fail-fast: false
       matrix:
@@ -102,7 +102,7 @@ jobs:
 
   macos:
     timeout-minutes: 10
-    runs-on: warp-macos-${{ matrix.compiler.osver }}-arm64-6x
+    runs-on: ${{ github.repository == 'libfn/functional' && format('warp-macos-{0}-arm64-6x', matrix.compiler.osver) || format('macos-{0}', matrix.compiler.osver) }}
     env:
       # Silence clang -Woverriding-deployment-version warnings.
       MACOSX_DEPLOYMENT_TARGET: ${{ matrix.compiler.osver }}.0
@@ -167,11 +167,17 @@ jobs:
           export CXX CC
         fi
         if [[ "${{ matrix.compiler.name }}" == "clang" ]]; then
+          if [[ ! -x "$(brew --prefix llvm@${{ matrix.compiler.release }})/bin/clang++" ]]; then
+            brew install llvm@${{ matrix.compiler.release }}
+          fi
           CXX="$(brew --prefix llvm@${{ matrix.compiler.release }})/bin/clang++"
           CC="$(brew --prefix llvm@${{ matrix.compiler.release }})/bin/clang"
           export CXX CC
         fi
         if [[ "${{ matrix.compiler.name }}" == "gcc" ]]; then
+          if [[ ! -x "$(brew --prefix gcc@${{ matrix.compiler.release }})/bin/g++-${{ matrix.compiler.release }}" ]]; then
+            brew install gcc@${{ matrix.compiler.release }}
+          fi
           CXX="$(brew --prefix gcc@${{ matrix.compiler.release }})/bin/g++-${{ matrix.compiler.release }}"
           CC="$(brew --prefix gcc@${{ matrix.compiler.release }})/bin/gcc-${{ matrix.compiler.release }}"
           export CXX CC
@@ -210,8 +216,9 @@ jobs:
             - Debug
             - Release
           vs:
+            # windows-2025-vs2026 is a GitHub-hosted label, so forks get VS 2026 too; only the VS 2022 runner differs (Warp vs hosted windows-2022).
             - generator: "Visual Studio 17 2022"
-              runner: "warp-windows-latest-x64-4x"
+              runner: ${{ github.repository == 'libfn/functional' && 'warp-windows-latest-x64-4x' || 'windows-2022' }}
             - generator: "Visual Studio 18 2026"
               runner: "windows-2025-vs2026"
 
@@ -239,7 +246,7 @@ jobs:
 
   nixos:
     timeout-minutes: 10
-    runs-on: warp-ubuntu-latest-x64-4x
+    runs-on: ${{ github.repository == 'libfn/functional' && 'warp-ubuntu-latest-x64-4x' || 'ubuntu-latest' }}
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -101,11 +101,15 @@ jobs:
         ctest --output-on-failure
 
   macos:
-    timeout-minutes: 10
+    # Installing a toolchain via brew may need more than 10 minutes.
+    timeout-minutes: 30
     runs-on: ${{ github.repository == 'libfn/functional' && format('warp-macos-{0}-arm64-6x', matrix.compiler.osver) || format('macos-{0}', matrix.compiler.osver) }}
     env:
       # Silence clang -Woverriding-deployment-version warnings.
       MACOSX_DEPLOYMENT_TARGET: ${{ matrix.compiler.osver }}.0
+      # Skip the slow Homebrew auto-update/cleanup around the on-demand brew install.
+      HOMEBREW_NO_AUTO_UPDATE: 1
+      HOMEBREW_NO_INSTALL_CLEANUP: 1
     strategy:
       max-parallel: 10
       fail-fast: false
@@ -168,6 +172,7 @@ jobs:
         fi
         if [[ "${{ matrix.compiler.name }}" == "clang" ]]; then
           if ! brew list --versions llvm@${{ matrix.compiler.release }} >/dev/null 2>&1; then
+            brew update
             brew install llvm@${{ matrix.compiler.release }}
           fi
           CXX="$(brew --prefix llvm@${{ matrix.compiler.release }})/bin/clang++"
@@ -176,6 +181,7 @@ jobs:
         fi
         if [[ "${{ matrix.compiler.name }}" == "gcc" ]]; then
           if ! brew list --versions gcc@${{ matrix.compiler.release }} >/dev/null 2>&1; then
+            brew update
             brew install gcc@${{ matrix.compiler.release }}
           fi
           CXX="$(brew --prefix gcc@${{ matrix.compiler.release }})/bin/g++-${{ matrix.compiler.release }}"

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -167,7 +167,7 @@ jobs:
           export CXX CC
         fi
         if [[ "${{ matrix.compiler.name }}" == "clang" ]]; then
-          if [[ ! -x "$(brew --prefix llvm@${{ matrix.compiler.release }})/bin/clang++" ]]; then
+          if ! brew list --versions llvm@${{ matrix.compiler.release }} >/dev/null 2>&1; then
             brew install llvm@${{ matrix.compiler.release }}
           fi
           CXX="$(brew --prefix llvm@${{ matrix.compiler.release }})/bin/clang++"
@@ -175,7 +175,7 @@ jobs:
           export CXX CC
         fi
         if [[ "${{ matrix.compiler.name }}" == "gcc" ]]; then
-          if [[ ! -x "$(brew --prefix gcc@${{ matrix.compiler.release }})/bin/g++-${{ matrix.compiler.release }}" ]]; then
+          if ! brew list --versions gcc@${{ matrix.compiler.release }} >/dev/null 2>&1; then
             brew install gcc@${{ matrix.compiler.release }}
           fi
           CXX="$(brew --prefix gcc@${{ matrix.compiler.release }})/bin/g++-${{ matrix.compiler.release }}"

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -211,44 +211,44 @@ jobs:
         ctest --output-on-failure
 
   windows:
-      timeout-minutes: 10
-      runs-on: ${{ matrix.vs.runner }}
-      strategy:
-        fail-fast: false
-        matrix:
-          mode:
-            - cxx20
-          configuration:
-            - Debug
-            - Release
-          vs:
-            # windows-2022 is required for the VS 2022 generator: windows-latest/windows-2025 resolve to the VS 2026 image
-            - generator: "Visual Studio 17 2022"
-              runner: "windows-2022"
-            - generator: "Visual Studio 18 2026"
-              runner: "windows-2025-vs2026"
+    timeout-minutes: 10
+    runs-on: ${{ matrix.vs.runner }}
+    strategy:
+      fail-fast: false
+      matrix:
+        mode:
+          - cxx20
+        configuration:
+          - Debug
+          - Release
+        vs:
+          # Pin explicit images: windows-2022 carries VS 2022, windows-2025-vs2026 carries VS 2026.
+          - generator: "Visual Studio 17 2022"
+            runner: "windows-2022"
+          - generator: "Visual Studio 18 2026"
+            runner: "windows-2025-vs2026"
 
-      steps:
-      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+    steps:
+    - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
 
-      - name: Prepare build
-        shell: bash
-        run: |
-          mkdir .build
-          cd .build
-          cmake -G "${{ matrix.vs.generator }}" -A x64 -DDISABLE_CXX23=ON ..
-          LINKER=$( grep -iE "^CMAKE_LINKER:FILEPATH=" CMakeCache.txt | sed -n 's/^[^=]*=//p' )
-          FLAGS=$( grep -iE "^CMAKE_CXX_FLAGS(_${{ matrix.configuration }})?:STRING" CMakeCache.txt | sed -n 's/^[^=]*=//p' | tr '\n' ' ' )
-          printf "C++ linker path: %s\n" "$LINKER"
-          "$LINKER" . || true
-          printf "C++ compilation options: %s\n" "$FLAGS"
+    - name: Prepare build
+      shell: bash
+      run: |
+        mkdir .build
+        cd .build
+        cmake -G "${{ matrix.vs.generator }}" -A x64 -DDISABLE_CXX23=ON ..
+        LINKER=$( grep -iE "^CMAKE_LINKER:FILEPATH=" CMakeCache.txt | sed -n 's/^[^=]*=//p' )
+        FLAGS=$( grep -iE "^CMAKE_CXX_FLAGS(_${{ matrix.configuration }})?:STRING" CMakeCache.txt | sed -n 's/^[^=]*=//p' | tr '\n' ' ' )
+        printf "C++ linker path: %s\n" "$LINKER"
+        "$LINKER" . || true
+        printf "C++ compilation options: %s\n" "$FLAGS"
 
-      - name: Build and test ${{ matrix.mode }}
-        shell: bash
-        run: |
-          cd .build
-          cmake --build . --target ${{ matrix.mode }} --config ${{ matrix.configuration }}
-          ctest -L ${{ matrix.mode }} -C ${{ matrix.configuration }} --output-on-failure
+    - name: Build and test ${{ matrix.mode }}
+      shell: bash
+      run: |
+        cd .build
+        cmake --build . --target ${{ matrix.mode }} --config ${{ matrix.configuration }}
+        ctest -L ${{ matrix.mode }} -C ${{ matrix.configuration }} --output-on-failure
 
   nixos:
     timeout-minutes: 10

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -216,9 +216,9 @@ jobs:
             - Debug
             - Release
           vs:
-            # windows-2025-vs2026 is a GitHub-hosted label, so forks get VS 2026 too; only the VS 2022 runner differs (Warp vs hosted windows-2022).
+            # windows-2022 is required for the VS 2022 generator: windows-latest/windows-2025 resolve to the VS 2026 image
             - generator: "Visual Studio 17 2022"
-              runner: ${{ github.repository == 'libfn/functional' && 'warp-windows-latest-x64-4x' || 'windows-2022' }}
+              runner: "windows-2022"
             - generator: "Visual Studio 18 2026"
               runner: "windows-2025-vs2026"
 

--- a/.github/workflows/ci-build.yml
+++ b/.github/workflows/ci-build.yml
@@ -33,8 +33,7 @@ env:
 jobs:
   build:
     if: ${{ github.repository == 'libfn/functional' }}
-    runs-on:
-      group: ${{ matrix.platform == 'linux/arm64' && 'runners-arm64' || 'runners-intel' }}
+    runs-on: ${{ matrix.platform == 'linux/arm64' && 'warp-ubuntu-latest-arm64-4x' || 'warp-ubuntu-latest-x64-4x' }}
     strategy:
       fail-fast: false
       matrix:
@@ -116,8 +115,7 @@ jobs:
 
   merge:
     if: ${{ github.repository == 'libfn/functional' && github.ref_type == 'branch' && github.ref_name == 'main' }}
-    runs-on:
-      group: runners-intel
+    runs-on: warp-ubuntu-latest-x64-4x
     needs:
       - build
     strategy:

--- a/.github/workflows/ci-docs.yml
+++ b/.github/workflows/ci-docs.yml
@@ -30,8 +30,7 @@ env:
 jobs:
   build:
     if: ${{ github.repository == 'libfn/functional' }}
-    runs-on:
-      group: ${{ matrix.platform == 'linux/arm64' && 'runners-arm64' || 'runners-intel' }}
+    runs-on: ${{ matrix.platform == 'linux/arm64' && 'warp-ubuntu-latest-arm64-4x' || 'warp-ubuntu-latest-x64-4x' }}
     strategy:
       fail-fast: false
       matrix:
@@ -69,8 +68,7 @@ jobs:
 
   merge:
     if: ${{ github.repository == 'libfn/functional' && github.ref_type == 'branch' && github.ref_name == 'main' }}
-    runs-on:
-      group: runners-intel
+    runs-on: warp-ubuntu-latest-x64-4x
     needs:
       - build
 

--- a/.github/workflows/ci-pre-commit.yml
+++ b/.github/workflows/ci-pre-commit.yml
@@ -24,8 +24,7 @@ env:
 jobs:
   build:
     if: ${{ github.repository == 'libfn/functional' }}
-    runs-on:
-      group: ${{ matrix.platform == 'linux/arm64' && 'runners-arm64' || 'runners-intel' }}
+    runs-on: ${{ matrix.platform == 'linux/arm64' && 'warp-ubuntu-latest-arm64-4x' || 'warp-ubuntu-latest-x64-4x' }}
     strategy:
       fail-fast: false
       matrix:
@@ -58,8 +57,7 @@ jobs:
 
   merge:
     if: ${{ github.repository == 'libfn/functional' && github.ref_type == 'branch' && github.ref_name == 'main' }}
-    runs-on:
-      group: runners-intel
+    runs-on: warp-ubuntu-latest-x64-4x
     needs:
       - build
 

--- a/.github/workflows/codecov-pr-scan.yml
+++ b/.github/workflows/codecov-pr-scan.yml
@@ -1,0 +1,106 @@
+name: codecov-pr-scan
+
+# Runs after `codecov` completes on a pull_request event. Because this workflow is triggered by
+# `workflow_run`, it executes in the context of the base repository's default branch and has access to
+# repository secrets, including CODECOV_TOKEN. This allows us to upload coverage for pull requests
+# opened from forks, which otherwise do not receive secrets.
+
+on:
+  workflow_run:
+    workflows: ["codecov"]
+    types: [completed]
+
+permissions:
+  contents: read
+  actions: read
+
+jobs:
+  scan:
+    if: >
+      github.repository == 'libfn/functional' &&
+      github.event.workflow_run.event == 'pull_request' &&
+      github.event.workflow_run.conclusion == 'success'
+    runs-on: warp-ubuntu-latest-x64-4x
+    container: libfn.azurecr.io/ci-build-gcc:15-sha-08b1133
+
+    steps:
+    # Download the artifact outside the workspace so the subsequent checkout does not wipe it.
+    - name: Download Codecov inputs artifact
+      uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+      with:
+        name: codecov-pr-inputs
+        github-token: ${{ secrets.GITHUB_TOKEN }}
+        run-id: ${{ github.event.workflow_run.id }}
+        path: ${{ runner.temp }}/codecov-artifact
+
+    - name: Validate artifact and read pull request metadata
+      # The artifact is a tarball containing .gcov files and a `.codecov-pr` directory with PR metadata.
+      # Validate the tarball contents before extracting to prevent path traversal etc. security issues.
+      id: pr
+      shell: bash
+      env:
+        ARCHIVE: ${{ runner.temp }}/codecov-artifact/codecov-inputs.tar.gz
+      run: |
+        list=$(tar -tvzf "$ARCHIVE")
+        bad_type=$(printf '%s\n' "$list" | grep -vE '^[-d]' || true)
+        if [ -n "$bad_type" ]; then
+          printf '::error::Disallowed entry types in artifact:\n%s\n' "$bad_type" >&2
+          exit 1
+        fi
+        names=$(printf '%s\n' "$list" | awk '{print $NF}')
+        if printf '%s\n' "$names" | grep -qE '(^/|(^|/)\.\.(/|$))'; then
+          printf '::error::Unsafe path traversal in artifact:\n%s\n' "$names" >&2
+          exit 1
+        fi
+        bad=$(printf '%s\n' "$names" | grep -vE '^(\.build|\.codecov-pr)(/|$)' || true)
+        if [ -n "$bad" ]; then
+          printf '::error::Unexpected entries in artifact:\n%s\n' "$bad" >&2
+          exit 1
+        fi
+        tar -xzf "$ARCHIVE" -C "${RUNNER_TEMP}/codecov-artifact" .codecov-pr
+        META="${RUNNER_TEMP}/codecov-artifact/.codecov-pr"
+        read_field() {
+          local name=$1 pattern=$2 value
+          IFS= read -r value < "$META/$name" || true
+          if ! printf '%s' "$value" | grep -qE "$pattern"; then
+            printf '::error::Invalid %s in artifact metadata\n' "$name" >&2
+            return 1
+          fi
+          printf '%s' "$value"
+        }
+        number=$(read_field number   '^[0-9]+$')             || exit 1
+        head_sha=$(read_field head_sha '^[0-9a-f]{40}$')     || exit 1
+        head_ref=$(read_field head_ref '^[A-Za-z0-9._/-]+$') || exit 1
+        {
+          echo "number=$number"
+          echo "head_sha=$head_sha"
+          echo "head_ref=$head_ref"
+        } >> "$GITHUB_OUTPUT"
+
+    - name: Check out pull request head
+      uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+      with:
+        ref: ${{ steps.pr.outputs.head_sha }}
+        fetch-depth: 0
+
+    - name: Restore coverage outputs from artifact
+      shell: bash
+      env:
+        ARCHIVE: ${{ runner.temp }}/codecov-artifact/codecov-inputs.tar.gz
+      run: |
+        # Refuse to merge into anything the checkout might have produced.
+        rm -rf .build
+        tar -xzf "$ARCHIVE" .build
+        rm -f "$ARCHIVE"
+
+    - name: Upload .gcov files
+      uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # v7.0.0
+      with:
+        fail_ci_if_error: true
+        disable_search: false
+        verbose: true
+        plugins: noop
+        token: ${{ secrets.CODECOV_TOKEN }}
+        override_commit: ${{ steps.pr.outputs.head_sha }}
+        override_pr: ${{ steps.pr.outputs.number }}
+        override_branch: ${{ steps.pr.outputs.head_ref }}

--- a/.github/workflows/codecov-pr-scan.yml
+++ b/.github/workflows/codecov-pr-scan.yml
@@ -33,65 +33,16 @@ jobs:
         run-id: ${{ github.event.workflow_run.id }}
         path: ${{ runner.temp }}/codecov-artifact
 
-    - name: Validate artifact and read pull request metadata
-      # The artifact is a tarball containing .gcov files and a `.codecov-pr` directory with PR metadata.
-      # Validate the tarball contents before extracting to prevent path traversal etc. security issues.
-      id: pr
-      shell: bash
-      env:
-        ARCHIVE: ${{ runner.temp }}/codecov-artifact/codecov-inputs.tar.gz
-      run: |
-        list=$(tar -tvzf "$ARCHIVE")
-        bad_type=$(printf '%s\n' "$list" | grep -vE '^[-d]' || true)
-        if [ -n "$bad_type" ]; then
-          printf '::error::Disallowed entry types in artifact:\n%s\n' "$bad_type" >&2
-          exit 1
-        fi
-        names=$(printf '%s\n' "$list" | awk '{print $NF}')
-        if printf '%s\n' "$names" | grep -qE '(^/|(^|/)\.\.(/|$))'; then
-          printf '::error::Unsafe path traversal in artifact:\n%s\n' "$names" >&2
-          exit 1
-        fi
-        bad=$(printf '%s\n' "$names" | grep -vE '^(\.build|\.codecov-pr)(/|$)' || true)
-        if [ -n "$bad" ]; then
-          printf '::error::Unexpected entries in artifact:\n%s\n' "$bad" >&2
-          exit 1
-        fi
-        tar -xzf "$ARCHIVE" -C "${RUNNER_TEMP}/codecov-artifact" .codecov-pr
-        META="${RUNNER_TEMP}/codecov-artifact/.codecov-pr"
-        read_field() {
-          local name=$1 pattern=$2 value
-          IFS= read -r value < "$META/$name" || true
-          if ! printf '%s' "$value" | grep -qE "$pattern"; then
-            printf '::error::Invalid %s in artifact metadata\n' "$name" >&2
-            return 1
-          fi
-          printf '%s' "$value"
-        }
-        number=$(read_field number   '^[0-9]+$')             || exit 1
-        head_sha=$(read_field head_sha '^[0-9a-f]{40}$')     || exit 1
-        head_ref=$(read_field head_ref '^[A-Za-z0-9._/-]+$') || exit 1
-        {
-          echo "number=$number"
-          echo "head_sha=$head_sha"
-          echo "head_ref=$head_ref"
-        } >> "$GITHUB_OUTPUT"
-
-    - name: Check out pull request head
-      uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+    # Check out the base repository to obtain the local action, before it checks out the PR head itself.
+    - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
       with:
-        ref: ${{ steps.pr.outputs.head_sha }}
-        fetch-depth: 0
+        sparse-checkout: .github
 
-    - name: Restore coverage outputs from artifact
-      shell: bash
-      env:
-        ARCHIVE: ${{ runner.temp }}/codecov-artifact/codecov-inputs.tar.gz
-      run: |
-        # Refuse to merge into anything the checkout might have produced.
-        rm -rf .build
-        tar -xzf "$ARCHIVE" .build
-        rm -f "$ARCHIVE"
+    - name: Restore pull request workspace
+      id: pr
+      uses: ./.github/actions/restore-pr-workspace
+      with:
+        archive: ${{ runner.temp }}/codecov-artifact/codecov-inputs.tar.gz
 
     - name: Upload .gcov files
       uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # v7.0.0

--- a/.github/workflows/codecov.yml
+++ b/.github/workflows/codecov.yml
@@ -10,6 +10,7 @@ on:
     paths:
       - '.github/workflows/codecov.yml'
       - '.github/workflows/codecov-pr-scan.yml'
+      - '.github/actions/restore-pr-workspace/**'
       - 'include/**'
       - 'tests/**'
       - 'CMakeLists.txt'
@@ -94,14 +95,15 @@ jobs:
         PR_HEAD_SHA: ${{ github.event.pull_request.head.sha }}
         PR_HEAD_REF: ${{ github.event.pull_request.head.ref }}
       run: |
-        mkdir -p .codecov-pr
-        printf "%s\n" "$PR_NUMBER"   > .codecov-pr/number
-        printf "%s\n" "$PR_HEAD_SHA" > .codecov-pr/head_sha
-        printf "%s\n" "$PR_HEAD_REF" > .codecov-pr/head_ref
+        # `.pr-meta` is the artifact contract consumed by the restore-pr-workspace action.
+        mkdir -p .pr-meta
+        printf "%s\n" "$PR_NUMBER"   > .pr-meta/number
+        printf "%s\n" "$PR_HEAD_SHA" > .pr-meta/head_sha
+        printf "%s\n" "$PR_HEAD_REF" > .pr-meta/head_ref
         # shellcheck disable=SC2046  # find emits one path per result; intentional word-splitting into tar arg list
         tar -czf codecov-inputs.tar.gz \
           $(find .build -name '*.gcov' -print) \
-          .codecov-pr
+          .pr-meta
 
     - name: Upload Codecov inputs (pull requests only)
       if: github.event_name == 'pull_request'

--- a/.github/workflows/codecov.yml
+++ b/.github/workflows/codecov.yml
@@ -1,4 +1,4 @@
-name: coverage
+name: codecov
 
 on:
   push:
@@ -8,7 +8,8 @@ on:
     branches:
       - main
     paths:
-      - '.github/workflows/coverage.yml'
+      - '.github/workflows/codecov.yml'
+      - '.github/workflows/codecov-pr-scan.yml'
       - 'include/**'
       - 'tests/**'
       - 'CMakeLists.txt'
@@ -19,7 +20,7 @@ on:
   # examples/** not included in coverage paths intentionally, see also .codecov.yml
 
 jobs:
-  coverage:
+  codecov:
     runs-on: ${{ github.repository == 'libfn/functional' && 'warp-ubuntu-latest-x64-4x' || 'ubuntu-latest' }}
     container: libfn.azurecr.io/ci-build-gcc:15-sha-08b1133
     env:
@@ -76,10 +77,37 @@ jobs:
         $GCOV -pbc -r -s "$(realpath ..)" $(find tests -type f -name '*.gcno') # generate .gcov files
 
     - name: Upload .gcov files
+      if: ${{ github.event_name != 'pull_request' && github.repository == 'libfn/functional' }}
       uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # v7.0.0
       with:
-        fail_ci_if_error: ${{ github.repository == 'libfn/functional' }}
+        fail_ci_if_error: true
         disable_search: false
         verbose: true
         plugins: noop
-        token: ${{ secrets.CODECOV_TOKEN || '' }}
+        token: ${{ secrets.CODECOV_TOKEN }}
+
+    - name: Package Codecov inputs for downstream upload
+      if: github.event_name == 'pull_request'
+      shell: bash
+      env:
+        PR_NUMBER: ${{ github.event.pull_request.number }}
+        PR_HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+        PR_HEAD_REF: ${{ github.event.pull_request.head.ref }}
+      run: |
+        mkdir -p .codecov-pr
+        printf "%s\n" "$PR_NUMBER"   > .codecov-pr/number
+        printf "%s\n" "$PR_HEAD_SHA" > .codecov-pr/head_sha
+        printf "%s\n" "$PR_HEAD_REF" > .codecov-pr/head_ref
+        # shellcheck disable=SC2046  # find emits one path per result; intentional word-splitting into tar arg list
+        tar -czf codecov-inputs.tar.gz \
+          $(find .build -name '*.gcov' -print) \
+          .codecov-pr
+
+    - name: Upload Codecov inputs (pull requests only)
+      if: github.event_name == 'pull_request'
+      uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+      with:
+        name: codecov-pr-inputs
+        path: codecov-inputs.tar.gz
+        retention-days: 1
+        if-no-files-found: error

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -81,5 +81,5 @@ jobs:
         fail_ci_if_error: ${{ github.repository == 'libfn/functional' }}
         disable_search: false
         verbose: true
-        plugin: noop
+        plugins: noop
         token: ${{ secrets.CODECOV_TOKEN || '' }}

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -20,8 +20,7 @@ on:
 
 jobs:
   coverage:
-    runs-on:
-      group: runners-intel
+    runs-on: ${{ github.repository == 'libfn/functional' && 'warp-ubuntu-latest-x64-4x' || 'ubuntu-latest' }}
     container: libfn.azurecr.io/ci-build-gcc:15-sha-08b1133
     env:
       CC: /usr/local/bin/gcc
@@ -79,7 +78,7 @@ jobs:
     - name: Upload .gcov files
       uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # v7.0.0
       with:
-        fail_ci_if_error: true
+        fail_ci_if_error: ${{ github.repository == 'libfn/functional' }}
         disable_search: false
         verbose: true
         plugin: noop

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -23,8 +23,7 @@ permissions:
 
 jobs:
   generate_docs:
-    runs-on:
-      group: runners-arm64
+    runs-on: ${{ github.repository == 'libfn/functional' && 'warp-ubuntu-latest-arm64-2x' || 'ubuntu-latest' }}
     container: libfn.azurecr.io/ci-docs:sha-08b1133
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
@@ -46,9 +45,11 @@ jobs:
           cmake --build . --target export_docs
 
       - name: Setup Pages
+        if: ${{ github.repository == 'libfn/functional' }}
         uses: actions/configure-pages@45bfe0192ca1faeb007ade9deae92b16b8254a0d # v6.0.0
 
       - name: Upload artifact
+        if: ${{ github.repository == 'libfn/functional' }}
         uses: actions/upload-pages-artifact@fc324d3547104276b827a68afc52ff2a11cc49c9 # v5.0.0
         with:
           path: ./.build/docs
@@ -56,6 +57,7 @@ jobs:
 
       - name: Deploy to GitHub Pages
         id: deployment
+        if: ${{ github.repository == 'libfn/functional' }}
         uses: actions/deploy-pages@cd2ce8fcbc39b97be8ca5fce6e763baed58fa128 # v5.0.0
         with:
           artifact_name: docs-develop

--- a/.github/workflows/licence.yml
+++ b/.github/workflows/licence.yml
@@ -35,9 +35,8 @@ on:
 
 jobs:
   licence-check:
-    if: ${{ github.event_name == 'push' || inputs.run_licence_check }}
-    runs-on:
-      group: runners-arm64
+    if: ${{ (github.event_name == 'push' || inputs.run_licence_check) && github.repository == 'libfn/functional' }}
+    runs-on: ${{ github.repository == 'libfn/functional' && 'warp-ubuntu-latest-arm64-2x' || 'ubuntu-latest' }}
     steps:
     - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
 
@@ -47,8 +46,7 @@ jobs:
 
   licence-unchanged:
     if: ${{ github.event_name == 'pull_request' }}
-    runs-on:
-      group: runners-arm64
+    runs-on: ${{ github.repository == 'libfn/functional' && 'warp-ubuntu-latest-arm64-2x' || 'ubuntu-latest' }}
     env:
       LICENCE_FILE: LICENSE.md
     steps:

--- a/.github/workflows/package-test-bazel.yml
+++ b/.github/workflows/package-test-bazel.yml
@@ -28,8 +28,7 @@ env:
 
 jobs:
   test_bazel:
-    runs-on:
-      group: runners-intel
+    runs-on: ${{ github.repository == 'libfn/functional' && 'warp-ubuntu-latest-x64-4x' || 'ubuntu-latest' }}
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/package-test-conan.yml
+++ b/.github/workflows/package-test-conan.yml
@@ -23,8 +23,7 @@ on:
 
 jobs:
   test_conan:
-    runs-on:
-      group: runners-intel
+    runs-on: ${{ github.repository == 'libfn/functional' && 'warp-ubuntu-latest-x64-4x' || 'ubuntu-latest' }}
     container: libfn.azurecr.io/ci-build-gcc:15-sha-08b1133
     strategy:
       fail-fast: false

--- a/.github/workflows/package-test-nix.yml
+++ b/.github/workflows/package-test-nix.yml
@@ -31,8 +31,7 @@ on:
 
 jobs:
   test_nix:
-    runs-on:
-      group: runners-intel
+    runs-on: ${{ github.repository == 'libfn/functional' && 'warp-ubuntu-latest-x64-4x' || 'ubuntu-latest' }}
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/package-test-vcpkg.yml
+++ b/.github/workflows/package-test-vcpkg.yml
@@ -27,8 +27,7 @@ on:
 
 jobs:
   test_vcpkg:
-    runs-on:
-      group: runners-intel
+    runs-on: ${{ github.repository == 'libfn/functional' && 'warp-ubuntu-latest-x64-4x' || 'ubuntu-latest' }}
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -11,8 +11,7 @@ on:
 
 jobs:
   checks:
-    runs-on:
-      group: runners-arm64
+    runs-on: ${{ github.repository == 'libfn/functional' && 'warp-ubuntu-latest-arm64-2x' || 'ubuntu-latest' }}
     container: libfn.azurecr.io/ci-pre-commit:sha-08b1133
 
     steps:

--- a/.github/workflows/sonarcloud-pr-scan.yml
+++ b/.github/workflows/sonarcloud-pr-scan.yml
@@ -27,6 +27,7 @@ permissions:
 jobs:
   scan:
     if: >
+      github.repository == 'libfn/functional' &&
       github.event.workflow_run.event == 'pull_request' &&
       github.event.workflow_run.conclusion == 'success'
     runs-on:

--- a/.github/workflows/sonarcloud-pr-scan.yml
+++ b/.github/workflows/sonarcloud-pr-scan.yml
@@ -43,67 +43,16 @@ jobs:
         run-id: ${{ github.event.workflow_run.id }}
         path: ${{ runner.temp }}/sonar-artifact
 
-    - name: Validate artifact and read pull request metadata
-      # The artifact is a tarball containing the build outputs and a `.sonar-pr` directory with PR metadata
-      # Validate the tarball contents before extracting to prevent path traversal etc. security issues.
-      id: pr
-      shell: bash
-      env:
-        ARCHIVE: ${{ runner.temp }}/sonar-artifact/sonar-inputs.tar.gz
-      run: |
-        list=$(tar -tvzf "$ARCHIVE")
-        bad_type=$(printf '%s\n' "$list" | grep -vE '^[-d]' || true)
-        if [ -n "$bad_type" ]; then
-          printf '::error::Disallowed entry types in artifact:\n%s\n' "$bad_type" >&2
-          exit 1
-        fi
-        names=$(printf '%s\n' "$list" | awk '{print $NF}')
-        if printf '%s\n' "$names" | grep -qE '(^/|(^|/)\.\.(/|$))'; then
-          printf '::error::Unsafe path traversal in artifact:\n%s\n' "$names" >&2
-          exit 1
-        fi
-        bad=$(printf '%s\n' "$names" | grep -vE '^(\.build|\.sonar-pr)(/|$)' || true)
-        if [ -n "$bad" ]; then
-          printf '::error::Unexpected entries in artifact:\n%s\n' "$bad" >&2
-          exit 1
-        fi
-        tar -xzf "$ARCHIVE" -C "${RUNNER_TEMP}/sonar-artifact" .sonar-pr
-        META="${RUNNER_TEMP}/sonar-artifact/.sonar-pr"
-        read_field() {
-          local name=$1 pattern=$2 value
-          IFS= read -r value < "$META/$name" || true
-          if ! printf '%s' "$value" | grep -qE "$pattern"; then
-            printf '::error::Invalid %s in artifact metadata\n' "$name" >&2
-            return 1
-          fi
-          printf '%s' "$value"
-        }
-        number=$(read_field number   '^[0-9]+$')                 || exit 1
-        head_sha=$(read_field head_sha '^[0-9a-f]{40}$')         || exit 1
-        head_ref=$(read_field head_ref '^[A-Za-z0-9._/-]+$')     || exit 1
-        base_ref=$(read_field base_ref '^[A-Za-z0-9._/-]+$')     || exit 1
-        {
-          echo "number=$number"
-          echo "head_sha=$head_sha"
-          echo "head_ref=$head_ref"
-          echo "base_ref=$base_ref"
-        } >> "$GITHUB_OUTPUT"
-
-    - name: Check out pull request head
-      uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+    # Check out the base repository to obtain the local action, before it checks out the PR head itself.
+    - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
       with:
-        ref: ${{ steps.pr.outputs.head_sha }}
-        fetch-depth: 0  # Full history for blame info
+        sparse-checkout: .github
 
-    - name: Restore build outputs from artifact
-      shell: bash
-      env:
-        ARCHIVE: ${{ runner.temp }}/sonar-artifact/sonar-inputs.tar.gz
-      run: |
-        # Refuse to merge into anything the checkout might have produced.
-        rm -rf .build
-        tar -xzf "$ARCHIVE" .build
-        rm -f "$ARCHIVE"
+    - name: Restore pull request workspace
+      id: pr
+      uses: ./.github/actions/restore-pr-workspace
+      with:
+        archive: ${{ runner.temp }}/sonar-artifact/sonar-inputs.tar.gz
 
     - name: Run SonarScanner
       uses: SonarSource/sonarqube-scan-action@713881670b6b3676cda39549040e2d88c70d582e # v8.2.0

--- a/.github/workflows/sonarcloud-pr-scan.yml
+++ b/.github/workflows/sonarcloud-pr-scan.yml
@@ -30,8 +30,7 @@ jobs:
       github.repository == 'libfn/functional' &&
       github.event.workflow_run.event == 'pull_request' &&
       github.event.workflow_run.conclusion == 'success'
-    runs-on:
-      group: runners-intel
+    runs-on: warp-ubuntu-latest-x64-4x
     container: libfn.azurecr.io/ci-build-gcc:15-sha-08b1133
 
     steps:

--- a/.github/workflows/sonarcloud.yml
+++ b/.github/workflows/sonarcloud.yml
@@ -68,16 +68,17 @@ jobs:
         PR_HEAD_REF: ${{ github.event.pull_request.head.ref }}
         PR_BASE_REF: ${{ github.event.pull_request.base.ref }}
       run: |
-        mkdir -p .sonar-pr
-        printf "%s\n" "$PR_NUMBER"   > .sonar-pr/number
-        printf "%s\n" "$PR_HEAD_SHA" > .sonar-pr/head_sha
-        printf "%s\n" "$PR_HEAD_REF" > .sonar-pr/head_ref
-        printf "%s\n" "$PR_BASE_REF" > .sonar-pr/base_ref
+        # `.pr-meta` is the artifact contract consumed by the restore-pr-workspace action.
+        mkdir -p .pr-meta
+        printf "%s\n" "$PR_NUMBER"   > .pr-meta/number
+        printf "%s\n" "$PR_HEAD_SHA" > .pr-meta/head_sha
+        printf "%s\n" "$PR_HEAD_REF" > .pr-meta/head_ref
+        printf "%s\n" "$PR_BASE_REF" > .pr-meta/base_ref
         # shellcheck disable=SC2046  # find emits one path per result; intentional word-splitting into tar arg list
         tar -czf sonar-inputs.tar.gz \
           .build/compile_commands.json \
           $(find .build -name '*.gcov' -print) \
-          .sonar-pr
+          .pr-meta
 
     - name: Upload SonarCloud inputs (pull requests only)
       if: github.event_name == 'pull_request'

--- a/.github/workflows/sonarcloud.yml
+++ b/.github/workflows/sonarcloud.yml
@@ -9,8 +9,7 @@ on:
 
 jobs:
   sonarcloud:
-    runs-on:
-      group: runners-intel
+    runs-on: ${{ github.repository == 'libfn/functional' && 'warp-ubuntu-latest-x64-4x' || 'ubuntu-latest' }}
     container: libfn.azurecr.io/ci-build-gcc:15-sha-08b1133
     env:
       CC: /usr/local/bin/gcc
@@ -50,7 +49,7 @@ jobs:
     # `sonarcloud-pr-scan` workflow (triggered via `workflow_run`), which
     # runs in the base repository context and has access to SONAR_TOKEN.
     - name: Run SonarScanner
-      if: github.event_name != 'pull_request'
+      if: ${{ github.event_name != 'pull_request' && github.repository == 'libfn/functional' }}
       uses: SonarSource/sonarqube-scan-action@713881670b6b3676cda39549040e2d88c70d582e # v8.2.0
       env:
         SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}

--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 .idea/
 .idea_modules/
 .build*/
+.pr-meta/
 build/
 /compile_commands.json
 .scratch*/

--- a/docs/ci/index.md
+++ b/docs/ci/index.md
@@ -10,7 +10,7 @@ Workflows for continuous integration:
 * `nix` - check build on [nix](https://nixos.org/) platform
 * `license` - license scan by [FOSSA](https://app.fossa.com/projects/git%2Bgithub.com%2Flibfn%2Ffunctional)
 * `pre-commit` - enforce rules defined in `.pre-commit-config.yaml`, including `clang-format`
-* `coverage` - submit unit tests coverage to [codecov.io](https://app.codecov.io/gh/libfn/functional)
+* `codecov` - submit unit tests coverage to [codecov.io](https://app.codecov.io/gh/libfn/functional)
 * `docs` - build this documentation site [libfn.org](https://libfn.org/)
 * `ci-...` - build [docker images](https://hub.docker.com/r/libfn) for continuous integration
 


### PR DESCRIPTION
Fall back to GitHub-hosted runners and gate secret/Pages steps to the base repo so forks run on hosted infra. Target WarpBuild runners by warp-* label instead of runner group, pinning intel->x64-4x and arm64->arm64-2x.
