### PR TITLE
Make the docs Pages deploy safe to re-run

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -53,11 +53,11 @@ jobs:
         uses: actions/upload-pages-artifact@fc324d3547104276b827a68afc52ff2a11cc49c9 # v5.0.0
         with:
           path: ./.build/docs
-          name: docs-develop
+          name: docs-develop-${{ github.run_attempt }}
 
       - name: Deploy to GitHub Pages
         id: deployment
         if: ${{ github.repository == 'libfn/functional' }}
         uses: actions/deploy-pages@cd2ce8fcbc39b97be8ca5fce6e763baed58fa128 # v5.0.0
         with:
-          artifact_name: docs-develop
+          artifact_name: docs-develop-${{ github.run_attempt }}


### PR DESCRIPTION
"Re-run failed jobs" re-executes the upload step, and the previous attempt's artifact survives, so `deploy-pages` finds two artifacts named `docs-develop` and refuses the ambiguity. Suffixing the name with `github.run_attempt` scopes each attempt to its own artifact.

Assisted-by: Claude:claude-fable-5