### PR TITLE
Make the in-place constructors of `sum` and `choice` explicit; clear the SonarQube issue backlog

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,7 @@ Functional programming in C++
 
 [![codecov](https://codecov.io/gh/libfn/functional/graph/badge.svg?token=3RHT38SEU0)](https://codecov.io/gh/libfn/functional)
 [![FOSSA Status](https://app.fossa.com/api/projects/git%2Bgithub.com%2Flibfn%2Ffunctional.svg?type=shield)](https://app.fossa.com/projects/git%2Bgithub.com%2Flibfn%2Ffunctional?ref=badge_shield)
+[![Quality Gate Status](https://sonarcloud.io/api/project_badges/measure?project=libfn_functional&metric=alert_status)](https://sonarcloud.io/summary/new_code?id=libfn_functional)
 
 ## Why
 

--- a/include/fn/choice.hpp
+++ b/include/fn/choice.hpp
@@ -31,7 +31,7 @@ static constexpr bool _is_valid_choice_subtype //
     &&(not ::std::is_reference_v<T>)           //
     &&(not some_sum<T>)                        //
     &&(not some_in_place_type<T>)              //
-    &&(::std::is_same_v<T, ::std::remove_cv_t<T>>);
+    &&::std::is_same_v<T, ::std::remove_cv_t<T>>;
 }
 
 /**
@@ -81,7 +81,7 @@ struct choice<Ts...> : sum<Ts...> {
    * @param v TODO
    */
   template <typename T>
-  constexpr choice(T &&v)
+  constexpr choice(T &&v) // NOSONAR cpp:S1709,S6458 implicit arm of the explicit pair; has_type excludes self
     requires has_type<::std::remove_cvref_t<T>> && (::std::is_constructible_v<::std::remove_cvref_t<T>, decltype(v)>)
              && (::std::is_convertible_v<decltype(v), ::std::remove_cvref_t<T>>)
       : _impl(::std::in_place_type<::std::remove_cvref_t<T>>, FWD(v))
@@ -95,7 +95,7 @@ struct choice<Ts...> : sum<Ts...> {
    * @param v TODO
    */
   template <typename T>
-  constexpr explicit choice(T &&v)
+  constexpr explicit choice(T &&v) // NOSONAR cpp:S6458 has_type excludes self
     requires has_type<::std::remove_cvref_t<T>> && (::std::is_constructible_v<::std::remove_cvref_t<T>, decltype(v)>)
              && (not ::std::is_convertible_v<decltype(v), ::std::remove_cvref_t<T>>)
       : _impl(::std::in_place_type<::std::remove_cvref_t<T>>, FWD(v))
@@ -110,7 +110,7 @@ struct choice<Ts...> : sum<Ts...> {
    * @param v TODO
    */
   template <typename T>
-  constexpr choice(::std::in_place_type_t<T> d, auto &&...args) noexcept
+  constexpr explicit choice(::std::in_place_type_t<T> d, auto &&...args) noexcept
     requires has_type<T>
       : _impl(d, FWD(args)...)
   {
@@ -123,7 +123,7 @@ struct choice<Ts...> : sum<Ts...> {
    * @param v TODO
    */
   template <typename... Tx>
-  constexpr choice(sum<Tx...> const &v) noexcept
+  constexpr choice(sum<Tx...> const &v) noexcept // NOSONAR cpp:S1709 implicit widening by design
     requires detail::is_superset_of<choice, choice<Tx...>> && (... && ::std::is_copy_constructible_v<Tx>)
       : _impl(::std::in_place_type<sum<Tx...>>, FWD(v))
   {
@@ -136,7 +136,7 @@ struct choice<Ts...> : sum<Ts...> {
    * @param v TODO
    */
   template <typename... Tx>
-  constexpr choice(sum<Tx...> &&v) noexcept
+  constexpr choice(sum<Tx...> &&v) noexcept // NOSONAR cpp:S1709 implicit widening by design
     requires detail::is_superset_of<choice, choice<Tx...>> && (... && ::std::is_move_constructible_v<Tx>)
       : _impl(::std::in_place_type<sum<Tx...>>, FWD(v))
   {

--- a/include/fn/detail/functional.hpp
+++ b/include/fn/detail/functional.hpp
@@ -188,7 +188,7 @@ template <typename Ret, typename Fn, typename... Args> struct _is_nothrow_invoca
 // invoke
 template <typename Fn, typename... Args>
   requires(_is_invocable<Fn, Args...>::value)
-constexpr inline auto _invoke(Fn &&fn, Args &&...args) noexcept(_is_nothrow_invocable<Fn, Args...>::value)
+constexpr auto _invoke(Fn &&fn, Args &&...args) noexcept(_is_nothrow_invocable<Fn, Args...>::value)
     -> _invoke_result<Fn, Args...>::type
 {
   return _invoke_detail::invoke(FWD(fn), FWD(args)...);

--- a/include/fn/detail/meta.hpp
+++ b/include/fn/detail/meta.hpp
@@ -51,7 +51,7 @@ template <typename T> struct _indexed_type {
   ::std::size_t index;
 };
 template <typename... Ts> struct _indexed_type_list : _indexed_type<Ts>... {
-  constexpr _indexed_type_list(::std::size_t i = 0) : _indexed_type<Ts>{i++}... {}
+  constexpr explicit _indexed_type_list(::std::size_t i = 0) : _indexed_type<Ts>{i++}... {}
 };
 template <typename T, typename... Ts>
   requires(... || ::std::is_same_v<Ts, T>)
@@ -146,18 +146,18 @@ template <typename... Ts> struct normalized final {
 
   struct _uniqued final {
     ::std::array<::std::size_t, N> indices;
-    ::std::size_t size;
+    ::std::size_t count;
   };
 
   [[nodiscard]] static constexpr auto _indices() noexcept
   {
     ::std::array<::std::string_view, sizeof...(Ts)> names{type_sortkey_v<Ts>...};
     ::std::array<::std::size_t, sizeof...(Ts)> indices{};
-    ::std::generate(indices.begin(), indices.end(), [n = 0]() mutable -> ::std::size_t { return n++; });
+    ::std::ranges::generate(indices, [n = 0]() mutable -> ::std::size_t { return n++; });
     auto const less = [v = &names](::std::size_t i, ::std::size_t j) constexpr { return (*v)[i] < (*v)[j]; };
-    ::std::sort(indices.begin(), indices.end(), less);
+    ::std::ranges::sort(indices, less);
     auto const equal = [v = &names](::std::size_t i, ::std::size_t j) constexpr { return (*v)[i] == (*v)[j]; };
-    auto const end = ::std::unique(indices.begin(), indices.end(), equal);
+    auto const end = ::std::ranges::unique(indices, equal).begin();
     return _uniqued{indices, static_cast<::std::size_t>(end - indices.begin())};
   }
 
@@ -168,7 +168,7 @@ template <typename... Ts> struct normalized final {
       -> F<select_nth_t<_indices_v.indices[Is], Ts...>...>;
 
   // How many unique types
-  static constexpr ::std::size_t size = _indices_v.size;
+  static constexpr ::std::size_t size = _indices_v.count;
 
   // Apply a given template on a normalized list of types
   template <template <typename...> typename F>
@@ -182,7 +182,7 @@ static constexpr bool is_superset_of<F<Ts...>, F<Tu...>> = (... && type_one_of<T
 template <typename... Tx> struct _ts final {};
 
 template <typename... Ts> struct is_normal final {
-  static constexpr auto value = ::std::is_same<typename normalized<Ts...>::template apply<_ts>, _ts<Ts...>>::value;
+  static constexpr auto value = ::std::is_same_v<typename normalized<Ts...>::template apply<_ts>, _ts<Ts...>>;
 };
 
 template <typename... Ts> static constexpr bool is_normal_v = is_normal<Ts...>::value;

--- a/include/fn/detail/pack_impl.hpp
+++ b/include/fn/detail/pack_impl.hpp
@@ -17,7 +17,7 @@
 namespace fn::detail {
 template <::std::size_t I, typename T> struct _element {
   static_assert(not ::std::is_rvalue_reference_v<T>);
-  T v;
+  T v; // NOSONAR cpp:S6226 MSVC ignores the attribute
 };
 
 template <typename, typename... Ts> struct pack_impl;

--- a/include/fn/detail/variadic_union.hpp
+++ b/include/fn/detail/variadic_union.hpp
@@ -13,9 +13,7 @@
 
 #include <type_traits>
 
-namespace fn {
-
-namespace detail {
+namespace fn::detail {
 
 template <typename T> constexpr bool _is_in_place_type = false;
 template <typename T> constexpr bool _is_in_place_type<::std::in_place_type_t<T> &> = true;
@@ -110,7 +108,7 @@ template <typename... Ts> constexpr bool _is_variadic_union<variadic_union<Ts...
 template <typename T>
 concept some_variadic_union = _is_variadic_union<T &>;
 
-template <typename T0> union variadic_union<T0> final {
+template <typename T0> union variadic_union<T0> {
   static_assert(not _some_in_place_type<T0>);
   using t0 = T0;
   T0 v0;
@@ -120,10 +118,10 @@ template <typename T0> union variadic_union<T0> final {
       = ::std::is_same_v<T, T0>;
   static constexpr ::std::size_t size = 1;
 
-  constexpr ~variadic_union() {}
+  constexpr ~variadic_union() {} // NOSONAR cpp:S3490 = default would be deleted for non-trivial members
 };
 
-template <typename T0, typename T1> union variadic_union<T0, T1> final {
+template <typename T0, typename T1> union variadic_union<T0, T1> {
   static_assert(not _some_in_place_type<T0>);
   static_assert(not _some_in_place_type<T1>);
   static_assert(not ::std::is_same_v<T0, T1>);
@@ -138,10 +136,10 @@ template <typename T0, typename T1> union variadic_union<T0, T1> final {
       = ::std::is_same_v<T, T0> || ::std::is_same_v<T, T1>;
   static constexpr ::std::size_t size = 2;
 
-  constexpr ~variadic_union() {}
+  constexpr ~variadic_union() {} // NOSONAR cpp:S3490 = default would be deleted for non-trivial members
 };
 
-template <typename T0, typename T1, typename T2> union variadic_union<T0, T1, T2> final {
+template <typename T0, typename T1, typename T2> union variadic_union<T0, T1, T2> {
   static_assert(not _some_in_place_type<T0>);
   static_assert(not _some_in_place_type<T1>);
   static_assert(not _some_in_place_type<T2>);
@@ -161,10 +159,10 @@ template <typename T0, typename T1, typename T2> union variadic_union<T0, T1, T2
       = ::std::is_same_v<T, T0> || ::std::is_same_v<T, T1> || ::std::is_same_v<T, T2>;
   static constexpr ::std::size_t size = 3;
 
-  constexpr ~variadic_union() {}
+  constexpr ~variadic_union() {} // NOSONAR cpp:S3490 = default would be deleted for non-trivial members
 };
 
-template <typename T0, typename T1, typename T2, typename T3> union variadic_union<T0, T1, T2, T3> final {
+template <typename T0, typename T1, typename T2, typename T3> union variadic_union<T0, T1, T2, T3> {
   static_assert(not _some_in_place_type<T0>);
   static_assert(not _some_in_place_type<T1>);
   static_assert(not _some_in_place_type<T2>);
@@ -190,12 +188,12 @@ template <typename T0, typename T1, typename T2, typename T3> union variadic_uni
       = ::std::is_same_v<T, T0> || ::std::is_same_v<T, T1> || ::std::is_same_v<T, T2> || ::std::is_same_v<T, T3>;
   static constexpr ::std::size_t size = 4;
 
-  constexpr ~variadic_union() {}
+  constexpr ~variadic_union() {} // NOSONAR cpp:S3490 = default would be deleted for non-trivial members
 };
 
 template <typename T0, typename T1, typename T2, typename T3, typename... Ts>
   requires(sizeof...(Ts) > 0)
-union variadic_union<T0, T1, T2, T3, Ts...> final {
+union variadic_union<T0, T1, T2, T3, Ts...> {
   static_assert(not _some_in_place_type<T0>);
   static_assert(not _some_in_place_type<T1>);
   static_assert(not _some_in_place_type<T2>);
@@ -229,7 +227,7 @@ union variadic_union<T0, T1, T2, T3, Ts...> final {
         || variadic_union<Ts...>::template has_type<T>;
   static constexpr ::std::size_t size = 4 + more_t::size;
 
-  constexpr ~variadic_union() {}
+  constexpr ~variadic_union() {} // NOSONAR cpp:S3490 = default would be deleted for non-trivial members
 };
 
 template <typename T, typename U>
@@ -608,7 +606,6 @@ constexpr void invoke_type_variadic_union(some_variadic_union auto &&v, ::std::s
     return invoke_type_variadic_union<R, typename U::more_t>(FWD(v).more, index - 4, FWD(fn));
 }
 
-} // namespace detail
-} // namespace fn
+} // namespace fn::detail
 
 #endif // INCLUDE_FN_DETAIL_VARIADIC_UNION

--- a/include/fn/discard.hpp
+++ b/include/fn/discard.hpp
@@ -29,7 +29,7 @@ constexpr inline struct discard_t final {
   [[nodiscard]] constexpr auto operator()() const noexcept -> functor<discard_t> { return {}; }
 
   struct apply final {
-    constexpr auto operator()(some_monadic_type auto &&) const noexcept -> void {}
+    constexpr auto operator()(some_monadic_type auto &&) const noexcept -> void {} // NOSONAR cpp:S1186 discards
   };
 } discard = {};
 

--- a/include/fn/expected.hpp
+++ b/include/fn/expected.hpp
@@ -220,8 +220,9 @@ template <typename T, typename E> struct _expected_base : ::pfn::detail::_expect
         ::fn::detail::_invoke(FWD(fn), _pfn_base::_value(FWD(self)));
         return type();
       } else
-        return type(::pfn::detail::_expected_from_invoke, ::std::in_place,
-                    [&]() -> decltype(auto) { return ::fn::detail::_invoke(FWD(fn), _pfn_base::_value(FWD(self))); });
+        return type(::pfn::detail::_expected_from_invoke, ::std::in_place, [&fn, &self]() -> decltype(auto) {
+          return ::fn::detail::_invoke(FWD(fn), _pfn_base::_value(FWD(self)));
+        });
     else
       return type(::pfn::unexpect, _pfn_base::_error(FWD(self)));
   }
@@ -239,7 +240,7 @@ template <typename T, typename E> struct _expected_base : ::pfn::detail::_expect
         return type();
       } else
         return type(::pfn::detail::_expected_from_invoke, ::std::in_place,
-                    [&]() -> decltype(auto) { return _pfn_base::_value(FWD(self)).transform(FWD(fn)); });
+                    [&fn, &self]() -> decltype(auto) { return _pfn_base::_value(FWD(self)).transform(FWD(fn)); });
     else
       return type(::pfn::unexpect, _pfn_base::_error(FWD(self)));
   }
@@ -260,7 +261,7 @@ template <typename T, typename E> struct _expected_base : ::pfn::detail::_expect
         return type();
       } else
         return type(::pfn::detail::_expected_from_invoke, ::std::in_place,
-                    [&]() -> decltype(auto) { return ::fn::detail::_invoke(FWD(fn)); });
+                    [&fn]() -> decltype(auto) { return ::fn::detail::_invoke(FWD(fn)); });
     else
       return type(::pfn::unexpect, _pfn_base::_error(FWD(self)));
   }
@@ -284,8 +285,9 @@ template <typename T, typename E> struct _expected_base : ::pfn::detail::_expect
       else
         return type();
     else
-      return type(::pfn::detail::_expected_from_invoke, ::pfn::unexpect,
-                  [&]() -> decltype(auto) { return ::fn::detail::_invoke(FWD(fn), _pfn_base::_error(FWD(self))); });
+      return type(::pfn::detail::_expected_from_invoke, ::pfn::unexpect, [&fn, &self]() -> decltype(auto) {
+        return ::fn::detail::_invoke(FWD(fn), _pfn_base::_error(FWD(self)));
+      });
   }
 
   // transform_error, error type is a sum (delegates to sum::transform)
@@ -302,7 +304,7 @@ template <typename T, typename E> struct _expected_base : ::pfn::detail::_expect
         return type();
     else
       return type(::pfn::detail::_expected_from_invoke, ::pfn::unexpect,
-                  [&]() -> decltype(auto) { return _pfn_base::_error(FWD(self)).transform(FWD(fn)); });
+                  [&fn, &self]() -> decltype(auto) { return _pfn_base::_error(FWD(self)).transform(FWD(fn)); });
   }
 };
 

--- a/include/fn/functional.hpp
+++ b/include/fn/functional.hpp
@@ -38,7 +38,7 @@ constexpr inline bool is_nothrow_invocable_r_v = is_nothrow_invocable_r<Ret, Fn,
 // invoke
 template <typename Fn, typename... Args>
   requires is_invocable_v<Fn, Args...>
-constexpr inline auto invoke(Fn &&fn, Args &&...args) noexcept(is_nothrow_invocable_v<Fn, Args...>)
+constexpr auto invoke(Fn &&fn, Args &&...args) noexcept(is_nothrow_invocable_v<Fn, Args...>)
     -> invoke_result_t<Fn, Args...>
 {
   return detail::_invoke(FWD(fn), FWD(args)...);

--- a/include/fn/optional.hpp
+++ b/include/fn/optional.hpp
@@ -126,7 +126,7 @@ template <typename T> struct _optional_base : ::pfn::detail::_optional_base<T, o
     using type = ::fn::optional<new_value_type>;
     if (self.has_value())
       return type(::pfn::detail::_optional_from_invoke,
-                  [&]() -> decltype(auto) { return ::fn::detail::_invoke(FWD(fn), *FWD(self)); });
+                  [&fn, &self]() -> decltype(auto) { return ::fn::detail::_invoke(FWD(fn), *FWD(self)); });
     else
       return type(::std::nullopt);
   }
@@ -140,7 +140,7 @@ template <typename T> struct _optional_base : ::pfn::detail::_optional_base<T, o
     using type = ::fn::optional<new_value_type>;
     if (self.has_value())
       return type(::pfn::detail::_optional_from_invoke,
-                  [&]() -> decltype(auto) { return (*FWD(self)).transform(FWD(fn)); });
+                  [&fn, &self]() -> decltype(auto) { return (*FWD(self)).transform(FWD(fn)); });
     else
       return type(::std::nullopt);
   }
@@ -148,7 +148,7 @@ template <typename T> struct _optional_base : ::pfn::detail::_optional_base<T, o
 
 } // namespace detail
 
-template <typename T> class optional : private detail::_optional_base<T> {
+template <typename T> class optional : private detail::_optional_base<T> { // NOSONAR cpp:S3624 base manages storage
   static_assert(::pfn::detail::_is_valid_optional<T>);
   static_assert(not ::std::is_same_v<T, ::fn::sum<>>);
   using _base = detail::_optional_base<T>;
@@ -162,7 +162,7 @@ public:
 
   // Constructors. Explicit forwarders to the base mirror pfn::optional.
   constexpr optional() noexcept : _base(::std::nullopt) {}
-  constexpr optional(::std::nullopt_t) noexcept : _base(::std::nullopt) {}
+  constexpr optional(::std::nullopt_t) noexcept : _base(::std::nullopt) {} // NOSONAR cpp:S1709 implicit per spec
 
   template <class U>
   constexpr explicit(not ::std::is_convertible_v<U const &, T>) optional(optional<U> const &s) //
@@ -439,7 +439,7 @@ public:
 
   // Constructors. Explicit forwarders to the base mirror pfn::optional.
   constexpr optional() noexcept = default;
-  constexpr optional(::std::nullopt_t) noexcept : optional() {}
+  constexpr optional(::std::nullopt_t) noexcept : optional() {} // NOSONAR cpp:S1709 implicit per spec
   constexpr optional(optional const &rhs) noexcept = default;
 
   template <class Arg>

--- a/include/fn/sum.hpp
+++ b/include/fn/sum.hpp
@@ -40,7 +40,7 @@ static constexpr bool _is_valid_sum_subtype //
     &&(not ::std::is_reference_v<T>)        //
     &&(not some_sum<T>)                     //
     &&(not some_in_place_type<T>)           //
-    &&(::std::is_same_v<T, ::std::remove_cv_t<T>>);
+    &&::std::is_same_v<T, ::std::remove_cv_t<T>>;
 
 struct _invoke_autodetect_tag final {};
 
@@ -213,7 +213,7 @@ struct sum<Ts...> {
    * @param v TODO
    */
   template <typename T>
-  constexpr sum(T &&v)
+  constexpr sum(T &&v) // NOSONAR cpp:S1709,S6458 implicit arm of the explicit pair; has_type excludes self
     requires has_type<::std::remove_cvref_t<T>> && (::std::is_constructible_v<::std::remove_cvref_t<T>, decltype(v)>)
                  && (::std::is_convertible_v<decltype(v), ::std::remove_cvref_t<T>>)
       : data(detail::make_variadic_union<::std::remove_cvref_t<T>, data_t>(FWD(v))),
@@ -228,7 +228,7 @@ struct sum<Ts...> {
    * @param v TODO
    */
   template <typename T>
-  constexpr explicit sum(T &&v)
+  constexpr explicit sum(T &&v) // NOSONAR cpp:S6458 has_type excludes self
     requires has_type<::std::remove_cvref_t<T>> && (::std::is_constructible_v<::std::remove_cvref_t<T>, decltype(v)>)
                  && (not ::std::is_convertible_v<decltype(v), ::std::remove_cvref_t<T>>)
       : data(detail::make_variadic_union<::std::remove_cvref_t<T>, data_t>(FWD(v))),
@@ -243,7 +243,7 @@ struct sum<Ts...> {
    * @param args TODO
    */
   template <typename T>
-  constexpr sum(::std::in_place_type_t<T>, auto &&...args)
+  constexpr explicit sum(::std::in_place_type_t<T>, auto &&...args)
     requires has_type<T>
       : data(detail::make_variadic_union<T, data_t>(FWD(args)...)), index(detail::type_index<T, Ts...>)
   {
@@ -256,7 +256,7 @@ struct sum<Ts...> {
    * @param arg TODO
    */
   template <typename... Tx>
-  constexpr sum(sum<Tx...> const &arg) noexcept
+  constexpr sum(sum<Tx...> const &arg) noexcept // NOSONAR cpp:S1709 implicit widening by design
     requires detail::is_superset_of<sum, sum<Tx...>> && (not ::std::is_same_v<sum, sum<Tx...>>)
                  && (... && ::std::is_copy_constructible_v<Tx>) && (sizeof...(Tx) > 0)
       : data(FWD(arg).template _invoke<data_t>([]<typename T>(::std::in_place_type_t<T>, auto &&v) {
@@ -275,7 +275,7 @@ struct sum<Ts...> {
    * @param arg TODO
    */
   template <typename... Tx>
-  constexpr sum(sum<Tx...> &&arg) noexcept
+  constexpr sum(sum<Tx...> &&arg) noexcept // NOSONAR cpp:S1709 implicit widening by design
     requires detail::is_superset_of<sum, sum<Tx...>> && (not ::std::is_same_v<sum, sum<Tx...>>)
                  && (... && ::std::is_move_constructible_v<Tx>) && (sizeof...(Tx) > 0)
       : data(FWD(arg).template _invoke<data_t>([]<typename T>(::std::in_place_type_t<T>, auto &&v) {

--- a/include/fn/value_or.hpp
+++ b/include/fn/value_or.hpp
@@ -59,7 +59,7 @@ struct value_or_t::apply final {
     requires invocable_value_or<V &&, Args...>
   {
     using type = ::std::remove_cvref_t<V>;
-    return FWD(v).or_else([&](auto &&...) -> type { return type{::std::in_place, FWD(args)...}; });
+    return FWD(v).or_else([&args...](auto &&...) -> type { return type{::std::in_place, FWD(args)...}; });
   }
 
   // No support for choice since there's no error to recover from

--- a/include/pfn/expected.hpp
+++ b/include/pfn/expected.hpp
@@ -19,10 +19,10 @@
 #ifdef FWD
 #pragma push_macro("FWD")
 #define INCLUDE_PFN_EXPECTED__POP_FWD
-#undef FWD
+#undef FWD // NOSONAR cpp:S959 saved by push_macro above
 #endif
 
-// Also defined in fn/detail/macro_fwd.hpp but pfn/* headers are standalone
+// Also defined in fn/detail/macro_fwd.hpp but pfn headers are standalone
 #define FWD(...) static_cast<decltype(__VA_ARGS__) &&>(__VA_ARGS__)
 
 #ifdef ASSERT
@@ -79,7 +79,7 @@ public:
   E const &&error() const && noexcept { return ::std::move(e_); }
 
 private:
-  E e_;
+  E e_; // NOSONAR cpp:S6226 MSVC ignores the attribute
 };
 
 // [expected.syn], unexpect_t disambiguation tag
@@ -187,7 +187,7 @@ public:
   }
 
 private:
-  E e_;
+  E e_; // NOSONAR cpp:S6226 MSVC ignores the attribute
 };
 
 template <class E> unexpected(E) -> unexpected<E>;
@@ -272,7 +272,7 @@ template <class T, class E> union _expected_union_t {
   constexpr ~_expected_union_t() noexcept
     requires(::std::is_trivially_destructible_v<T> && ::std::is_trivially_destructible_v<E>)
   = default;
-  constexpr ~_expected_union_t() noexcept {}
+  constexpr ~_expected_union_t() noexcept {} // NOSONAR cpp:S3490 non-trivial arm of the conditionally-trivial pair
 
   // [expected.object.assign], implementation of reinit-expected
   template <typename New, typename Old, typename... Args>
@@ -296,7 +296,7 @@ template <class T, class E> union _expected_union_t {
       // (and therefore trivially-destructible per [class.prop]/1). Old is
       // observationally identical to the destroy-and-recreate branch below.
       if (not ::std::is_constant_evaluated()) {
-        alignas(Old) unsigned char _bytes[sizeof(Old)];
+        alignas(Old) unsigned char _bytes[sizeof(Old)]; // NOSONAR cpp:S5945 raw byte snapshot
         ::std::memcpy(_bytes, oldp, sizeof(Old));
         try {
           ::std::construct_at(newp, ::std::forward<Args>(args)...);
@@ -360,7 +360,10 @@ template <class E> union _expected_union_t<void, E> {
   constexpr _expected_union_t &operator=(_expected_union_t const &) = delete;
   constexpr _expected_union_t &operator=(_expected_union_t &&) = delete;
 
-  constexpr explicit _expected_union_t(::std::in_place_t /*ignored*/) noexcept : v_{} {}
+  constexpr explicit _expected_union_t(::std::in_place_t /*ignored*/) noexcept
+      : v_{} // NOSONAR cpp:S3230 activates the member
+  {
+  }
 
   template <class... Args>
   constexpr explicit _expected_union_t(unexpect_t /*ignored*/, Args &&...a) //
@@ -385,7 +388,7 @@ template <class E> union _expected_union_t<void, E> {
   constexpr ~_expected_union_t() noexcept
     requires(::std::is_trivially_destructible_v<E>)
   = default;
-  constexpr ~_expected_union_t() noexcept {}
+  constexpr ~_expected_union_t() noexcept {} // NOSONAR cpp:S3490 non-trivial arm of the conditionally-trivial pair
 
   // [expected.void.assign] mandates direct construction (no temporary).
   template <typename New, typename Old, typename... Args>

--- a/include/pfn/optional.hpp
+++ b/include/pfn/optional.hpp
@@ -19,10 +19,10 @@
 #ifdef FWD
 #pragma push_macro("FWD")
 #define INCLUDE_PFN_OPTIONAL__POP_FWD
-#undef FWD
+#undef FWD // NOSONAR cpp:S959 saved by push_macro above
 #endif
 
-// Also defined in fn/detail/fwd_macro.hpp but pfn/* headers are standalone
+// Also defined in fn/detail/macro_fwd.hpp but pfn headers are standalone
 #define FWD(...) static_cast<decltype(__VA_ARGS__) &&>(__VA_ARGS__)
 
 #ifdef ASSERT
@@ -60,7 +60,7 @@ concept _is_derived_from_optional = requires(T const &t) { // exposition only
 // * noexcept of an expression itself (e.g. operator==) AND
 // * noexcept of the expression's implicit conversion to bool
 // May only be used in unevaluated contexts; any ODR-use will trigger a link error.
-// Also declared in pfn/expected.hpp (a benign redeclaration; pfn/* headers are standalone).
+// Also declared in pfn/expected.hpp (a benign redeclaration; pfn headers are standalone).
 constexpr bool _implicit_to_bool(bool) noexcept;
 
 template <typename> constexpr bool _is_some_optional = false;
@@ -312,12 +312,15 @@ template <class T> union _optional_union_t {
       : v_(FWD(a)...)
   {
   }
-  constexpr explicit _optional_union_t(::std::nullopt_t /*ignored*/) noexcept : e_{} {}
+  constexpr explicit _optional_union_t(::std::nullopt_t /*ignored*/) noexcept
+      : e_{} // NOSONAR cpp:S3230 activates the member
+  {
+  }
 
   constexpr ~_optional_union_t() noexcept
     requires(::std::is_trivially_destructible_v<T>)
   = default;
-  constexpr ~_optional_union_t() noexcept {}
+  constexpr ~_optional_union_t() noexcept {} // NOSONAR cpp:S3490 non-trivial arm of the conditionally-trivial pair
 
   // reinit, mirroring [expected.void.assign]'s direct construction: one of New/Old is
   // always the trivial `_dummy_t` (value <-> empty transition), so no strong-exception
@@ -918,7 +921,7 @@ public:
 
   // [optional.ctor], constructors
   constexpr optional() noexcept : _base(::std::nullopt) {}
-  constexpr optional(::std::nullopt_t) noexcept : _base(::std::nullopt) {}
+  constexpr optional(::std::nullopt_t) noexcept : _base(::std::nullopt) {} // NOSONAR cpp:S1709 implicit per spec
 
   constexpr optional(optional const &) = delete;
   constexpr optional(optional const &s)                   //
@@ -1150,7 +1153,7 @@ public:
 
   // [optional.ref.ctor], constructors
   constexpr optional() noexcept = default;
-  constexpr optional(::std::nullopt_t) noexcept : optional() {}
+  constexpr optional(::std::nullopt_t) noexcept : optional() {} // NOSONAR cpp:S1709 implicit per spec
   constexpr optional(optional const &rhs) noexcept = default;
 
   template <class Arg>

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -20,19 +20,120 @@ sonar.exclusions=.build*/**,**/_deps/**
 sonar.cpd.exclusions=**/*
 
 # Suppress selected SonarCloud issues (scope + rationale per entry):
-sonar.issue.ignore.multicriteria=e1,e2,e3
+sonar.issue.ignore.multicriteria=e1,e2,e3,e4,e5,e6,e7,e8,e9,e10,e11,e12,e13,x1,x2,x3,x4,x5,x6,x7,x8,x9,x10,x11,x12,x13,x14,x15,x16,x17,x18
 
-# e1 — cpp:S5145 (tainted input reaching an output sink), examples only: the demos read
-# input and print it back, which is the point of a demo, not an injection surface.
-sonar.issue.ignore.multicriteria.e1.ruleKey=cpp:S5145
-sonar.issue.ignore.multicriteria.e1.resourceKey=examples/**/*
-
-# e2 — cpp:S3659 (alternative operator tokens such as `not`), project-wide: deliberate
+# e1 — cpp:S3659 (alternative operator tokens such as `not`), project-wide: deliberate
 # readability choice — `not ` (with the trailing space) is harder to overlook than `!`.
-sonar.issue.ignore.multicriteria.e2.ruleKey=cpp:S3659
+sonar.issue.ignore.multicriteria.e1.ruleKey=cpp:S3659
+sonar.issue.ignore.multicriteria.e1.resourceKey=**/*
+
+# e2 — cpp:S3646 (types and variables declared in single statement), project-wide: deliberate
+# choice — single use type should not introduce complexity.
+sonar.issue.ignore.multicriteria.e2.ruleKey=cpp:S3646
 sonar.issue.ignore.multicriteria.e2.resourceKey=**/*
 
-# e3 — cpp:S3646 (types and variables declared in single statement), project-wide: deliberate
-# choice — single use type should not introduce complexity.
-sonar.issue.ignore.multicriteria.e3.ruleKey=cpp:S3646
+# e3 — cpp:S1135 (track TODO tags), project-wide: the TODO markers are mostly Doxygen
+# placeholder stanzas, tracked as a roadmap item — Sonar issues add nothing over `grep TODO`.
+sonar.issue.ignore.multicriteria.e3.ruleKey=cpp:S1135
 sonar.issue.ignore.multicriteria.e3.resourceKey=**/*
+
+# e4 — cpp:S6189 (name reused template parameters), project-wide: (constrained) `auto`
+# parameters with `decltype`/`FWD` are the codebase idiom; naming a template parameter for
+# every reused deduced type would bloat hundreds of already heavily templated signatures.
+sonar.issue.ignore.multicriteria.e4.ruleKey=cpp:S6189
+sonar.issue.ignore.multicriteria.e4.resourceKey=**/*
+
+# e5 — cpp:S6460 (extract ad-hoc requires-expression into a concept), project-wide: inline
+# requires-expressions spell single-use constraints where they apply; extraction would create
+# dozens of single-use concept names, and in pfn would hide the correspondence with the
+# Constraints wording of the ISO spec.
+sonar.issue.ignore.multicriteria.e5.ruleKey=cpp:S6460
+sonar.issue.ignore.multicriteria.e5.resourceKey=**/*
+
+# e6 — cpp:S2807 (binary operators as hidden friends), include only: the comparison operator
+# templates deliberately mirror the non-member operators of the ISO spec ([optional.relops],
+# [optional.comp.with.t]); sum/choice comparisons are heterogeneous across instantiations.
+sonar.issue.ignore.multicriteria.e6.ruleKey=cpp:S2807
+sonar.issue.ignore.multicriteria.e6.resourceKey=include/**/*
+
+# e7 — cpp:S5018 (move/swap should be unconditionally noexcept), include only: move and swap
+# carry a conditional noexcept exactly where the ISO spec mandates one ([optional.swap],
+# [expected.object.swap]); unconditional noexcept would be a lie for throwing types.
+sonar.issue.ignore.multicriteria.e7.ruleKey=cpp:S5018
+sonar.issue.ignore.multicriteria.e7.resourceKey=include/**/*
+
+# e8 — cpp:S5425 (forwarding reference parameters should be forwarded), include only: the
+# library is built on cvref-deducing parameters that are propagated via casts
+# (apply_const_lvalue_t, member access through FWD(self)) or deliberately read in place;
+# a literal std::forward call is not the only valid consumption.
+sonar.issue.ignore.multicriteria.e8.ruleKey=cpp:S5425
+sonar.issue.ignore.multicriteria.e8.resourceKey=include/**/*
+
+# e9 — cpp:S1448 (too many methods), include only: the classes mirror the API surface of
+# std::optional/std::expected, which the ISO spec defines with this many members.
+sonar.issue.ignore.multicriteria.e9.ruleKey=cpp:S1448
+sonar.issue.ignore.multicriteria.e9.resourceKey=include/**/*
+
+# e10 — cpp:S5421 (non-const global variables), traits header only: the flagged variable
+# templates are declared and never defined, pure decltype operands; adding const would
+# change the very types they are meant to compute.
+sonar.issue.ignore.multicriteria.e10.ruleKey=cpp:S5421
+sonar.issue.ignore.multicriteria.e10.resourceKey=include/fn/detail/traits.hpp
+
+# e11 — cpp:S6352 (result of std::move should be used in a function call), sum only: the
+# `::std::move(*this).data` idiom moves a member subobject; the xvalue member access is
+# consumed by the call on the same line.
+sonar.issue.ignore.multicriteria.e11.ruleKey=cpp:S6352
+sonar.issue.ignore.multicriteria.e11.resourceKey=include/fn/sum.hpp
+
+# e12 — cpp:S6461 (declval inside requires-expression), concepts header only: declval
+# preserves the value category of the tested expression; a requires-expression parameter
+# is always an lvalue, so the suggested rewrite would test a different conversion.
+sonar.issue.ignore.multicriteria.e12.ruleKey=cpp:S6461
+sonar.issue.ignore.multicriteria.e12.resourceKey=include/fn/concepts.hpp
+
+# e13 — cpp:S6020 (use the _t/_v trait forms), pack_impl only: `::std::invoke_result<...>::type`
+# and `::std::is_invocable<...>::value` match the adjacent fn-detail traits, which exist only in
+# struct form; this spelling was settled in the MSVC port — do not churn it for style.
+sonar.issue.ignore.multicriteria.e13.ruleKey=cpp:S6020
+sonar.issue.ignore.multicriteria.e13.resourceKey=include/fn/detail/pack_impl.hpp
+
+# x1..x18 — examples are demo code and do not adhere to the strict standards of include/;
+# suppressed per rule observed there rather than wholesale, so that new rule types still
+# surface for a human decision.
+sonar.issue.ignore.multicriteria.x1.ruleKey=cpp:S1110
+sonar.issue.ignore.multicriteria.x1.resourceKey=examples/**/*
+sonar.issue.ignore.multicriteria.x2.ruleKey=cpp:S1117
+sonar.issue.ignore.multicriteria.x2.resourceKey=examples/**/*
+sonar.issue.ignore.multicriteria.x3.ruleKey=cpp:S1186
+sonar.issue.ignore.multicriteria.x3.resourceKey=examples/**/*
+sonar.issue.ignore.multicriteria.x4.ruleKey=cpp:S1188
+sonar.issue.ignore.multicriteria.x4.resourceKey=examples/**/*
+sonar.issue.ignore.multicriteria.x5.ruleKey=cpp:S1238
+sonar.issue.ignore.multicriteria.x5.resourceKey=examples/**/*
+sonar.issue.ignore.multicriteria.x6.ruleKey=cpp:S134
+sonar.issue.ignore.multicriteria.x6.resourceKey=examples/**/*
+sonar.issue.ignore.multicriteria.x7.ruleKey=cpp:S1709
+sonar.issue.ignore.multicriteria.x7.resourceKey=examples/**/*
+sonar.issue.ignore.multicriteria.x8.ruleKey=cpp:S1905
+sonar.issue.ignore.multicriteria.x8.resourceKey=examples/**/*
+sonar.issue.ignore.multicriteria.x9.ruleKey=cpp:S3574
+sonar.issue.ignore.multicriteria.x9.resourceKey=examples/**/*
+sonar.issue.ignore.multicriteria.x10.ruleKey=cpp:S3608
+sonar.issue.ignore.multicriteria.x10.resourceKey=examples/**/*
+sonar.issue.ignore.multicriteria.x11.ruleKey=cpp:S3642
+sonar.issue.ignore.multicriteria.x11.resourceKey=examples/**/*
+sonar.issue.ignore.multicriteria.x12.ruleKey=cpp:S5276
+sonar.issue.ignore.multicriteria.x12.resourceKey=examples/**/*
+sonar.issue.ignore.multicriteria.x13.ruleKey=cpp:S5415
+sonar.issue.ignore.multicriteria.x13.resourceKey=examples/**/*
+sonar.issue.ignore.multicriteria.x14.ruleKey=cpp:S5425
+sonar.issue.ignore.multicriteria.x14.resourceKey=examples/**/*
+sonar.issue.ignore.multicriteria.x15.ruleKey=cpp:S5500
+sonar.issue.ignore.multicriteria.x15.resourceKey=examples/**/*
+sonar.issue.ignore.multicriteria.x16.ruleKey=cpp:S6004
+sonar.issue.ignore.multicriteria.x16.resourceKey=examples/**/*
+sonar.issue.ignore.multicriteria.x17.ruleKey=cpp:S6226
+sonar.issue.ignore.multicriteria.x17.resourceKey=examples/**/*
+sonar.issue.ignore.multicriteria.x18.ruleKey=cpp:S5145
+sonar.issue.ignore.multicriteria.x18.resourceKey=examples/**/*


### PR DESCRIPTION
## Interface changes

- `sum(std::in_place_type_t<T>, args...)` and `choice(std::in_place_type_t<T>, args...)`  are now `explicit`, matching the convention of every in-place-tagged constructor in the  standard library (`std::optional`, `std::expected`, `std::variant`). Copy-list-init  through a disambiguation tag (`sum<int> s = {std::in_place_type<int>, 42};`) no longer  compiles; direct-init is unaffected. Nothing in the library, tests or examples used the  removed form.

## Fixes

- `pfn/optional.hpp` referred to `fn/detail/fwd_macro.hpp`, stale since the rename to  `macro_fwd.hpp`; comments no longer contain the `pfn/*` glob (misleading `/*`).
- `detail::normalized`: the nested `_uniqued::size` member shadowed the outer static  `size`; renamed to `count`.
- Removed redundant `final` on the `variadic_union` specializations (unions cannot be  base classes), redundant `inline` on two `constexpr` functions, and redundant  parentheses in two constraint chains.

## Modernization

- `detail/meta.hpp` uses the constrained ranges algorithms (`ranges::generate/sort/unique`)  and `is_same_v`; validated on gcc/clang (libstdc++/libc++) locally and MSVC.
- The from-invoke thunk lambdas capture `[&fn, &self]` explicitly instead of `[&]`  (including the unflagged parallel case in `value_or.hpp`).
- `variadic_union.hpp` uses the concatenated `namespace fn::detail`.

## SonarQube

All 480 open issues triaged. Beyond the fixes above:

- ~30 site-specific false positives are suppressed with `// NOSONAR cpp:SXXXX <reason>`.  Several of Sonar's proposed fixes would have been genuine breakage: `= default` on the  union destructors would be *deleted* for non-trivial members, removing the `: e_{}` /  `: v_{}` initializers would leave the union with no active member, and replacing  `declval` in requires-expressions with a parameter would test the wrong value category.
- `sonar-project.properties` gains scoped exemptions for rules that are systematically  inapplicable: project-wide (TODO tags, `auto`-parameter idiom, ad-hoc requires),  include-only where the ISO spec mandates the flagged shape (non-member comparison  templates, conditional noexcept on move/swap, API surface size), and per-file clusters.  Entries are now grouped: `e*` = general/include, `x*` = examples (exempted per rule  observed there, not wholesale).

Assisted-by: Claude:claude-fable-5