### PR TITLE
Implement P3168 `optional` range support

### DIFF
--- a/include/fn/optional.hpp
+++ b/include/fn/optional.hpp
@@ -25,8 +25,105 @@ concept some_optional = detail::_some_optional<T>;
 
 namespace detail {
 
+// [optional.iterators]: the implementation-defined iterator types for fn::optional. A
+// minimal wrapper over T* whose job is to keep pointer-ness out of optional interface.
+template <class T> class _optional_iterator {
+  static_assert(::std::is_object_v<T>);
+
+  T *p_ = nullptr;
+
+  // Only an optional's base mints iterators from storage pointers; the sibling friendship
+  // lets the iterator -> const_iterator converting constructor read p_.
+  template <class, class> friend struct ::pfn::detail::_optional_base;
+  template <class> friend class _optional_iterator;
+
+  constexpr explicit _optional_iterator(T *p) noexcept : p_(p) {}
+
+public:
+  using iterator_concept = ::std::contiguous_iterator_tag;
+  using iterator_category = ::std::random_access_iterator_tag;
+  using value_type = ::std::remove_cv_t<T>;
+  using difference_type = ::std::ptrdiff_t;
+  using pointer = T *;
+  using reference = T &;
+
+  constexpr _optional_iterator() noexcept = default;
+
+  // iterator -> const_iterator, required by the container iterator requirements
+  template <class U>
+    requires ::std::is_same_v<U const, T>
+  constexpr _optional_iterator(_optional_iterator<U> const &other) noexcept // NOSONAR cpp:S1709 implicit per spec
+      : p_(other.p_)
+  {
+  }
+
+  [[nodiscard]] constexpr T &operator*() const noexcept { return *p_; }
+  [[nodiscard]] constexpr T *operator->() const noexcept { return p_; } // std::to_address requires this
+  [[nodiscard]] constexpr T &operator[](difference_type n) const noexcept { return p_[n]; }
+
+  constexpr _optional_iterator &operator++() noexcept
+  {
+    ++p_;
+    return *this;
+  }
+  constexpr _optional_iterator operator++(int) noexcept
+  {
+    auto r = *this;
+    ++p_;
+    return r;
+  }
+  constexpr _optional_iterator &operator--() noexcept
+  {
+    --p_;
+    return *this;
+  }
+  constexpr _optional_iterator operator--(int) noexcept
+  {
+    auto r = *this;
+    --p_;
+    return r;
+  }
+  constexpr _optional_iterator &operator+=(difference_type n) noexcept
+  {
+    p_ += n;
+    return *this;
+  }
+  constexpr _optional_iterator &operator-=(difference_type n) noexcept
+  {
+    p_ -= n;
+    return *this;
+  }
+
+  [[nodiscard]] constexpr friend _optional_iterator operator+(_optional_iterator i, difference_type n) noexcept
+  {
+    return i += n;
+  }
+  [[nodiscard]] constexpr friend _optional_iterator operator+(difference_type n, _optional_iterator i) noexcept
+  {
+    return i += n;
+  }
+  [[nodiscard]] constexpr friend _optional_iterator operator-(_optional_iterator i, difference_type n) noexcept
+  {
+    return i -= n;
+  }
+  [[nodiscard]] constexpr friend difference_type operator-(_optional_iterator const &x,
+                                                           _optional_iterator const &y) noexcept
+  {
+    return x.p_ - y.p_;
+  }
+
+  [[nodiscard]] constexpr friend bool operator==(_optional_iterator const &, _optional_iterator const &) noexcept
+      = default;
+  [[nodiscard]] constexpr friend ::std::strong_ordering operator<=>(_optional_iterator const &x,
+                                                                    _optional_iterator const &y) noexcept
+  {
+    return x.p_ <=> y.p_;
+  }
+};
+
 struct optional_policy {
   template <class U> using type = ::fn::optional<U>;
+  template <class U> using iterator = _optional_iterator<U>;
   template <class X> static constexpr bool is_specialization = _is_some_optional<X &>;
 };
 
@@ -159,6 +256,9 @@ template <typename T> class optional : private detail::_optional_base<T> { // NO
 
 public:
   using value_type = T;
+  // [optional.iterators]: mirrors pfn::optional, with fn's own iterator type
+  using iterator = detail::_optional_iterator<T>;
+  using const_iterator = detail::_optional_iterator<T const>;
 
   // Constructors. Explicit forwarders to the base mirror pfn::optional.
   constexpr optional() noexcept : _base(::std::nullopt) {}
@@ -283,6 +383,10 @@ public:
     static_assert(::std::is_move_constructible_v<T>);
     this->_swap_with(rhs);
   }
+
+  // Iterator support inherited from _optional_base, mirrors pfn::optional
+  using _base::begin;
+  using _base::end;
 
   // Observers inherited from _optional_base
   using _base::has_value;
@@ -436,6 +540,8 @@ template <class T> class optional<T &> : private detail::_optional_base<T &> {
 
 public:
   using value_type = T;
+  // [optional.ref.iterators]: mirrors pfn::optional, with fn's own iterator type
+  using iterator = detail::_optional_iterator<T>;
 
   // Constructors. Explicit forwarders to the base mirror pfn::optional.
   constexpr optional() noexcept = default;
@@ -503,6 +609,10 @@ public:
 
   // Swap; body delegates to _optional_base helper
   constexpr void swap(optional &rhs) noexcept { this->_swap_with(rhs); }
+
+  // Iterator support inherited from _optional_base, mirrors pfn::optional
+  using _base::begin;
+  using _base::end;
 
   // Observers inherited from _optional_base
   using _base::has_value;
@@ -780,6 +890,17 @@ namespace std {
 // hash support, reusing pfn's [optional.hash] machinery (enabled iff hash<remove_const_t<T>>
 // is enabled, hence never for reference types)
 template <class T> struct hash<::fn::optional<T>> : ::pfn::detail::_optional_hash_base<::fn::optional<T>, T> {};
+
+#if defined(__cpp_lib_format_ranges)
+// range-format opt-out, mirroring pfn's [optional.syn] specialization
+template <class T> constexpr range_format format_kind<::fn::optional<T>> = range_format::disabled;
+#endif
+
+// view opt-in, mirroring pfn's [optional.syn] specialization (nested-namespace block for
+// MSVC, as in pfn/optional.hpp)
+namespace ranges {
+template <class T> constexpr bool enable_view<::fn::optional<T>> = true;
+} // namespace ranges
 } // namespace std
 
 #endif // INCLUDE_FN_OPTIONAL

--- a/include/pfn/optional.hpp
+++ b/include/pfn/optional.hpp
@@ -13,8 +13,14 @@
 #include <functional>
 #include <memory>
 #include <optional> // For anything that is not std::optional or std::make_optional
+#include <ranges>   // For std::ranges::enable_view
 #include <type_traits>
 #include <utility>
+#include <version>
+
+#if defined(__cpp_lib_format_ranges)
+#include <format> // For std::format_kind
+#endif
 
 #ifdef FWD
 #pragma push_macro("FWD")
@@ -591,6 +597,19 @@ template <class T, class Policy> struct _optional_base {
     return storage_.v_;
   }
 
+  // [optional.iterators], iterator support. The Policy picks which library's iterator
+  // wrapper is minted here, so fn::optional never exposes a pfn type. A disengaged
+  // optional hands out the empty range (nullptr, nullptr).
+  using iterator = typename Policy::template iterator<T>;
+  using const_iterator = typename Policy::template iterator<T const>;
+  [[nodiscard]] constexpr iterator begin() noexcept { return iterator(set_ ? ::std::addressof(storage_.v_) : nullptr); }
+  [[nodiscard]] constexpr const_iterator begin() const noexcept
+  {
+    return const_iterator(set_ ? ::std::addressof(storage_.v_) : nullptr);
+  }
+  [[nodiscard]] constexpr iterator end() noexcept { return begin() + has_value(); }
+  [[nodiscard]] constexpr const_iterator end() const noexcept { return begin() + has_value(); }
+
   // [optional.observe], observers
   constexpr T const *operator->() const noexcept
   {
@@ -798,6 +817,13 @@ template <class T, class Policy> struct _optional_base<T &, Policy> {
   constexpr void _swap_with(_optional_base &rhs) noexcept { ::std::swap(v_, rhs.v_); }
   constexpr void reset() noexcept { v_ = nullptr; }
 
+  // [optional.ref.iterators], iterator support; const-only like the observers below. The
+  // draft's "present only if T is an object type other than an array of unknown bound" is
+  // vacuously satisfied: _is_valid_optional already rejects any other referent.
+  using iterator = typename Policy::template iterator<T>;
+  [[nodiscard]] constexpr iterator begin() const noexcept { return iterator(v_); }
+  [[nodiscard]] constexpr iterator end() const noexcept { return begin() + has_value(); }
+
   // [optional.ref.observe], observers. Unlike optional<T>, const does not propagate to the
   // referent: *this being const only means the stored pointer can't be rebound, not that T
   // becomes T const -- so these all return plain T&/T*, and there is only ever one overload
@@ -869,8 +895,106 @@ template <class T, class Policy> struct _optional_base<T &, Policy> {
   }
 };
 
+// [optional.iterators]: the implementation-defined iterator types for pfn::optional. A minimal
+// wrapper over T* whose job is to keep pointer-ness out of optional interface. Only what mandated
+// by contiguous_iterator, Cpp17RandomAccessIterator and the container iterator requirements.
+template <class T> class _optional_iterator {
+  static_assert(::std::is_object_v<T>);
+
+  T *p_ = nullptr;
+
+  // Only an optional's base mints iterators from storage pointers; the sibling friendship
+  // lets the iterator -> const_iterator converting constructor read p_.
+  template <class, class> friend struct _optional_base;
+  template <class> friend class _optional_iterator;
+
+  constexpr explicit _optional_iterator(T *p) noexcept : p_(p) {}
+
+public:
+  using iterator_concept = ::std::contiguous_iterator_tag;
+  using iterator_category = ::std::random_access_iterator_tag;
+  using value_type = ::std::remove_cv_t<T>;
+  using difference_type = ::std::ptrdiff_t;
+  using pointer = T *;
+  using reference = T &;
+
+  constexpr _optional_iterator() noexcept = default;
+
+  // iterator -> const_iterator, required by the container iterator requirements
+  template <class U>
+    requires ::std::is_same_v<U const, T>
+  constexpr _optional_iterator(_optional_iterator<U> const &other) noexcept // NOSONAR cpp:S1709 implicit per spec
+      : p_(other.p_)
+  {
+  }
+
+  [[nodiscard]] constexpr T &operator*() const noexcept { return *p_; }
+  [[nodiscard]] constexpr T *operator->() const noexcept { return p_; } // std::to_address requires this
+  [[nodiscard]] constexpr T &operator[](difference_type n) const noexcept { return p_[n]; }
+
+  constexpr _optional_iterator &operator++() noexcept
+  {
+    ++p_;
+    return *this;
+  }
+  constexpr _optional_iterator operator++(int) noexcept
+  {
+    auto r = *this;
+    ++p_;
+    return r;
+  }
+  constexpr _optional_iterator &operator--() noexcept
+  {
+    --p_;
+    return *this;
+  }
+  constexpr _optional_iterator operator--(int) noexcept
+  {
+    auto r = *this;
+    --p_;
+    return r;
+  }
+  constexpr _optional_iterator &operator+=(difference_type n) noexcept
+  {
+    p_ += n;
+    return *this;
+  }
+  constexpr _optional_iterator &operator-=(difference_type n) noexcept
+  {
+    p_ -= n;
+    return *this;
+  }
+
+  [[nodiscard]] constexpr friend _optional_iterator operator+(_optional_iterator i, difference_type n) noexcept
+  {
+    return i += n;
+  }
+  [[nodiscard]] constexpr friend _optional_iterator operator+(difference_type n, _optional_iterator i) noexcept
+  {
+    return i += n;
+  }
+  [[nodiscard]] constexpr friend _optional_iterator operator-(_optional_iterator i, difference_type n) noexcept
+  {
+    return i -= n;
+  }
+  [[nodiscard]] constexpr friend difference_type operator-(_optional_iterator const &x,
+                                                           _optional_iterator const &y) noexcept
+  {
+    return x.p_ - y.p_;
+  }
+
+  [[nodiscard]] constexpr friend bool operator==(_optional_iterator const &, _optional_iterator const &) noexcept
+      = default;
+  [[nodiscard]] constexpr friend ::std::strong_ordering operator<=>(_optional_iterator const &x,
+                                                                    _optional_iterator const &y) noexcept
+  {
+    return x.p_ <=> y.p_;
+  }
+};
+
 struct optional_policy {
   template <class T> using type = ::pfn::optional<T>;
+  template <class T> using iterator = _optional_iterator<T>;
   template <class X> static constexpr bool is_specialization = _is_some_optional<X>;
 };
 
@@ -918,6 +1042,9 @@ template <class T> class optional : private detail::_optional_base<T, detail::op
 
 public:
   using value_type = T;
+  // [optional.iterators]: the iterator types are implementation-defined
+  using iterator = detail::_optional_iterator<T>;
+  using const_iterator = detail::_optional_iterator<T const>;
 
   // [optional.ctor], constructors
   constexpr optional() noexcept : _base(::std::nullopt) {}
@@ -1042,6 +1169,10 @@ public:
     this->_swap_with(rhs);
   }
 
+  // [optional.iterators], iterator support
+  using _base::begin;
+  using _base::end;
+
   // [optional.observe], observers
   using _base::has_value;
   using _base::operator bool;
@@ -1150,6 +1281,8 @@ template <class T> class optional<T &> : private detail::_optional_base<T &, det
 
 public:
   using value_type = T;
+  // [optional.ref.iterators]: the iterator type is implementation-defined
+  using iterator = detail::_optional_iterator<T>;
 
   // [optional.ref.ctor], constructors
   constexpr optional() noexcept = default;
@@ -1215,6 +1348,10 @@ public:
 
   // [optional.ref.swap], swap
   constexpr void swap(optional &rhs) noexcept { this->_swap_with(rhs); }
+
+  // [optional.ref.iterators], iterator support
+  using _base::begin;
+  using _base::end;
 
   // [optional.ref.observe], observers
   using _base::has_value;
@@ -1471,6 +1608,18 @@ constexpr optional<T> make_optional(::std::initializer_list<U> il, Args &&...arg
 namespace std {
 // [optional.hash], hash support
 template <class T> struct hash<::pfn::optional<T>> : ::pfn::detail::_optional_hash_base<::pfn::optional<T>, T> {};
+
+#if defined(__cpp_lib_format_ranges)
+// [optional.syn]: an optional is never formatted as a range
+template <class T> constexpr range_format format_kind<::pfn::optional<T>> = range_format::disabled;
+#endif
+
+// [optional.syn]: an optional is a view of at most one element. The nested-namespace block
+// mirrors MSVC's own STL (e.g. span): a qualified definition draws C2888 and the compound
+// `namespace std::ranges` form is not reliably matched by MSVC either.
+namespace ranges {
+template <class T> constexpr bool enable_view<::pfn::optional<T>> = true;
+} // namespace ranges
 } // namespace std
 
 #undef ASSERT

--- a/tests/pfn/optional.cpp
+++ b/tests/pfn/optional.cpp
@@ -1038,6 +1038,136 @@ TEST_CASE("optional", "[optional][polyfill]")
     }
   }
 
+#if !defined(PFN_TEST_VALIDATION) || defined(__cpp_lib_optional_range_support)
+  SECTION("iterator support")
+  {
+    static_assert(std::contiguous_iterator<optional<int>::iterator>);
+    static_assert(std::contiguous_iterator<optional<int>::const_iterator>);
+    static_assert(std::is_same_v<std::iter_value_t<optional<int const>::iterator>, int>);
+    static_assert(std::is_same_v<std::iter_reference_t<optional<int>::iterator>, int &>);
+    static_assert(std::is_same_v<std::iter_reference_t<optional<int>::const_iterator>, int const &>);
+    static_assert(std::ranges::contiguous_range<optional<int>>);
+    static_assert(std::ranges::enable_view<optional<int>>);
+#if defined(__cpp_lib_format_ranges)
+    static_assert(std::format_kind<optional<int>> == std::range_format::disabled);
+#endif
+
+    SECTION("engaged")
+    {
+      optional<int> o{std::in_place, 42};
+
+      SECTION("mutable")
+      {
+        CHECK(o.end() - o.begin() == 1);
+        CHECK(std::addressof(*o.begin()) == std::addressof(*o));
+
+        SECTION("write-through")
+        {
+          *o.begin() += 1;
+          CHECK(*o == 43);
+        }
+      }
+
+      SECTION("const")
+      {
+        auto const &c = o;
+        static_assert(std::is_same_v<decltype(*c.begin()), int const &>);
+        CHECK(c.end() - c.begin() == 1);
+        CHECK(std::addressof(*c.begin()) == std::addressof(*o));
+      }
+
+      SECTION("range-based for")
+      {
+        int count = 0;
+        for (auto &v : o) {
+          CHECK(v == 42);
+          count += 1;
+        }
+        CHECK(count == 1);
+      }
+
+      SECTION("iterator operations")
+      {
+        auto it = o.begin();
+        auto const e = o.end();
+        CHECK(*it == 42);
+        CHECK(it[0] == 42);
+        CHECK(it != e);
+        CHECK(it < e);
+        CHECK(it <= e);
+        CHECK(e > it);
+        CHECK(e >= it);
+        CHECK(++it == e);
+        CHECK(--it == o.begin());
+        CHECK(it++ == o.begin());
+        CHECK(it-- == e);
+        CHECK(it + 1 == e);
+        CHECK(1 + it == e);
+        CHECK(e - 1 == it);
+        CHECK(e - it == 1);
+        it += 1;
+        CHECK(it == e);
+        it -= 1;
+        CHECK(it == o.begin());
+
+        SECTION("conversion to const_iterator")
+        {
+          optional<int>::const_iterator cit = it;
+          CHECK(cit == it);
+          CHECK(it == cit);
+          CHECK(it - cit == 0);
+        }
+
+        SECTION("member access")
+        {
+          struct pt {
+            int x;
+          };
+          optional<pt> p{std::in_place, pt{7}};
+          CHECK(p.begin()->x == 7);
+        }
+      }
+    }
+
+    SECTION("disengaged")
+    {
+      optional<int> o{};
+
+      SECTION("mutable") { CHECK(o.begin() == o.end()); }
+
+      SECTION("const")
+      {
+        auto const &c = o;
+        CHECK(c.begin() == c.end());
+      }
+
+      SECTION("range-based for")
+      {
+        int count = 0;
+        for ([[maybe_unused]] auto &v : o)
+          count += 1;
+        CHECK(count == 0);
+      }
+    }
+
+    SECTION("constexpr")
+    {
+      static_assert([] {
+        optional<int> o{std::in_place, 7};
+        int n = 0;
+        for (auto v : o)
+          n += v;
+        return n == 7;
+      }());
+      static_assert([] {
+        optional<int> o{};
+        return o.begin() == o.end();
+      }());
+      SUCCEED();
+    }
+  }
+#endif
+
   SECTION("accessors")
   {
     SECTION("value")
@@ -2187,6 +2317,59 @@ TEST_CASE("optional reference", "[optional_ref][polyfill]")
         T b(std::in_place, y);
         a.swap(b);
         return &*a == &y && &*b == &x && x == 1 && y == 2;
+      }());
+      SUCCEED();
+    }
+  }
+
+  SECTION("iterator support")
+  {
+    static_assert(std::contiguous_iterator<optional<int &>::iterator>);
+    static_assert(std::is_same_v<std::iter_value_t<optional<int const &>::iterator>, int>);
+    static_assert(std::is_same_v<std::iter_reference_t<optional<int &>::iterator>, int &>);
+    static_assert(std::ranges::contiguous_range<optional<int &>>);
+    static_assert(std::ranges::enable_view<optional<int &>>);
+    // const-only single overload, like the observers: const does not propagate to the referent
+    static_assert(std::is_same_v<decltype(std::declval<optional<int &> const &>().begin()), //
+                                 optional<int &>::iterator>);
+
+    SECTION("engaged")
+    {
+      int x = 42;
+      optional<int &> const o{std::in_place, x};
+
+      SECTION("referent identity")
+      {
+        CHECK(o.end() - o.begin() == 1);
+        CHECK(std::addressof(*o.begin()) == std::addressof(x));
+      }
+
+      SECTION("write-through")
+      {
+        for (auto &v : o)
+          v += 1;
+        CHECK(x == 43);
+      }
+    }
+
+    SECTION("disengaged")
+    {
+      optional<int &> const o{};
+      CHECK(o.begin() == o.end());
+      int count = 0;
+      for ([[maybe_unused]] auto &v : o)
+        count += 1;
+      CHECK(count == 0);
+    }
+
+    SECTION("constexpr")
+    {
+      static_assert([] {
+        int x = 3;
+        optional<int &> const o{std::in_place, x};
+        for (auto &v : o)
+          v += 4;
+        return x == 7 && std::addressof(*o.begin()) == std::addressof(x);
       }());
       SUCCEED();
     }

--- a/tests/pfn/optional.cpp
+++ b/tests/pfn/optional.cpp
@@ -1126,6 +1126,35 @@ TEST_CASE("optional", "[optional][polyfill]")
           optional<pt> p{std::in_place, pt{7}};
           CHECK(p.begin()->x == 7);
         }
+
+        SECTION("constexpr")
+        {
+          static_assert([] {
+            optional<int> a{std::in_place, 42};
+            auto i = a.begin();
+            auto const s = a.end();
+            bool ok = *i == 42 && i[0] == 42 && i != s && i < s && i <= s && s > i && s >= i;
+            ok = ok && ++i == s;
+            ok = ok && --i == a.begin();
+            ok = ok && i++ == a.begin();
+            ok = ok && i-- == s;
+            ok = ok && i + 1 == s && 1 + i == s && s - 1 == i && s - i == 1;
+            i += 1;
+            ok = ok && i == s;
+            i -= 1;
+            ok = ok && i == a.begin();
+            optional<int>::const_iterator ci = i;
+            return ok && ci == i && i == ci && i - ci == 0;
+          }());
+          static_assert([] {
+            struct pt {
+              int x;
+            };
+            optional<pt> p{std::in_place, pt{7}};
+            return p.begin()->x == 7;
+          }());
+          SUCCEED();
+        }
       }
     }
 


### PR DESCRIPTION
Implements [P3168](https://wg21.link/p3168) (C++26 "Give std::optional Range Support"), verified against the current draft's [optional.iterators](https://wg21.link/optional.iterators) and [optional.ref.iterators](https://wg21.link/optional.ref.iterators) wording rather than the paper (they have drifted).

## pfn

- `optional<T>` gains `iterator`/`const_iterator` and `begin()`/`end()` (2 overloads  each); `optional<T&>` gains `iterator` and const-only `begin()`/`end()`, matching its  observers (const does not propagate to the referent). `end()` is `begin() + has_value()`;  a disengaged optional hands out the empty `(nullptr, nullptr)` range, avoiding any  address-of-inactive-union-member question in constant evaluation.
- The iterator is a minimal wrapper over `T*` (`detail::_optional_iterator<T>`;  `const_iterator` = the same template at `T const`): models `contiguous_iterator`,  meets Cpp17RandomAccessIterator and the container iterator requirements, fully  constexpr and unconditionally noexcept — and exposes nothing beyond that (no raw  pointer conversions, no user construction; Hyrum's law). The `iterator` →  `const_iterator` conversion is a single constrained constructor.
- `[optional.syn]` extras: `ranges::enable_view<optional<T>> = true` and  `format_kind<optional<T>> = range_format::disabled`, the latter gated on  `__cpp_lib_format_ranges` to keep the header C++20-clean. The `enable_view`  specialization is spelled as a nested `namespace ranges` block inside `namespace std`,  mirroring MSVC's own STL — the qualified form draws C2888 and the compound  `namespace std::ranges` form is not reliably matched by MSVC.

## fn

`fn::optional` mirrors all of the above through the shared base: the `Policy` parameter gains an `iterator` alias, so pfn's base mints each library's own iterator type — `fn::optional`'s iterators are `fn::detail::_optional_iterator`, and no pfn type is reachable through fn's interface. The iterator class is deliberately mirrored rather than shared or inherited: the iterator concepts require exact-type signatures (`{ i += n } -> same_as<I&>`), so every conforming design must spell the operator surface once per final type — inheritance would only add inaccessible-conversion and return-type problems, and a shared owner-tagged template would put `pfn::detail` template-ids into fn diagnostics. The two copies are frozen by the standard's requirements and both run the same conformance suite on every build.

## Tests

New `SECTION("iterator support")` in both `optional` TEST_CASEs, nested by dimension: static concept/alias properties, engaged (mutable / const / range-based for / the full mandated operator surface at runtime, including the const-conversion and `operator->`), disengaged, and constexpr. Everything asserted is draft-mandated behaviour — never the implementation-defined iterator type identity — so the same sections validate against real `std::optional` implementations (gated on `__cpp_lib_optional_range_support`, gcc-15+ lanes) and against `fn::optional` through the nested polyfill suite.

Assisted-by: Claude:claude-fable-5