### PR TITLE
Add the RPN calculator example

### DIFF
--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -2,3 +2,4 @@ cmake_minimum_required(VERSION 3.25)
 
 add_subdirectory(simple)
 add_subdirectory(polygon)
+add_subdirectory(calculator)

--- a/examples/calculator/CMakeLists.txt
+++ b/examples/calculator/CMakeLists.txt
@@ -1,0 +1,70 @@
+cmake_minimum_required(VERSION 3.25)
+project(examples_calculator)
+
+set(CMAKE_CXX_EXTENSIONS OFF)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+
+# Pls keep the filenames sorted
+set(EXAMPLES_CALCULATOR_SOURCES
+    calculator.hpp
+    main.cpp
+)
+
+foreach(mode 20 23)
+    if (NOT VALIDATE_CXX23 AND mode EQUAL 23)
+        continue()
+    endif()
+
+    # Current releases of MSVC only support C++20
+    if(MSVC AND NOT (mode EQUAL 20))
+        continue()
+    endif()
+
+    set(target "examples_calculator_cxx${mode}")
+
+    add_executable("${target}" ${EXAMPLES_CALCULATOR_SOURCES})
+    target_link_libraries("${target}" include_fn)
+    append_compilation_options("${target}" WARNINGS)
+    add_dependencies("cxx${mode}" "${target}")
+    add_dependencies("examples" "${target}")
+    set_property(TARGET "${target}" PROPERTY CXX_STANDARD "${mode}")
+    target_compile_definitions("${target}" PRIVATE LIBFN_MODE=${mode})
+
+    unset(target)
+endforeach()
+
+set(TESTS_EXAMPLES_CALCULATOR_SOURCES
+    calculator.hpp
+    test.cpp
+)
+
+foreach(mode 20 23)
+    if (NOT VALIDATE_CXX23 AND mode EQUAL 23)
+        continue()
+    endif()
+
+    # Current releases of MSVC only support C++20
+    if(MSVC AND NOT (mode EQUAL 20))
+        continue()
+    endif()
+
+    set(target "tests_examples_calculator_cxx${mode}")
+
+    add_executable("${target}" ${TESTS_EXAMPLES_CALCULATOR_SOURCES})
+    target_link_libraries("${target}" include_fn Catch2::Catch2WithMain)
+    append_compilation_options("${target}" WARNINGS OPTIMIZATION)
+    add_dependencies("cxx${mode}" "${target}")
+    add_dependencies("examples" "${target}")
+    add_dependencies("tests" "${target}")
+    set_property(TARGET "${target}" PROPERTY CXX_STANDARD "${mode}")
+    target_compile_definitions("${target}" PRIVATE LIBFN_MODE=${mode})
+
+    add_test(
+        NAME "${target}"
+        COMMAND "${target}" -r console
+        WORKING_DIRECTORY ${CMAKE_BINARY_DIR}
+    )
+    set_property(TEST "${target}" PROPERTY LABELS examples "cxx${mode}")
+
+    unset(target)
+endforeach()

--- a/examples/calculator/calculator.hpp
+++ b/examples/calculator/calculator.hpp
@@ -1,0 +1,209 @@
+// Copyright (c) 2026 Bronek Kozicki
+//
+// Distributed under the ISC License. See accompanying file LICENSE.md
+// or copy at https://opensource.org/licenses/ISC
+
+#ifndef EXAMPLES_CALCULATOR_CALCULATOR
+#define EXAMPLES_CALCULATOR_CALCULATOR
+
+#include "fn/and_then.hpp"
+#include "fn/expected.hpp"
+#include "fn/pack.hpp"
+#include "fn/transform.hpp"
+#include "fn/utility.hpp"
+
+#include <cerrno>
+#include <cstdlib>
+#include <iterator>
+#include <limits>
+#include <sstream>
+#include <string>
+#include <string_view>
+#include <utility>
+#include <vector>
+
+namespace calc {
+
+// A number is a long or a double, selected by the input's spelling — a type-indexed sum
+using Number = fn::sum<double, long>;
+using Stack = std::vector<Number>;
+
+enum class ParseError { UnknownToken };
+enum class StackError { NotEnoughOperands };
+enum class MathError { DivisionByZero, NotIntegral, Overflow };
+
+// Each step contributes its own error type; the API exposes their sum
+using Error = fn::sum<MathError, ParseError, StackError>;
+using Result = fn::expected<Stack, Error>;
+
+// An operation is a tiny struct: argument_count says how many operands it pops. A parsed number is
+// itself an operation — the nullary Push of its value — so a whole line is a sequence of operations.
+struct Add {
+  static constexpr int argument_count = 2;
+};
+struct Div {
+  static constexpr int argument_count = 2;
+};
+struct Drop {
+  static constexpr int argument_count = 1;
+};
+struct Dup {
+  static constexpr int argument_count = 1;
+};
+struct Mod {
+  static constexpr int argument_count = 2;
+};
+struct Mul {
+  static constexpr int argument_count = 2;
+};
+struct Push {
+  static constexpr int argument_count = 0;
+  Number value;
+};
+struct Sub {
+  static constexpr int argument_count = 2;
+};
+struct Swap {
+  static constexpr int argument_count = 2;
+};
+using Operation = fn::sum<Add, Div, Drop, Dup, Mod, Mul, Push, Sub, Swap>;
+
+// "42", "052" and "0x2a" are long, "2.5", "1e-3" and ".5" are double; a long overflow promotes to double
+inline auto parse(std::string const &token) -> fn::expected<Number, ParseError>
+{
+  char const *last = token.data() + token.size();
+  char *end = {};
+  errno = 0;
+  if (long const i = std::strtol(token.data(), &end, 0); end == last && end != token.data() && errno == 0)
+    return Number{i};
+  if (double const d = std::strtod(token.data(), &end); end == last && end != token.data())
+    return Number{d};
+  return pfn::unexpected(ParseError::UnknownToken);
+}
+
+inline auto lookup(std::string const &token) -> fn::expected<Operation, ParseError>
+{
+  if (token == "+")
+    return {Add{}};
+  if (token == "-")
+    return {Sub{}};
+  if (token == "*")
+    return {Mul{}};
+  if (token == "/")
+    return {Div{}};
+  if (token == "%")
+    return {Mod{}};
+  if (token == "swap")
+    return {Swap{}};
+  if (token == "dup")
+    return {Dup{}};
+  if (token == "drop")
+    return {Drop{}};
+
+  return parse(token) | fn::transform([](auto n) { //
+           return Push{Number{n}};
+         });
+}
+
+inline auto pop(Stack &s) -> fn::expected<Number, StackError>
+{
+  if (s.empty())
+    return pfn::unexpected(StackError::NotEnoughOperands);
+  Number n = s.back();
+  s.pop_back();
+  return n;
+}
+
+// What an operation pushes back — zero, one or two numbers — or its typed failure
+using Results = fn::expected<fn::sum_for<fn::pack<>, fn::pack<long>, fn::pack<double>, fn::pack<long, long>,
+                                         fn::pack<double, long>, fn::pack<long, double>, fn::pack<double, double>>,
+                             MathError>;
+
+constexpr inline long minimum = std::numeric_limits<long>::min();
+
+// One table defines every operation, dispatched on the runtime types of *both* operands and the
+// operation itself; overload resolution picks the arm, so `7 2 /` is exact and `7 2.0 /` promotes
+constexpr inline auto execute = fn::overload{
+    [](auto x, auto y, Add) -> Results { return {fn::pack{x + y}}; },
+    [](auto x, auto y, Sub) -> Results { return {fn::pack{x - y}}; },
+    [](auto x, auto y, Mul) -> Results { return {fn::pack{x * y}}; },
+    [](long x, long y, Div) -> Results {
+      if (y == 0)
+        return pfn::unexpected(MathError::DivisionByZero);
+      if (x == minimum && y == -1)
+        return pfn::unexpected(MathError::Overflow);
+      return {fn::pack{x / y}}; // exact: `7 2 /` is 3
+    },
+    [](auto x, auto y, Div) -> Results {
+      if (y == 0)
+        return pfn::unexpected(MathError::DivisionByZero);
+      return {fn::pack{x / y}}; // a double anywhere promotes: `7 2.0 /` is 3.5
+    },
+    [](long x, long y, Mod) -> Results {
+      if (y == 0)
+        return pfn::unexpected(MathError::DivisionByZero);
+      if (x == minimum && y == -1)
+        return pfn::unexpected(MathError::Overflow);
+      return {fn::pack{x % y}};
+    },
+    // dispatch is also how an operation rejects operands it is not defined for
+    [](auto, auto, Mod) -> Results { return pfn::unexpected(MathError::NotIntegral); },
+    // named arguments deduce reference elements in a pack; spell the value types instead
+    [](auto x, auto y, Swap) -> Results { return {fn::pack<decltype(y), decltype(x)>{y, x}}; },
+    [](auto x, Dup) -> Results { return {fn::pack<decltype(x), decltype(x)>{x, x}}; },
+    [](auto, Drop) -> Results { return {fn::pack<>{}}; },
+    // a Push carries a runtime Number; one more dispatch unwraps it into a raw pack
+    [](Push p) -> Results { return p.value.invoke([](auto v) -> Results { return {fn::pack<decltype(v)>{v}}; }); }};
+
+// One token = one step: look the operation up, pop as many operands as it declares (folding them and
+// the operation itself into one cartesian sum of packs), execute the matching arm, store what it returns
+inline auto step(Stack s, std::string const &token) -> Result
+{
+  auto const store = [&s](auto &&...args) -> fn::expected<Stack, MathError> {
+    static_assert(sizeof...(args) < 3);
+    (s.push_back(Number{args}), ...);
+    return {std::move(s)};
+  };
+
+  return (fn::expected<void, fn::sum<>>{} & lookup(token)) //
+         | fn::and_then([&s, &store](auto op) -> Result {
+             // the wrapper's StackError is never raised; `&` needs a non-empty error type to fold with
+             using loaded = fn::expected<decltype(op), StackError>;
+             constexpr int take = decltype(op)::argument_count;
+             if constexpr (take == 0)
+               return execute(op) | fn::and_then(store);
+             else if constexpr (take == 1)
+               return (fn::expected<void, fn::sum<>>{} & pop(s) & loaded{op}) //
+                      | fn::and_then(execute)                                 //
+                      | fn::and_then(store);
+             else {
+               static_assert(decltype(op)::argument_count == 2);
+               auto rhs = pop(s); // popped before lhs: in `2 1 -` the top of the stack, 1, is the right operand
+               auto lhs = pop(s);
+               return (fn::expected<void, fn::sum<>>{} & std::move(lhs) & std::move(rhs) & loaded{op}) //
+                      | fn::and_then(execute)                                                          //
+                      | fn::and_then(store);
+             }
+           });
+}
+
+// Evaluate one line of whitespace-separated tokens — a recursive monadic fold over the stack
+// (Y-combinator: self is passed explicitly), where the first error short-circuits the rest of the line
+inline auto evaluate(Stack s, std::string_view line) -> Result
+{
+  using iterator = std::vector<std::string>::const_iterator;
+  static constexpr auto fold = [](auto self, Stack acc, iterator it, iterator end) -> Result {
+    if (it == end)
+      return {std::move(acc)};
+    return step(std::move(acc), *it) //
+           | fn::and_then([self, it, end](Stack next) { return self(self, std::move(next), std::next(it), end); });
+  };
+
+  std::istringstream stream{std::string{line}};
+  std::vector<std::string> const tokens{std::istream_iterator<std::string>{stream}, {}};
+  return fold(fold, std::move(s), tokens.begin(), tokens.end());
+}
+
+} // namespace calc
+
+#endif // EXAMPLES_CALCULATOR_CALCULATOR

--- a/examples/calculator/calculator.hpp
+++ b/examples/calculator/calculator.hpp
@@ -79,10 +79,8 @@ inline auto parse(std::string const &token) -> fn::expected<Number, ParseError>
   errno = 0;
   if (long const i = std::strtol(token.data(), &end, 0); end == last && end != token.data() && errno == 0)
     return Number{i};
-  errno = 0; // strtol left ERANGE behind on the very path where a long promotes to double
-  if (double const d = std::strtod(token.data(), &end);
-      end == last && end != token.data() && errno == 0 && std::isfinite(d))
-    return Number{d};
+  if (double const d = std::strtod(token.data(), &end); end == last && end != token.data() && std::isfinite(d))
+    return Number{d}; // an overflow returns HUGE_VAL, which is infinity; an underflow is just a tiny number
   return pfn::unexpected(ParseError::UnknownToken);
 }
 
@@ -155,19 +153,31 @@ constexpr inline auto execute = fn::overload{
         return pfn::unexpected(MathError::Overflow);
       return {fn::pack{x + y}};
     },
-    [](auto x, auto y, Add) -> Results { return {fn::pack{x + y}}; },
+    [](auto x, auto y, Add) -> Results {
+      if (not std::isfinite(x + y))
+        return pfn::unexpected(MathError::Overflow);
+      return {fn::pack{x + y}};
+    },
     [](long x, long y, Sub op) -> Results {
       if (overflows(x, y, op))
         return pfn::unexpected(MathError::Overflow);
       return {fn::pack{x - y}};
     },
-    [](auto x, auto y, Sub) -> Results { return {fn::pack{x - y}}; },
+    [](auto x, auto y, Sub) -> Results {
+      if (not std::isfinite(x - y))
+        return pfn::unexpected(MathError::Overflow);
+      return {fn::pack{x - y}};
+    },
     [](long x, long y, Mul op) -> Results {
       if (overflows(x, y, op))
         return pfn::unexpected(MathError::Overflow);
       return {fn::pack{x * y}};
     },
-    [](auto x, auto y, Mul) -> Results { return {fn::pack{x * y}}; },
+    [](auto x, auto y, Mul) -> Results {
+      if (not std::isfinite(x * y))
+        return pfn::unexpected(MathError::Overflow);
+      return {fn::pack{x * y}};
+    },
     [](long x, long y, Div) -> Results {
       if (y == 0)
         return pfn::unexpected(MathError::DivisionByZero);
@@ -178,6 +188,8 @@ constexpr inline auto execute = fn::overload{
     [](auto x, auto y, Div) -> Results {
       if (y == 0)
         return pfn::unexpected(MathError::DivisionByZero);
+      if (not std::isfinite(x / y))
+        return pfn::unexpected(MathError::Overflow);
       return {fn::pack{x / y}}; // a double anywhere promotes: `7 2.0 /` is 3.5
     },
     [](long x, long y, Mod) -> Results {

--- a/examples/calculator/calculator.hpp
+++ b/examples/calculator/calculator.hpp
@@ -19,6 +19,7 @@
 #include <sstream>
 #include <string>
 #include <string_view>
+#include <type_traits>
 #include <utility>
 #include <vector>
 
@@ -100,9 +101,8 @@ inline auto lookup(std::string const &token) -> fn::expected<Operation, ParseErr
   if (token == "drop")
     return {Drop{}};
 
-  return parse(token) | fn::transform([](auto n) { //
-           return Push{Number{n}};
-         });
+  return parse(token) //
+         | fn::transform([](auto n) { return Push{Number{n}}; });
 }
 
 inline auto pop(Stack &s) -> fn::expected<Number, StackError>
@@ -115,9 +115,19 @@ inline auto pop(Stack &s) -> fn::expected<Number, StackError>
 }
 
 // What an operation pushes back — zero, one or two numbers — or its typed failure
-using Results = fn::expected<fn::sum_for<fn::pack<>, fn::pack<long>, fn::pack<double>, fn::pack<long, long>,
-                                         fn::pack<double, long>, fn::pack<long, double>, fn::pack<double, double>>,
+using Results = fn::expected<fn::sum_for<fn::pack<>,                                      //
+                                         decltype(fn::pack<>{} & std::declval<Number>()), //
+                                         decltype(std::declval<Number>() & std::declval<Number>())>,
                              MathError>;
+
+// How: `&` concatenates operands into packs, distributing sum alternatives — two Numbers form the
+// 2×2 cartesian sum of packs — and sum_for absorbs nested sums into one normalized alternative
+// list; fully distributed, the deduction above is exactly:
+static_assert(
+    std::is_same_v<Results,
+                   fn::expected<fn::sum_for<fn::pack<>, fn::pack<long>, fn::pack<double>, fn::pack<long, long>,
+                                            fn::pack<double, long>, fn::pack<long, double>, fn::pack<double, double>>,
+                                MathError>>);
 
 constexpr inline long minimum = std::numeric_limits<long>::min();
 constexpr inline long maximum = std::numeric_limits<long>::max();

--- a/examples/calculator/calculator.hpp
+++ b/examples/calculator/calculator.hpp
@@ -220,8 +220,8 @@ inline auto step(Stack s, std::string const &token) -> Result
 
   return (fn::expected<void, fn::sum<>>{} & lookup(token)) //
          | fn::and_then([&s, &store](auto op) -> Result {
-             // the wrapper's StackError is never raised; `&` needs a non-empty error type to fold with
-             using loaded = fn::expected<decltype(op), StackError>;
+             // the operation itself cannot fail — sum<> is the empty set of errors
+             using loaded = fn::expected<decltype(op), fn::sum<>>;
              constexpr int take = decltype(op)::argument_count;
              if constexpr (take == 0)
                return execute(op) | fn::and_then(store);

--- a/examples/calculator/calculator.hpp
+++ b/examples/calculator/calculator.hpp
@@ -13,6 +13,7 @@
 #include "fn/utility.hpp"
 
 #include <cerrno>
+#include <cmath>
 #include <cstdlib>
 #include <iterator>
 #include <limits>
@@ -69,7 +70,8 @@ struct Swap {
 };
 using Operation = fn::sum<Add, Div, Drop, Dup, Mod, Mul, Push, Sub, Swap>;
 
-// "42", "052" and "0x2a" are long, "2.5", "1e-3" and ".5" are double; a long overflow promotes to double
+// "42", "052" and "0x2a" are long, "2.5", "1e-3" and ".5" are double; a long overflow promotes to
+// double, while a double overflow — like the "inf" and "nan" spellings strtod accepts — is no number here
 inline auto parse(std::string const &token) -> fn::expected<Number, ParseError>
 {
   char const *last = token.data() + token.size();
@@ -77,7 +79,9 @@ inline auto parse(std::string const &token) -> fn::expected<Number, ParseError>
   errno = 0;
   if (long const i = std::strtol(token.data(), &end, 0); end == last && end != token.data() && errno == 0)
     return Number{i};
-  if (double const d = std::strtod(token.data(), &end); end == last && end != token.data())
+  errno = 0; // strtol left ERANGE behind on the very path where a long promotes to double
+  if (double const d = std::strtod(token.data(), &end);
+      end == last && end != token.data() && errno == 0 && std::isfinite(d))
     return Number{d};
   return pfn::unexpected(ParseError::UnknownToken);
 }

--- a/examples/calculator/calculator.hpp
+++ b/examples/calculator/calculator.hpp
@@ -120,12 +120,39 @@ using Results = fn::expected<fn::sum_for<fn::pack<>, fn::pack<long>, fn::pack<do
                              MathError>;
 
 constexpr inline long minimum = std::numeric_limits<long>::min();
+constexpr inline long maximum = std::numeric_limits<long>::max();
+
+// Signed overflow is UB, so operands are checked before the arithmetic, never after; the Mul bounds
+// are exact because integer division truncates toward zero
+constexpr auto overflows(long x, long y, Add) -> bool { return y > 0 ? x > maximum - y : x < minimum - y; }
+constexpr auto overflows(long x, long y, Sub) -> bool { return y < 0 ? x > maximum + y : x < minimum + y; }
+constexpr auto overflows(long x, long y, Mul) -> bool
+{
+  if (x > 0)
+    return y > 0 ? x > maximum / y : y < minimum / x;
+  return y > 0 ? x < minimum / y : x != 0 && y < maximum / x;
+}
 
 // One table defines every operation, dispatched on the runtime types of *both* operands and the
 // operation itself; overload resolution picks the arm, so `7 2 /` is exact and `7 2.0 /` promotes
 constexpr inline auto execute = fn::overload{
+    [](long x, long y, Add op) -> Results {
+      if (overflows(x, y, op))
+        return pfn::unexpected(MathError::Overflow);
+      return {fn::pack{x + y}};
+    },
     [](auto x, auto y, Add) -> Results { return {fn::pack{x + y}}; },
+    [](long x, long y, Sub op) -> Results {
+      if (overflows(x, y, op))
+        return pfn::unexpected(MathError::Overflow);
+      return {fn::pack{x - y}};
+    },
     [](auto x, auto y, Sub) -> Results { return {fn::pack{x - y}}; },
+    [](long x, long y, Mul op) -> Results {
+      if (overflows(x, y, op))
+        return pfn::unexpected(MathError::Overflow);
+      return {fn::pack{x * y}};
+    },
     [](auto x, auto y, Mul) -> Results { return {fn::pack{x * y}}; },
     [](long x, long y, Div) -> Results {
       if (y == 0)

--- a/examples/calculator/main.cpp
+++ b/examples/calculator/main.cpp
@@ -1,0 +1,56 @@
+// Copyright (c) 2026 Bronek Kozicki
+//
+// Distributed under the ISC License. See accompanying file LICENSE.md
+// or copy at https://opensource.org/licenses/ISC
+
+#include "calculator.hpp"
+
+#include "fn/utility.hpp"
+
+#include <exception>
+#include <iostream>
+#include <string>
+
+namespace {
+
+void print(calc::Stack const &stack)
+{
+  std::cout << "stack:";
+  for (calc::Number const &n : stack)
+    n.invoke([](auto v) { std::cout << ' ' << v; });
+  std::cout << '\n';
+}
+
+void report(calc::Error const &error)
+{
+  std::cout << error.invoke(fn::overload{[](calc::ParseError) { return "not a number or a known operation"; },
+                                         [](calc::StackError) { return "not enough operands on the stack"; },
+                                         [](calc::MathError e) {
+                                           if (e == calc::MathError::DivisionByZero)
+                                             return "division by zero";
+                                           if (e == calc::MathError::NotIntegral)
+                                             return "operation is defined for integers only";
+                                           return "overflow";
+                                         }})
+            << '\n';
+}
+
+} // namespace
+
+auto main() -> int
+try {
+  calc::Stack stack;
+  for (std::string line; std::getline(std::cin, line);) {
+    // A failed line reports its error and leaves the stack untouched
+    if (auto r = calc::evaluate(stack, line); r.has_value()) {
+      stack = std::move(r).value();
+      print(stack);
+    } else {
+      report(r.error());
+    }
+  }
+  return 0;
+} catch (std::exception const &e) {
+  std::cerr << e.what() << '\n';
+  return 1;
+}

--- a/examples/calculator/main.cpp
+++ b/examples/calculator/main.cpp
@@ -15,10 +15,10 @@ namespace {
 
 void print(calc::Stack const &stack)
 {
-  std::cout << "stack:";
+  std::cout << "[";
   for (calc::Number const &n : stack)
     n.invoke([](auto v) { std::cout << ' ' << v; });
-  std::cout << '\n';
+  std::cout << " ]\n";
 }
 
 void report(calc::Error const &error)
@@ -40,7 +40,8 @@ void report(calc::Error const &error)
 auto main() -> int
 try {
   calc::Stack stack;
-  for (std::string line; std::getline(std::cin, line);) {
+  // the prompt goes to stderr (like a shell's) so piped stdout stays clean without any TTY detection
+  for (std::string line; std::cerr << "> ", std::getline(std::cin, line);) {
     // A failed line reports its error and leaves the stack untouched
     if (auto r = calc::evaluate(stack, line); r.has_value()) {
       stack = std::move(r).value();

--- a/examples/calculator/main.cpp
+++ b/examples/calculator/main.cpp
@@ -23,15 +23,16 @@ void print(calc::Stack const &stack)
 
 void report(calc::Error const &error)
 {
-  std::cout << error.invoke(fn::overload{[](calc::ParseError) { return "not a number or a known operation"; },
-                                         [](calc::StackError) { return "not enough operands on the stack"; },
-                                         [](calc::MathError e) {
-                                           if (e == calc::MathError::DivisionByZero)
-                                             return "division by zero";
-                                           if (e == calc::MathError::NotIntegral)
-                                             return "operation is defined for integers only";
-                                           return "overflow";
-                                         }})
+  std::cout << error.invoke( //
+      fn::overload{[](calc::ParseError) { return "not a number or a known operation"; },
+                   [](calc::StackError) { return "not enough operands on the stack"; },
+                   [](calc::MathError e) {
+                     if (e == calc::MathError::DivisionByZero)
+                       return "division by zero";
+                     if (e == calc::MathError::NotIntegral)
+                       return "operation is defined for integers only";
+                     return "overflow";
+                   }})
             << '\n';
 }
 

--- a/examples/calculator/test.cpp
+++ b/examples/calculator/test.cpp
@@ -1,0 +1,139 @@
+// Copyright (c) 2026 Bronek Kozicki
+//
+// Distributed under the ISC License. See accompanying file LICENSE.md
+// or copy at https://opensource.org/licenses/ISC
+
+#include "calculator.hpp"
+
+#include "fn/pack.hpp"
+
+#include <catch2/catch_all.hpp>
+
+#include <string_view>
+#include <type_traits>
+#include <utility>
+
+namespace {
+auto run(std::string_view line) -> calc::Result { return calc::evaluate({}, line); }
+} // namespace
+
+// `&` folds two parses into a cartesian product of packs and a sum of errors, all composed by the library:
+static_assert(std::is_same_v<decltype(fn::expected<void, fn::sum<>>{} & calc::parse("") & calc::parse("")),
+                             fn::expected<fn::sum_for<fn::pack<double, double>, fn::pack<double, long>,
+                                                      fn::pack<long, double>, fn::pack<long, long>>,
+                                          fn::sum<calc::ParseError>>>);
+
+// ... `step` folds the operands AND the operation into one cartesian dispatch table for `execute`:
+static_assert(
+    std::is_same_v<decltype(fn::expected<void, fn::sum<>>{} & calc::pop(std::declval<calc::Stack &>())
+                            & calc::pop(std::declval<calc::Stack &>())
+                            & fn::expected<calc::Div, calc::StackError>{calc::Div{}}),
+                   fn::expected<fn::sum_for<fn::pack<double, double, calc::Div>, fn::pack<double, long, calc::Div>,
+                                            fn::pack<long, double, calc::Div>, fn::pack<long, long, calc::Div>>,
+                                fn::sum<calc::StackError>>>);
+
+// ... and the calculator's Error alias is exactly the normalized sum of its three error types:
+static_assert(std::is_same_v<calc::Error, fn::sum_for<calc::MathError, calc::ParseError, calc::StackError>>);
+
+TEST_CASE("parse", "[calculator]")
+{
+  SECTION("long formats")
+  {
+    CHECK(calc::parse("42").value() == calc::Number{42L});
+    CHECK(calc::parse("-7").value() == calc::Number{-7L});
+    CHECK(calc::parse("0x2a").value() == calc::Number{42L});
+    CHECK(calc::parse("052").value() == calc::Number{42L});
+  }
+
+  SECTION("double formats")
+  {
+    CHECK(calc::parse("2.5").value() == calc::Number{2.5});
+    CHECK(calc::parse("1e3").value() == calc::Number{1000.0});
+    CHECK(calc::parse(".5").value() == calc::Number{0.5});
+    CHECK(calc::parse("2.").value() == calc::Number{2.0});
+    CHECK(calc::parse("0x1.8p1").value() == calc::Number{3.0});
+  }
+
+  SECTION("a long overflow promotes to the double alternative")
+  {
+    CHECK(calc::parse("9223372036854775808").value() == calc::Number{9223372036854775808.0});
+  }
+
+  SECTION("rejected tokens")
+  {
+    CHECK(calc::parse("").error() == calc::ParseError::UnknownToken);
+    CHECK(calc::parse("x").error() == calc::ParseError::UnknownToken);
+    CHECK(calc::parse("1x").error() == calc::ParseError::UnknownToken);
+  }
+}
+
+TEST_CASE("arithmetic dispatches on the runtime types of both operands", "[calculator]")
+{
+  SECTION("long with long stays exact")
+  {
+    CHECK(run("1 2 +").value() == calc::Stack{calc::Number{3L}});
+    CHECK(run("1 2 -").value() == calc::Stack{calc::Number{-1L}});
+    CHECK(run("2 3 *").value() == calc::Stack{calc::Number{6L}});
+    CHECK(run("7 2 /").value() == calc::Stack{calc::Number{3L}});
+    CHECK(run("7 3 %").value() == calc::Stack{calc::Number{1L}});
+  }
+
+  SECTION("a double anywhere promotes")
+  {
+    CHECK(run("1 2.5 +").value() == calc::Stack{calc::Number{3.5}});
+    CHECK(run("7 2.0 /").value() == calc::Stack{calc::Number{3.5}});
+    CHECK(run("7.0 2 /").value() == calc::Stack{calc::Number{3.5}});
+  }
+
+  SECTION("modulo is defined for longs only")
+  {
+    CHECK(run("7 3.0 %").error() == fn::sum{calc::MathError::NotIntegral});
+  }
+}
+
+TEST_CASE("stack operations", "[calculator]")
+{
+  CHECK(run("2 1 swap").value() == calc::Stack{calc::Number{1L}, calc::Number{2L}});
+  CHECK(run("2 1 swap /").value() == calc::Stack{calc::Number{0L}});
+  CHECK(run("3 dup *").value() == calc::Stack{calc::Number{9L}});
+  CHECK(run("1 2 drop").value() == calc::Stack{calc::Number{1L}});
+  CHECK(run("").value() == calc::Stack{});
+}
+
+TEST_CASE("errors", "[calculator]")
+{
+  SECTION("division by zero")
+  {
+    CHECK(run("1 0 /").error() == fn::sum{calc::MathError::DivisionByZero});
+    CHECK(run("1 0.0 /").error() == fn::sum{calc::MathError::DivisionByZero});
+    CHECK(run("1 0 %").error() == fn::sum{calc::MathError::DivisionByZero});
+  }
+
+  SECTION("long division cannot overflow")
+  {
+    CHECK(run("-9223372036854775808 -1 /").error() == fn::sum{calc::MathError::Overflow});
+    CHECK(run("-9223372036854775808 -1 %").error() == fn::sum{calc::MathError::Overflow});
+  }
+
+  SECTION("stack underflow")
+  {
+    CHECK(run("1 +").error() == fn::sum{calc::StackError::NotEnoughOperands});
+    CHECK(run("swap").error() == fn::sum{calc::StackError::NotEnoughOperands});
+    CHECK(run("dup").error() == fn::sum{calc::StackError::NotEnoughOperands});
+  }
+
+  SECTION("unknown token") { CHECK(run("1 2 bogus").error() == fn::sum{calc::ParseError::UnknownToken}); }
+
+  SECTION("the first error short-circuits the rest of the line")
+  {
+    CHECK(run("1 0 / 5 5 +").error() == fn::sum{calc::MathError::DivisionByZero});
+  }
+}
+
+TEST_CASE("the stack persists across lines", "[calculator]")
+{
+  auto first = calc::evaluate({}, "1 2");
+  REQUIRE(first.has_value());
+  auto second = calc::evaluate(std::move(first).value(), "+");
+  CHECK(second.value() == calc::Stack{calc::Number{3L}});
+}

--- a/examples/calculator/test.cpp
+++ b/examples/calculator/test.cpp
@@ -66,6 +66,9 @@ TEST_CASE("parse", "[calculator]")
     CHECK(calc::parse("").error() == calc::ParseError::UnknownToken);
     CHECK(calc::parse("x").error() == calc::ParseError::UnknownToken);
     CHECK(calc::parse("1x").error() == calc::ParseError::UnknownToken);
+    CHECK(calc::parse("1e999").error() == calc::ParseError::UnknownToken);
+    CHECK(calc::parse("inf").error() == calc::ParseError::UnknownToken);
+    CHECK(calc::parse("nan").error() == calc::ParseError::UnknownToken);
   }
 }
 

--- a/examples/calculator/test.cpp
+++ b/examples/calculator/test.cpp
@@ -9,6 +9,8 @@
 
 #include <catch2/catch_all.hpp>
 
+#include <limits>
+#include <string>
 #include <string_view>
 #include <type_traits>
 #include <utility>
@@ -111,8 +113,9 @@ TEST_CASE("errors", "[calculator]")
 
   SECTION("long division cannot overflow")
   {
-    CHECK(run("-9223372036854775808 -1 /").error() == fn::sum{calc::MathError::Overflow});
-    CHECK(run("-9223372036854775808 -1 %").error() == fn::sum{calc::MathError::Overflow});
+    auto const minimum = std::to_string(std::numeric_limits<long>::min());
+    CHECK(run(minimum + " -1 /").error() == fn::sum{calc::MathError::Overflow});
+    CHECK(run(minimum + " -1 %").error() == fn::sum{calc::MathError::Overflow});
   }
 
   SECTION("stack underflow")

--- a/examples/calculator/test.cpp
+++ b/examples/calculator/test.cpp
@@ -111,11 +111,19 @@ TEST_CASE("errors", "[calculator]")
     CHECK(run("1 0 %").error() == fn::sum{calc::MathError::DivisionByZero});
   }
 
-  SECTION("long division cannot overflow")
+  SECTION("long overflow")
   {
     auto const minimum = std::to_string(std::numeric_limits<long>::min());
+    auto const maximum = std::to_string(std::numeric_limits<long>::max());
     CHECK(run(minimum + " -1 /").error() == fn::sum{calc::MathError::Overflow});
     CHECK(run(minimum + " -1 %").error() == fn::sum{calc::MathError::Overflow});
+    CHECK(run(maximum + " 1 +").error() == fn::sum{calc::MathError::Overflow});
+    CHECK(run(minimum + " 1 -").error() == fn::sum{calc::MathError::Overflow});
+    CHECK(run(maximum + " 2 *").error() == fn::sum{calc::MathError::Overflow});
+    CHECK(run(minimum + " -1 *").error() == fn::sum{calc::MathError::Overflow});
+    // ... while the guards admit the exact bounds
+    CHECK(run(maximum + " 0 +").value() == calc::Stack{calc::Number{std::numeric_limits<long>::max()}});
+    CHECK(run(minimum + " 1 *").value() == calc::Stack{calc::Number{std::numeric_limits<long>::min()}});
   }
 
   SECTION("stack underflow")

--- a/examples/calculator/test.cpp
+++ b/examples/calculator/test.cpp
@@ -54,6 +54,7 @@ TEST_CASE("parse", "[calculator]")
     CHECK(calc::parse(".5").value() == calc::Number{0.5});
     CHECK(calc::parse("2.").value() == calc::Number{2.0});
     CHECK(calc::parse("0x1.8p1").value() == calc::Number{3.0});
+    CHECK(calc::parse("1e-999").value() == calc::Number{0.0}); // an underflow rounds to zero
   }
 
   SECTION("a long overflow promotes to the double alternative")
@@ -127,6 +128,14 @@ TEST_CASE("errors", "[calculator]")
     // ... while the guards admit the exact bounds
     CHECK(run(maximum + " 0 +").value() == calc::Stack{calc::Number{std::numeric_limits<long>::max()}});
     CHECK(run(minimum + " 1 *").value() == calc::Stack{calc::Number{std::numeric_limits<long>::min()}});
+  }
+
+  SECTION("double overflow")
+  {
+    CHECK(run("1e308 1e308 +").error() == fn::sum{calc::MathError::Overflow});
+    CHECK(run("-1e308 1e308 -").error() == fn::sum{calc::MathError::Overflow});
+    CHECK(run("1e308 1e308 *").error() == fn::sum{calc::MathError::Overflow});
+    CHECK(run("1e308 1e-308 /").error() == fn::sum{calc::MathError::Overflow});
   }
 
   SECTION("stack underflow")

--- a/examples/calculator/test.cpp
+++ b/examples/calculator/test.cpp
@@ -26,13 +26,12 @@ static_assert(std::is_same_v<decltype(fn::expected<void, fn::sum<>>{} & calc::pa
                                           fn::sum<calc::ParseError>>>);
 
 // ... `step` folds the operands AND the operation into one cartesian dispatch table for `execute`:
-static_assert(
-    std::is_same_v<decltype(fn::expected<void, fn::sum<>>{} & calc::pop(std::declval<calc::Stack &>())
-                            & calc::pop(std::declval<calc::Stack &>())
-                            & fn::expected<calc::Div, calc::StackError>{calc::Div{}}),
-                   fn::expected<fn::sum_for<fn::pack<double, double, calc::Div>, fn::pack<double, long, calc::Div>,
-                                            fn::pack<long, double, calc::Div>, fn::pack<long, long, calc::Div>>,
-                                fn::sum<calc::StackError>>>);
+static_assert(std::is_same_v<
+              decltype(fn::expected<void, fn::sum<>>{} & calc::pop(std::declval<calc::Stack &>())
+                       & calc::pop(std::declval<calc::Stack &>()) & fn::expected<calc::Div, fn::sum<>>{calc::Div{}}),
+              fn::expected<fn::sum_for<fn::pack<double, double, calc::Div>, fn::pack<double, long, calc::Div>,
+                                       fn::pack<long, double, calc::Div>, fn::pack<long, long, calc::Div>>,
+                           fn::sum<calc::StackError>>>);
 
 // ... and the calculator's Error alias is exactly the normalized sum of its three error types:
 static_assert(std::is_same_v<calc::Error, fn::sum_for<calc::MathError, calc::ParseError, calc::StackError>>);


### PR DESCRIPTION
An RPN REPL where every operation is a tiny `argument_count` struct (a parsed number being the nullary `Push`), step folds operands and the operation into one cartesian sum-of-packs, a single `fn::overload` table dispatches on all of it at once, and a lone variadic `store` handles every result arity — with parse/stack/math errors accumulating into one library-composed `fn::sum` that the REPL reports by exhaustive dispatch.
 
Assisted-by: Claude:claude-fable-5