### PR TITLE
Fix `operator&` for non-void expected carrying the `sum<>` unit error

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,7 @@ build/
 .scratch*/
 dist*/
 result*
+__pycache__/**
 .cache/
 .devcontainer/
 .venv/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 Design history of libfn, newest first. The living documents — [README.md](README.md), [CONTRIBUTING.md](CONTRIBUTING.md), [docs/](docs/) — describe only the present state of the design; when a decision makes an earlier idea obsolete, this file is where the transition is recorded and explained.
 
+## `operator&` composes the `sum<>` unit error — 8 July 2026
+
+- **A non-void `fn::expected` carrying the `sum<>` unit error now composes under `operator&`.** A never-erroring operand — `expected<T, sum<>>`, the "cannot fail" grade — folds into a fallible `&`-chain, adding its value to the pack and no alternative to the widened error. The different-error overload had been ill-formed here: its error lambda deduced `void` for the `sum<>` side, poisoning the pack join's return-type deduction. The README example follows the fix, collapsing from a two-stage pipeline into a single `and_then` over the cartesian `(a & op & b)` dispatch table, its operator honestly typed `expected<sum_for<Add, Mul>, sum<>>`.
+
 ## Documentation realigned — 7 July 2026
 
 - **README.md caught up with the two-library reality.** Its founding description — `fn` extends the `std` vocabulary types via inheritance and requires a C++23 standard library (gcc 13 / clang 18) — predated `pfn` (September 2025) and the C++20 rebase (June 2026). Replaced by the present state: `fn` builds on `pfn`, everything is C++20, minimums gcc 12 / clang 16. A "Using the library" section names the supported packaging routes.

--- a/README.md
+++ b/README.md
@@ -16,62 +16,98 @@ The purpose of this library is to exercise an approach to functional programming
 #include <fn/and_then.hpp>
 #include <fn/utility.hpp>
 
+#include <charconv>
 #include <climits>
 #include <numeric>
+#include <string_view>
 #include <type_traits>
 
-struct DivByZero {};
-struct Overflow {};
-struct Add {};
-struct Mul {};
+enum NotANumber { notANumber };
+enum DivByZero { divByZero };
+enum Overflow { overflow };
+enum Add { add };
+enum Mul { mul };
 enum Side { num, den };
+
 class Rational {
-  int num_, den_;
-  constexpr Rational(int n, int d) noexcept : num_(n), den_(d) {}
+  int n_, d_;
+  constexpr Rational(int n, int d) noexcept : n_(n), d_(d) {}
 
 public:
   constexpr bool operator==(Rational const &) const noexcept = default;
-  template <Side S> constexpr friend auto get(Rational const &r) noexcept -> int { return S == num ? r.num_ : r.den_; }
-  // The invariant lives in the type: `make` is the only way to build one, so every Rational is reduced,
-  // sign-normalized and representable — callers receive a value they never have to re-check.
-  static auto make(long long n, long long d) -> fn::expected<Rational, fn::sum_for<DivByZero, Overflow>>
+  template <Side S> constexpr friend int get(Rational const &r) noexcept
   {
-    if (d == 0) return pfn::unexpected{fn::sum{DivByZero{}}};
-    if (n == LLONG_MIN || d == LLONG_MIN) return pfn::unexpected{fn::sum{Overflow{}}};
+    return S == num ? r.n_ : r.d_;
+  }
+
+  // The invariant lives in the type: `make` is the only way to build one, so every
+  // Rational is reduced, sign-normalized and representable — callers receive a value they
+  // never have to re-check.
+  static constexpr auto make(long long n, long long d)
+      -> fn::expected<Rational, fn::sum_for<DivByZero, Overflow>>
+  {
+    if (d == 0) return pfn::unexpected{fn::sum{divByZero}};
+    if (n == LLONG_MIN || d == LLONG_MIN) return pfn::unexpected{fn::sum{overflow}};
     auto const g = (d < 0 ? -1 : 1) * std::gcd(n, d);
     n /= g;
     d /= g;
-    if (n < INT_MIN || n > INT_MAX || d > INT_MAX) return pfn::unexpected{fn::sum{Overflow{}}};
+    if (n < INT_MIN || n > INT_MAX || d > INT_MAX) return pfn::unexpected{fn::sum{overflow}};
     return Rational(int(n), int(d));
   }
 };
-// `evaluate` trusts its operands — the type guarantees them, so it never revalidates. The int64 intermediates
-// cannot overflow for int32 fields, and `make` rejects any result that will not fit back, folding Overflow in:
-auto evaluate(fn::expected<Rational, fn::sum_for<DivByZero, Overflow>> a, fn::sum_for<Add, Mul> op,
-              fn::expected<Rational, fn::sum_for<DivByZero, Overflow>> b)
+
+// `parse` turns a string into a pair of numbers (a numerator and denominator)
+auto parse(std::string_view s) -> fn::expected<fn::pack<int, int>, fn::sum<NotANumber>>
 {
-  return (a & b) | fn::and_then([op](Rational x, Rational y) {
-           return op.invoke(fn::overload{
-               [&](Add) {
-                 return Rational::make(1LL * get<num>(x) * get<den>(y) + 1LL * get<num>(y) * get<den>(x),
-                                       1LL * get<den>(x) * get<den>(y));
-               },
-               [&](Mul) { return Rational::make(1LL * get<num>(x) * get<num>(y), 1LL * get<den>(x) * get<den>(y)); }});
-         });
+  int n = 0, d = 1;
+  auto const bar = s.find('/');
+  auto const head = s.substr(0, bar);
+  auto const [p, e] = std::from_chars(head.data(), head.data() + head.size(), n);
+  if (e != std::errc{} || p != head.data() + head.size())
+    return pfn::unexpected{fn::sum{notANumber}};
+  if (bar != std::string_view::npos) {
+    auto const tail = s.substr(bar + 1);
+    auto const [q, f] = std::from_chars(tail.data(), tail.data() + tail.size(), d);
+    if (f != std::errc{} || q != tail.data() + tail.size())
+      return pfn::unexpected{fn::sum{notANumber}};
+  }
+  return fn::pack<int, int>{n, d};
 }
-// The library composes the pipeline type — a Rational, over the sum of every way construction can fail:
-static_assert(std::is_same_v<decltype(evaluate(Rational::make(0, 1), Add{}, Rational::make(0, 1))),
-                             fn::expected<Rational, fn::sum<DivByZero, Overflow>>>);
+
+// Helper, does not need to name any error types — let the library compose them.
+constexpr auto number = [](std::string_view s) { return parse(s) | fn::and_then(Rational::make); };
+
+// `evaluate` parses both operands, applies the operator, and lets `make` re-check the
+// result. Each stage fails its own way, and the library folds those failures into one
+// error sum, never spelled by hand:
+auto evaluate(std::string_view a, fn::sum_for<Add, Mul> op, std::string_view b)
+{
+  using Op = fn::expected<fn::sum_for<Add, Mul>, fn::sum<>>;
+  constexpr auto apply = fn::overload{
+      [](Rational x, Add, Rational y) {
+        return Rational::make(1LL * get<num>(x) * get<den>(y) + 1LL * get<num>(y) * get<den>(x),
+                              1LL * get<den>(x) * get<den>(y));
+      },
+      [](Rational x, Mul, Rational y) {
+        return Rational::make(1LL * get<num>(x) * get<num>(y), 1LL * get<den>(x) * get<den>(y));
+      }};
+  return (number(a) & Op{op} & number(b)) | fn::and_then(apply);
+}
+
+// Result is a Rational, over the sum of every way a stage can fail:
+static_assert(std::is_same_v<decltype(evaluate("1/2", add, "3/4")),
+                             fn::expected<Rational, fn::sum<DivByZero, NotANumber, Overflow>>>);
+
 ```
 
 ### What
 
 The library features demonstrated by the code example above:
 
-* **Smart constructors** — `Rational`'s constructor is private; the only way to build one is the static `make`, which enforces the invariant (reduced, representable) and returns `fn::expected`. An invalid `Rational` cannot exist, so callers stop re-checking what the type already guarantees.
+* **Smart constructors** — `Rational`'s constructor is private; the only way to build one is the static `make`, which enforces invariants and returns `fn::expected`. An invalid `Rational` cannot exist, so callers don't need to check what the type already guarantees.
 * **Monadic pipelines** — `operator|` pipes `fn::expected` (and `fn::optional`) through operations: `and_then` above; also `or_else`, `transform`, `filter`, `inspect`, `recover`, `fail`, `transform_error` and more.
-* **Composition** — `operator&` accumulates several monadic values into one: the two operands arrive at the next operation as separate arguments, courtesy of `fn::pack`.
-* **Graded errors** — each way a step can fail contributes its own error type, and the library widens them into a single `fn::sum` — here `fn::sum<DivByZero, Overflow>`, the whole pipeline's error, composed by the library and never written by hand (pinned by a `static_assert`).
+* **Composition** — `operator&` accumulates both operands and the operator, as monadic values, into a `fn::pack` — which the next operation receives as separate arguments.
+* **Graded errors** — each stage fails in its own way — a malformed string, a zero denominator, an out-of-range result — and the library widens these into a single `fn::sum`, here `fn::sum<DivByZero, NotANumber, Overflow>`: the whole pipeline's error, composed by the library and never written by hand.
 * **Multidispatch** — `fn::sum` is indexed by type, not by position like `std::variant`, and `fn::overload` dispatches over its alternatives (`Add` and `Mul`) by ordinary overload resolution — exhaustively, so a missing handler is a compile error.
 
 Beyond the example: `fn::choice` (a monad over `fn::sum`), dispatch across any combination of `fn::pack` and `fn::sum`, and more — see [examples/](examples/) and the [API reference][docs].

--- a/README.md
+++ b/README.md
@@ -82,7 +82,6 @@ constexpr auto number = [](std::string_view s) { return parse(s) | fn::and_then(
 // error sum, never spelled by hand:
 auto evaluate(std::string_view a, fn::sum_for<Add, Mul> op, std::string_view b)
 {
-  using Op = fn::expected<fn::sum_for<Add, Mul>, fn::sum<>>;
   constexpr auto apply = fn::overload{
       [](Rational x, Add, Rational y) {
         return Rational::make(1LL * get<num>(x) * get<den>(y) + 1LL * get<num>(y) * get<den>(x),
@@ -91,6 +90,7 @@ auto evaluate(std::string_view a, fn::sum_for<Add, Mul> op, std::string_view b)
       [](Rational x, Mul, Rational y) {
         return Rational::make(1LL * get<num>(x) * get<num>(y), 1LL * get<den>(x) * get<den>(y));
       }};
+  using Op = fn::expected<decltype(op), fn::sum<>>;
   return (number(a) & Op{op} & number(b)) | fn::and_then(apply);
 }
 

--- a/examples/readme/.clang-format
+++ b/examples/readme/.clang-format
@@ -1,2 +1,3 @@
 BasedOnStyle: InheritParentConfig
 AllowShortIfStatementsOnASingleLine: WithoutElse
+ColumnLimit:     100

--- a/examples/readme/main.cpp
+++ b/examples/readme/main.cpp
@@ -73,7 +73,6 @@ constexpr auto number = [](std::string_view s) { return parse(s) | fn::and_then(
 // error sum, never spelled by hand:
 auto evaluate(std::string_view a, fn::sum_for<Add, Mul> op, std::string_view b)
 {
-  using Op = fn::expected<fn::sum_for<Add, Mul>, fn::sum<>>;
   constexpr auto apply = fn::overload{
       [](Rational x, Add, Rational y) {
         return Rational::make(1LL * get<num>(x) * get<den>(y) + 1LL * get<num>(y) * get<den>(x),
@@ -82,6 +81,7 @@ auto evaluate(std::string_view a, fn::sum_for<Add, Mul> op, std::string_view b)
       [](Rational x, Mul, Rational y) {
         return Rational::make(1LL * get<num>(x) * get<num>(y), 1LL * get<den>(x) * get<den>(y));
       }};
+  using Op = fn::expected<decltype(op), fn::sum<>>;
   return (number(a) & Op{op} & number(b)) | fn::and_then(apply);
 }
 

--- a/examples/readme/main.cpp
+++ b/examples/readme/main.cpp
@@ -7,61 +7,97 @@
 #include <fn/and_then.hpp>
 #include <fn/utility.hpp>
 
+#include <charconv>
 #include <climits>
 #include <numeric>
+#include <string_view>
 #include <type_traits>
 
-struct DivByZero {};
-struct Overflow {};
-struct Add {};
-struct Mul {};
+enum NotANumber { notANumber };
+enum DivByZero { divByZero };
+enum Overflow { overflow };
+enum Add { add };
+enum Mul { mul };
 enum Side { num, den };
+
 class Rational {
-  int num_, den_;
-  constexpr Rational(int n, int d) noexcept : num_(n), den_(d) {}
+  int n_, d_;
+  constexpr Rational(int n, int d) noexcept : n_(n), d_(d) {}
 
 public:
   constexpr bool operator==(Rational const &) const noexcept = default;
-  template <Side S> constexpr friend auto get(Rational const &r) noexcept -> int { return S == num ? r.num_ : r.den_; }
-  // The invariant lives in the type: `make` is the only way to build one, so every Rational is reduced,
-  // sign-normalized and representable — callers receive a value they never have to re-check.
-  static auto make(long long n, long long d) -> fn::expected<Rational, fn::sum_for<DivByZero, Overflow>>
+  template <Side S> constexpr friend int get(Rational const &r) noexcept
   {
-    if (d == 0) return pfn::unexpected{fn::sum{DivByZero{}}};
-    if (n == LLONG_MIN || d == LLONG_MIN) return pfn::unexpected{fn::sum{Overflow{}}};
+    return S == num ? r.n_ : r.d_;
+  }
+
+  // The invariant lives in the type: `make` is the only way to build one, so every
+  // Rational is reduced, sign-normalized and representable — callers receive a value they
+  // never have to re-check.
+  static constexpr auto make(long long n, long long d)
+      -> fn::expected<Rational, fn::sum_for<DivByZero, Overflow>>
+  {
+    if (d == 0) return pfn::unexpected{fn::sum{divByZero}};
+    if (n == LLONG_MIN || d == LLONG_MIN) return pfn::unexpected{fn::sum{overflow}};
     auto const g = (d < 0 ? -1 : 1) * std::gcd(n, d);
     n /= g;
     d /= g;
-    if (n < INT_MIN || n > INT_MAX || d > INT_MAX) return pfn::unexpected{fn::sum{Overflow{}}};
+    if (n < INT_MIN || n > INT_MAX || d > INT_MAX) return pfn::unexpected{fn::sum{overflow}};
     return Rational(int(n), int(d));
   }
 };
-// `evaluate` trusts its operands — the type guarantees them, so it never revalidates. The int64 intermediates
-// cannot overflow for int32 fields, and `make` rejects any result that will not fit back, folding Overflow in:
-auto evaluate(fn::expected<Rational, fn::sum_for<DivByZero, Overflow>> a, fn::sum_for<Add, Mul> op,
-              fn::expected<Rational, fn::sum_for<DivByZero, Overflow>> b)
+
+// `parse` turns a string into a pair of numbers (a numerator and denominator)
+auto parse(std::string_view s) -> fn::expected<fn::pack<int, int>, fn::sum<NotANumber>>
 {
-  return (a & b) | fn::and_then([op](Rational x, Rational y) {
-           return op.invoke(fn::overload{
-               [&](Add) {
-                 return Rational::make(1LL * get<num>(x) * get<den>(y) + 1LL * get<num>(y) * get<den>(x),
-                                       1LL * get<den>(x) * get<den>(y));
-               },
-               [&](Mul) { return Rational::make(1LL * get<num>(x) * get<num>(y), 1LL * get<den>(x) * get<den>(y)); }});
-         });
+  int n = 0, d = 1;
+  auto const bar = s.find('/');
+  auto const head = s.substr(0, bar);
+  auto const [p, e] = std::from_chars(head.data(), head.data() + head.size(), n);
+  if (e != std::errc{} || p != head.data() + head.size())
+    return pfn::unexpected{fn::sum{notANumber}};
+  if (bar != std::string_view::npos) {
+    auto const tail = s.substr(bar + 1);
+    auto const [q, f] = std::from_chars(tail.data(), tail.data() + tail.size(), d);
+    if (f != std::errc{} || q != tail.data() + tail.size())
+      return pfn::unexpected{fn::sum{notANumber}};
+  }
+  return fn::pack<int, int>{n, d};
 }
-// The library composes the pipeline type — a Rational, over the sum of every way construction can fail:
-static_assert(std::is_same_v<decltype(evaluate(Rational::make(0, 1), Add{}, Rational::make(0, 1))),
-                             fn::expected<Rational, fn::sum<DivByZero, Overflow>>>);
+
+// Helper, does not need to name any error types — let the library compose them.
+constexpr auto number = [](std::string_view s) { return parse(s) | fn::and_then(Rational::make); };
+
+// `evaluate` parses both operands, applies the operator, and lets `make` re-check the
+// result. Each stage fails its own way, and the library folds those failures into one
+// error sum, never spelled by hand:
+auto evaluate(std::string_view a, fn::sum_for<Add, Mul> op, std::string_view b)
+{
+  using Op = fn::expected<fn::sum_for<Add, Mul>, fn::sum<>>;
+  constexpr auto apply = fn::overload{
+      [](Rational x, Add, Rational y) {
+        return Rational::make(1LL * get<num>(x) * get<den>(y) + 1LL * get<num>(y) * get<den>(x),
+                              1LL * get<den>(x) * get<den>(y));
+      },
+      [](Rational x, Mul, Rational y) {
+        return Rational::make(1LL * get<num>(x) * get<num>(y), 1LL * get<den>(x) * get<den>(y));
+      }};
+  return (number(a) & Op{op} & number(b)) | fn::and_then(apply);
+}
+
+// Result is a Rational, over the sum of every way a stage can fail:
+static_assert(std::is_same_v<decltype(evaluate("1/2", add, "3/4")),
+                             fn::expected<Rational, fn::sum<DivByZero, NotANumber, Overflow>>>);
+
 // readme-example
 
 int main()
 {
-  auto const big = Rational::make(2000000000, 1); // fits int32; its square does not
-  return (evaluate(Rational::make(1, 2), Add{}, Rational::make(1, 3)).value() == Rational::make(5, 6)    //
-          && evaluate(Rational::make(2, 3), Mul{}, Rational::make(3, 4)).value() == Rational::make(1, 2) //
-          && Rational::make(1, 0).error().has_value<DivByZero>()                                         //
-          && evaluate(big, Mul{}, big).error().has_value<Overflow>())
+  return (evaluate("1/2", add, "1/3").value() == Rational::make(5, 6)    //
+          && evaluate("2/3", mul, "3/4").value() == Rational::make(1, 2) //
+          && parse("abc").error().has_value<NotANumber>()                //
+          && number("1/0").error().has_value<DivByZero>()                //
+          && evaluate("2000000000", mul, "2000000000").error().has_value<Overflow>())
              ? 0
              : 1;
 }

--- a/include/fn/expected.hpp
+++ b/include/fn/expected.hpp
@@ -1178,7 +1178,9 @@ template <typename Lh, typename Rh>
 {
   using new_error_type
       = sum_for<typename ::std::remove_cvref_t<Lh>::error_type, typename ::std::remove_cvref_t<Rh>::error_type>;
-  constexpr auto efn = [](auto &&v) {
+  // Explicit return type: for a sum<> (never-erroring) operand the else branch is the only one
+  // instantiated, and without this it would deduce void — poisoning _join's return-type deduction.
+  constexpr auto efn = [](auto &&v) -> ::pfn::unexpected<new_error_type> {
     if constexpr (not ::std::is_same_v<typename ::std::remove_cvref_t<decltype(v)>::error_type, sum<>>) {
       return ::pfn::unexpected<new_error_type>(FWD(v).error());
     } else {

--- a/tests/fn/expected.cpp
+++ b/tests/fn/expected.cpp
@@ -2201,8 +2201,11 @@ TEST_CASE("expected pack support", "[expected][pack][and_then][transform][operat
         static_assert((VoidUnit{} & Rh{5}).value() == 5);
         static_assert((VoidUnit{} & Rh{::pfn::unexpect, FileNotFound}).error() == fn::sum{FileNotFound});
         static_assert((Rh{5} & VoidUnit{}).value() == 5);
+        static_assert((Rh{::pfn::unexpect, FileNotFound} & VoidUnit{}).error() == fn::sum{FileNotFound});
 
         CHECK((VoidUnit{} & Rh{5}).value() == 5);
+        CHECK((VoidUnit{} & Rh{::pfn::unexpect, FileNotFound}).error() == fn::sum{FileNotFound});
+        CHECK((Rh{5} & VoidUnit{}).value() == 5);
         CHECK((Rh{::pfn::unexpect, FileNotFound} & VoidUnit{}).error() == fn::sum{FileNotFound});
       }
     }

--- a/tests/fn/expected.cpp
+++ b/tests/fn/expected.cpp
@@ -2119,6 +2119,93 @@ TEST_CASE("expected pack support", "[expected][pack][and_then][transform][operat
         }
       }
     }
+
+    WHEN("unit error grade sum<>")
+    {
+      // A never-erroring expected<T, sum<>> composes with a fallible one: the sum<> operand adds no
+      // alternative to the widened error, only its value to the pack. Previously ill-formed, because the
+      // sum<> side made operator&'s error lambda deduce void and poisoned _join's return type.
+      using Unit = fn::expected<int, fn::sum<>>;
+
+      WHEN("different error, unit on left")
+      {
+        using Rh = fn::expected<int, Error>;
+        static_assert(std::same_as<decltype(std::declval<Unit>() & std::declval<Rh>()),
+                                   fn::expected<fn::pack<int, int>, fn::sum<Error>>>);
+
+        static_assert((Unit{7} & Rh{5}) //
+                          .transform([](int a, int b) constexpr -> bool { return a == 7 && b == 5; })
+                          .value());
+        static_assert((Unit{7} & Rh{::pfn::unexpect, FileNotFound}).error() == fn::sum{FileNotFound});
+
+        CHECK((Unit{7} & Rh{5}) //
+                  .transform([](int a, int b) constexpr -> bool { return a == 7 && b == 5; })
+                  .value());
+        CHECK((Unit{7} & Rh{::pfn::unexpect, FileNotFound}).error() == fn::sum{FileNotFound});
+      }
+
+      WHEN("different error, unit on right")
+      {
+        using Lh = fn::expected<int, Error>;
+        static_assert(std::same_as<decltype(std::declval<Lh>() & std::declval<Unit>()),
+                                   fn::expected<fn::pack<int, int>, fn::sum<Error>>>);
+
+        static_assert((Lh{5} & Unit{7}) //
+                          .transform([](int a, int b) constexpr -> bool { return a == 5 && b == 7; })
+                          .value());
+        static_assert((Lh{::pfn::unexpect, FileNotFound} & Unit{7}).error() == fn::sum{FileNotFound});
+
+        CHECK((Lh{5} & Unit{7}) //
+                  .transform([](int a, int b) constexpr -> bool { return a == 5 && b == 7; })
+                  .value());
+        CHECK((Lh{::pfn::unexpect, FileNotFound} & Unit{7}).error() == fn::sum{FileNotFound});
+      }
+
+      WHEN("unit meets a sum grade, either order")
+      {
+        using Rh = fn::expected<int, fn::sum<Error>>;
+        static_assert(std::same_as<decltype(std::declval<Unit>() & std::declval<Rh>()),
+                                   fn::expected<fn::pack<int, int>, fn::sum<Error>>>);
+        static_assert(std::same_as<decltype(std::declval<Rh>() & std::declval<Unit>()),
+                                   fn::expected<fn::pack<int, int>, fn::sum<Error>>>);
+
+        static_assert((Unit{7} & Rh{::pfn::unexpect, fn::sum{FileNotFound}}).error() == fn::sum{FileNotFound});
+        static_assert((Rh{::pfn::unexpect, fn::sum{FileNotFound}} & Unit{7}).error() == fn::sum{FileNotFound});
+
+        CHECK((Unit{7} & Rh{::pfn::unexpect, fn::sum{FileNotFound}}).error() == fn::sum{FileNotFound});
+        CHECK((Rh{::pfn::unexpect, fn::sum{FileNotFound}} & Unit{7}).error() == fn::sum{FileNotFound});
+      }
+
+      WHEN("same error, both unit")
+      {
+        static_assert(std::same_as<decltype(std::declval<Unit>() & std::declval<Unit>()),
+                                   fn::expected<fn::pack<int, int>, fn::sum<>>>);
+
+        static_assert((Unit{7} & Unit{5}) //
+                          .transform([](int a, int b) constexpr -> bool { return a == 7 && b == 5; })
+                          .value());
+        CHECK((Unit{7} & Unit{5}) //
+                  .transform([](int a, int b) constexpr -> bool { return a == 7 && b == 5; })
+                  .value());
+      }
+
+      WHEN("void operand carries the unit error")
+      {
+        using VoidUnit = fn::expected<void, fn::sum<>>;
+        using Rh = fn::expected<int, Error>;
+        static_assert(
+            std::same_as<decltype(std::declval<VoidUnit>() & std::declval<Rh>()), fn::expected<int, fn::sum<Error>>>);
+        static_assert(
+            std::same_as<decltype(std::declval<Rh>() & std::declval<VoidUnit>()), fn::expected<int, fn::sum<Error>>>);
+
+        static_assert((VoidUnit{} & Rh{5}).value() == 5);
+        static_assert((VoidUnit{} & Rh{::pfn::unexpect, FileNotFound}).error() == fn::sum{FileNotFound});
+        static_assert((Rh{5} & VoidUnit{}).value() == 5);
+
+        CHECK((VoidUnit{} & Rh{5}).value() == 5);
+        CHECK((Rh{::pfn::unexpect, FileNotFound} & VoidUnit{}).error() == fn::sum{FileNotFound});
+      }
+    }
   }
 }
 


### PR DESCRIPTION
The `sum<>` (never-erroring) operand made `operator&`'s error lambda deduce `void`, poisoning `_join`'s return-type deduction; an explicit `unexpected<new_error_type>` return type fixes it. The `README` example is reworked to compose the operator through the fixed path.

Assisted-by: Claude:claude-opus-4-8