### PR TITLE
Implement the tuple protocol for `fn::pack`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 Design history of libfn, newest first. The living documents — [README.md](README.md), [CONTRIBUTING.md](CONTRIBUTING.md), [docs/](docs/) — describe only the present state of the design; when a decision makes an earlier idea obsolete, this file is where the transition is recorded and explained.
 
+## `fn::pack` gained the tuple protocol — 9 July 2026
+
+- **`fn::pack` now models the tuple protocol** — `std::tuple_size`, `std::tuple_element`, and an ADL-found `get<I>`, so a pack works with structured bindings and the generic `using std::get; get<I>(p)` idiom.
+- **A const pack propagates const onto its reference elements.** `get<I>` carries the pack's const through to the element, so `get<0>` on a `const pack<T&>` yields `T const&`. This diverges from `std::tuple<T&>`, whose reference members ignore container const — a deliberate difference: it lets a const pack hand out read-only views of referenced data, which a caller passing a pack of references by const reference generally wants. `std::tuple_element<I, pack const>` is specialized to match `get` rather than defer to the generic `tuple_element<I, const T>` wrapper.
+
 ## `operator&` composes the `sum<>` unit error — 8 July 2026
 
 - **A non-void `fn::expected` carrying the `sum<>` unit error now composes under `operator&`.** A never-erroring operand — `expected<T, sum<>>`, the "cannot fail" grade — folds into a fallible `&`-chain, adding its value to the pack and no alternative to the widened error. The different-error overload had been ill-formed here: its error lambda deduced `void` for the `sum<>` side, poisoning the pack join's return-type deduction. The README example follows the fix, collapsing from a two-stage pipeline into a single `and_then` over the cartesian `(a & op & b)` dispatch table, its operator honestly typed `expected<sum_for<Add, Mul>, sum<>>`.

--- a/include/fn/detail/meta.hpp
+++ b/include/fn/detail/meta.hpp
@@ -10,6 +10,7 @@
 #include <array>
 #include <string>
 #include <string_view>
+#include <tuple>
 #include <type_traits>
 #include <utility>
 

--- a/include/fn/detail/pack_impl.hpp
+++ b/include/fn/detail/pack_impl.hpp
@@ -9,6 +9,7 @@
 #include <fn/detail/functional.hpp>
 #include <fn/detail/fwd.hpp>
 #include <fn/detail/macro_fwd.hpp>
+#include <fn/detail/meta.hpp>
 #include <fn/detail/traits.hpp>
 
 #include <type_traits>
@@ -67,6 +68,14 @@ struct pack_impl<::std::index_sequence<Is...>, Ts...> : _element<Is, Ts>... {
   {
     return ::fn::detail::_invoke(
         FWD(fn), static_cast<apply_const_lvalue_t<Self, Ts &&>>(FWD(self)._element<Is, Ts>::v)..., FWD(args)...);
+  }
+
+  template <::std::size_t I, typename Self>
+  static constexpr decltype(auto) _get(Self &&self) noexcept
+    requires(I < size)
+  {
+    return static_cast<apply_const_lvalue_t<Self, select_nth_t<I, Ts...> &&>>(
+        FWD(self)._element<I, select_nth_t<I, Ts...>>::v);
   }
 
   template <typename T> using append_type = _pack_append<T, Ts...>::type;

--- a/include/fn/pack.hpp
+++ b/include/fn/pack.hpp
@@ -8,9 +8,11 @@
 
 #include <fn/detail/macro_deduced_return.hpp>
 #include <fn/detail/macro_fwd.hpp>
+#include <fn/detail/meta.hpp>
 #include <fn/detail/pack_impl.hpp>
 #include <fn/sum.hpp>
 
+#include <tuple>
 #include <type_traits>
 
 namespace fn {
@@ -287,6 +289,24 @@ template <typename... Ts> struct pack : detail::pack_impl<::std::index_sequence_
 
 template <typename... Args> pack(Args &&...args) -> pack<Args...>;
 
+/**
+ * @brief Tuple-protocol element access
+ *
+ * Returns the `I`-th element carrying the pack's cv-qualification and value
+ * category, exactly as `invoke` would pass it. Found by ADL, so it also serves
+ * structured bindings and the generic `using ::std::get; get<I>(p)` idiom.
+ *
+ * @tparam I element index
+ * @param p the pack
+ * @return reference to the `I`-th element
+ */
+template <::std::size_t I, some_pack P>
+[[nodiscard]] constexpr decltype(auto) get(P &&p) noexcept
+  requires(I < ::std::remove_cvref_t<P>::size)
+{
+  return ::std::remove_cvref_t<P>::template _get<I>(FWD(p));
+}
+
 // Lifts
 /**
  * @brief TODO
@@ -389,5 +409,17 @@ constexpr inline struct identity_t {
 } identity;
 
 } // namespace fn
+
+namespace std {
+// tuple-protocol opt-in for structured bindings. Only the unqualified pack is
+// specialized; the standard library's own tuple_size<const T> / tuple_element<I,
+// const T> partial specializations layer the cv-qualification on top of these.
+template <typename... Ts>
+struct tuple_size<::fn::pack<Ts...>> : ::std::integral_constant<::std::size_t, sizeof...(Ts)> {};
+
+template <::std::size_t I, typename... Ts> struct tuple_element<I, ::fn::pack<Ts...>> {
+  using type = ::fn::detail::select_nth_t<I, Ts...>;
+};
+} // namespace std
 
 #endif // INCLUDE_FN_PACK

--- a/include/fn/pack.hpp
+++ b/include/fn/pack.hpp
@@ -12,7 +12,6 @@
 #include <fn/detail/pack_impl.hpp>
 #include <fn/sum.hpp>
 
-#include <tuple>
 #include <type_traits>
 
 namespace fn {

--- a/include/fn/pack.hpp
+++ b/include/fn/pack.hpp
@@ -410,14 +410,17 @@ constexpr inline struct identity_t {
 } // namespace fn
 
 namespace std {
-// tuple-protocol opt-in for structured bindings. Only the unqualified pack is
-// specialized; the standard library's own tuple_size<const T> / tuple_element<I,
-// const T> partial specializations layer the cv-qualification on top of these.
 template <typename... Ts>
 struct tuple_size<::fn::pack<Ts...>> : ::std::integral_constant<::std::size_t, sizeof...(Ts)> {};
 
 template <::std::size_t I, typename... Ts> struct tuple_element<I, ::fn::pack<Ts...>> {
   using type = ::fn::detail::select_nth_t<I, Ts...>;
+};
+
+// A const pack propagates const onto reference elements, so `tuple_element<I, pack const>`
+// must match `get` and cannot defer to the generic `tuple_element<I, const T>`.
+template <::std::size_t I, typename... Ts> struct tuple_element<I, ::fn::pack<Ts...> const> {
+  using type = decltype(::fn::detail::_apply_const<::fn::pack<Ts...> const &, ::fn::detail::select_nth_t<I, Ts...>>);
 };
 } // namespace std
 

--- a/tests/fn/detail/pack_impl.cpp
+++ b/tests/fn/detail/pack_impl.cpp
@@ -36,6 +36,9 @@ concept can_invoke = requires(P p, Fn fn, Args &&...args) { P::_invoke(p, fn, st
 template <typename P, typename T, typename... Args>
 concept can_append = requires(P p, Args &&...args) { P::template _append<T>(p, static_cast<Args &&>(args)...); };
 
+template <typename P, std::size_t I>
+concept can_get = requires(P p) { std::remove_cvref_t<P>::template _get<I>(static_cast<P &&>(p)); };
+
 } // namespace
 
 TEST_CASE("pack_impl size and aggregate construction", "[pack_impl]")
@@ -130,6 +133,37 @@ TEST_CASE("pack_impl _invoke", "[pack_impl][invoke]")
   static_assert(not can_invoke<P, decltype([](int *, int *) {})>);
   // positive control
   static_assert(can_invoke<P, decltype([](int, double) {})>);
+}
+
+TEST_CASE("pack_impl _get", "[pack_impl][get]")
+{
+  using fn::detail::pack_impl;
+  using P = pack_impl<std::index_sequence_for<int, double>, int, double>;
+
+  // value category of the pack is carried onto the returned reference
+  P p{2, 4.0};
+  static_assert(std::same_as<decltype(P::_get<0>(p)), int &>);
+  static_assert(std::same_as<decltype(P::_get<1>(p)), double &>);
+  static_assert(std::same_as<decltype(P::_get<0>(std::as_const(p))), int const &>);
+  static_assert(std::same_as<decltype(P::_get<0>(std::move(p))), int &&>);
+  static_assert(std::same_as<decltype(P::_get<0>(std::move(std::as_const(p)))), int const &&>);
+
+  CHECK(P::_get<0>(p) == 2);
+  CHECK(P::_get<1>(p) == 4.0);
+  P::_get<0>(p) = 5;
+  CHECK(P::_get<0>(p) == 5);
+
+  // in-range indices are viable, out-of-range is not
+  static_assert(can_get<P &, 0>);
+  static_assert(can_get<P &, 1>);
+  static_assert(not can_get<P &, 2>);
+
+  // constexpr twin
+  static_assert([] {
+    P q{7, 1.5};
+    P::_get<1>(q) = 3.5;
+    return P::_get<0>(q) == 7 && P::_get<1>(q) == 3.5;
+  }());
 }
 
 TEST_CASE("pack_impl _append and append_type", "[pack_impl][append][append_type]")

--- a/tests/fn/pack.cpp
+++ b/tests/fn/pack.cpp
@@ -12,6 +12,7 @@
 
 #include <catch2/catch_all.hpp>
 
+#include <tuple>
 #include <utility>
 
 namespace {
@@ -677,4 +678,88 @@ TEST_CASE("operator &", "[pack][sum][operator_and]")
                     fn::pack<int, int, double, double, bool, double, int>> const>);
   static_assert(r2.invoke([](auto &&...args) -> double { return (1 * ... * static_cast<double>(args)); })
                 == 12. * 3 * 2.5 * 0.5 * 1 * 1.5 * 12);
+}
+
+namespace {
+template <typename P, std::size_t I>
+concept can_get = requires(P p) { fn::get<I>(static_cast<P &&>(p)); };
+} // namespace
+
+TEST_CASE("pack get and tuple protocol", "[pack][get][tuple]")
+{
+  using fn::get;
+  using fn::pack;
+
+  // tuple_size / tuple_element
+  static_assert(std::tuple_size_v<pack<int, double, A>> == 3);
+  static_assert(std::tuple_size_v<pack<>> == 0);
+  static_assert(std::same_as<std::tuple_element_t<0, pack<int, double, A>>, int>);
+  static_assert(std::same_as<std::tuple_element_t<1, pack<int, double, A>>, double>);
+  static_assert(std::same_as<std::tuple_element_t<2, pack<int, double, A>>, A>);
+  // the library's tuple_element<I, const T> propagates const onto value elements
+  static_assert(std::same_as<std::tuple_element_t<0, pack<int, double, A> const>, int const>);
+
+  // get value categories mirror what invoke passes
+  pack<int, double> p{2, 4};
+  static_assert(std::same_as<decltype(get<0>(p)), int &>);
+  static_assert(std::same_as<decltype(get<1>(p)), double &>);
+  static_assert(std::same_as<decltype(get<0>(std::as_const(p))), int const &>);
+  static_assert(std::same_as<decltype(get<0>(std::move(p))), int &&>);
+  static_assert(std::same_as<decltype(get<0>(std::move(std::as_const(p)))), int const &&>);
+
+  CHECK(get<0>(p) == 2);
+  CHECK(get<1>(p) == 4.0);
+  get<0>(p) = 7;
+  CHECK(get<0>(p) == 7);
+
+  // out-of-range index is not viable (SFINAE-clean, not a hard error)
+  static_assert(can_get<pack<int, double> &, 0>);
+  static_assert(can_get<pack<int, double> &, 1>);
+  static_assert(not can_get<pack<int, double> &, 2>);
+  static_assert(not can_get<pack<> &, 0>);
+
+  // reference-holding element: a non-const pack yields the stored reference
+  int x = 11;
+  pack<int &> r{x};
+  static_assert(std::same_as<std::tuple_element_t<0, pack<int &>>, int &>);
+  static_assert(std::same_as<decltype(get<0>(r)), int &>);
+  get<0>(r) = 12;
+  CHECK(x == 12);
+
+  // structured bindings over an lvalue pack alias the elements
+  auto &[a0, a1] = p;
+  CHECK(a0 == 7);
+  CHECK(a1 == 4.0);
+  a0 = 9;
+  CHECK(get<0>(p) == 9);
+
+  // structured bindings over an rvalue pack move the elements out
+  auto [b0, b1] = std::move(p);
+  static_assert(std::same_as<decltype(b0), int>);
+  static_assert(std::same_as<decltype(b1), double>);
+  CHECK(b0 == 9);
+  CHECK(b1 == 4.0);
+
+  // generic idiom: unqualified get with std::get also in scope resolves to fn::get by ADL
+  {
+    using std::get;
+    pack<int, double> q{3, 1.5};
+    CHECK(get<0>(q) == 3);
+    CHECK(get<1>(q) == 1.5);
+  }
+
+  // constexpr twins
+  static_assert(std::tuple_size_v<pack<int, double>> == 2);
+  static_assert([] {
+    pack<int, double> q{5, 2.5};
+    auto &[c0, c1] = q;
+    c0 = 6;
+    return get<0>(q) == 6 && get<1>(q) == 2.5;
+  }());
+  static_assert([] {
+    int y = 3;
+    pack<int &> s{y};
+    get<0>(s) = 4;
+    return y == 4;
+  }());
 }

--- a/tests/fn/pack.cpp
+++ b/tests/fn/pack.cpp
@@ -726,6 +726,20 @@ TEST_CASE("pack get and tuple protocol", "[pack][get][tuple]")
   get<0>(r) = 12;
   CHECK(x == 12);
 
+  // const pack of a reference: fn propagates const through the reference (unlike
+  // std::tuple<int&>, whose reference member is immune to container const), so
+  // get and tuple_element agree on int const& here.
+  static_assert(std::same_as<std::tuple_element_t<0, pack<int &> const>, int const &>);
+  static_assert(std::same_as<decltype(get<0>(std::as_const(r))), int const &>);
+  static_assert(std::same_as<decltype(get<0>(std::move(std::as_const(r)))), int const &>);
+  CHECK(get<0>(std::as_const(r)) == 12);
+  // a const structured binding over the const pack observes the const-propagated reference
+  {
+    auto const &[e0] = std::as_const(r);
+    static_assert(std::same_as<decltype(e0), int const &>);
+    CHECK(e0 == 12);
+  }
+
   // structured bindings over an lvalue pack alias the elements
   auto &[a0, a1] = p;
   CHECK(a0 == 7);
@@ -761,5 +775,15 @@ TEST_CASE("pack get and tuple protocol", "[pack][get][tuple]")
     pack<int &> s{y};
     get<0>(s) = 4;
     return y == 4;
+  }());
+  static_assert([] {
+    int y = 5;
+    pack<int &> s{y};
+    // const-propagation twin: get on the const pack yields int const&, and
+    // tuple_element agrees, so the binding is read-only yet still aliases y.
+    static_assert(std::same_as<decltype(get<0>(std::as_const(s))), int const &>);
+    static_assert(std::same_as<std::tuple_element_t<0, pack<int &> const>, int const &>);
+    auto const &[e0] = std::as_const(s);
+    return e0 == 5;
   }());
 }


### PR DESCRIPTION
Add `get<I>`, `std::tuple_size`, and `std::tuple_element` so a pack works with structured bindings and the generic `using std::get; get<I>(p)` idiom. `get<I>` carries the pack's cv-qualification and value category, matching what `invoke` passes.

The detail `_get<I>` keeps a deduced `decltype(auto)` return with no body-local alias, and the public `get` takes an explicit `some_pack P` parameter rather than `auto&&` + `decltype(p)`: both avoid MSVC's deduced-return type leak, while a trailing return type is unavailable here because the return expression instantiates `select_nth_t`/`_element`, which hard-assert out of range on a constrained overload.

Assisted-by: Claude:claude-opus-4-8