### PR TITLE
Clean up unit tests: uniform coverage, then uniform structure

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -45,8 +45,9 @@ C++20 is the sole export surface — fn + pfn build and pass tests as C++20 on a
 
 ## Tests
 
+- Test standards: CONTRIBUTING.md `## Unit tests` (reference shape, assertion kinds, probe idioms) — read before writing tests; the two below are load-bearing.
+- The kind of fact decides the assertion: a fact the compiler decides (noexcept, a trait, overload viability, concept satisfaction) is `static_assert` ALONE — `CHECK(noexcept(…))` is `CHECK(true)`, never add or request one. Behaviour the program performs gets BOTH a runtime `CHECK` (a `static_assert`-only executable branch is a codecov hole) and a constant-evaluation twin (constexpr diagnoses UB; users rely on it). CT-only `SECTION`s end with `SUCCEED()`.
 - Add each check to the existing `TEST_CASE`/`SECTION` (or file) covering that member/behaviour, matching local idiom — not the nearest spot or a catch-all. A check in the right named section is self-documenting.
-- Every behaviour gets both a runtime `CHECK` (a `static_assert`-only branch is a codecov hole) and a constant-evaluation twin (`static_assert`) — constexpr diagnoses UB at compile time, and users rely on it.
 
 ## Tooling
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -15,7 +15,7 @@ Conventions for AI agents in this repo (you are the primary reader — keep this
 
 - Trailer `Assisted-by: Claude:<exact session model id>` (Linux-kernel convention), e.g. `claude-opus-4-8`. No `Co-Authored-By:`.
 - Offer commits; never commit without confirmation. Terse messages: imperative topic, body only if needed.
-- A feature or fix and its tests written together land as one commit.
+- A feature or fix commit should include a test for the behaviour it changes; exceptions are allowed. The PR must contain such a test somewhere unless the behaviour is inherently untestable (for example, because of language or compiler limitations); explain the omission.
 - Never `git push` or sign commits — the user signs (GPG) and pushes.
 
 ## Git state
@@ -45,9 +45,7 @@ C++20 is the sole export surface — fn + pfn build and pass tests as C++20 on a
 
 ## Tests
 
-- Test standards: CONTRIBUTING.md `## Unit tests` (reference shape, assertion kinds, probe idioms) — read before writing tests; the two below are load-bearing.
-- The kind of fact decides the assertion: a fact the compiler decides (noexcept, a trait, overload viability, concept satisfaction) is `static_assert` ALONE — `CHECK(noexcept(…))` is `CHECK(true)`, never add or request one. Behaviour the program performs gets BOTH a runtime `CHECK` (a `static_assert`-only executable branch is a codecov hole) and a constant-evaluation twin (constexpr diagnoses UB; users rely on it). CT-only `SECTION`s end with `SUCCEED()`.
-- Add each check to the existing `TEST_CASE`/`SECTION` (or file) covering that member/behaviour, matching local idiom — not the nearest spot or a catch-all. A check in the right named section is self-documenting.
+- Before writing or reviewing tests, read and follow `CONTRIBUTING.md` from `## Unit tests` to the next top-level heading; it is the source of truth for test structure, assertions and compile-time probes.
 
 ## Tooling
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -20,30 +20,35 @@ g++ -std=c++20 -Iinclude examples/polygon/main.cpp -o /tmp/polygon
 
 ## Unit tests
 
-In this project, 100% tests coverage does not actually mean much, because the most useful tests cases are around compile-time language elements, such as overload resolution, built-in conversions etc. Any meaningful tests must execute the same set of functions in many, subtly different ways, rather than simply execute each function and branch at least once.
-
-An entity's tests span four dimensions: its observable behaviour at runtime, the same behaviour in constant evaluation, the exactness of its `noexcept` specification, and the accuracy of its constraints — positive and negative. (Entities that exist only at compile time — traits, concepts — have only the compile-time dimensions.)
+Although we aim for 100% unit-test coverage, executing every line and branch tells only part of the story in this project. Many important guarantees are compile-time properties, such as overload resolution, conversions, constraints and `noexcept` specifications. Tests must therefore exercise an interface with combinations of value categories and type properties, not merely execute every line.
 
 ### Structure
 
-A `TEST_CASE` covers one entity, a top-level `SECTION` covers one member function or overload set, and nested `SECTION`s cover the product of dimensions that member spans — value category first, then type properties. Keep section names short, and use plain `SECTION` rather than the BDD macros (`WHEN`, `GIVEN`, `THEN`). `tests/pfn/expected.cpp` is the reference shape; when unsure how to organise a test, imitate it.
+A consistent test shape helps make those combinations visible. The guidelines below are a living standard and may evolve when a clearer structure reveals coverage more effectively.
 
-* Declare the subject alias and the probe lambdas once, at `TEST_CASE` scope; nested sections use them rather than re-declaring their own.
-* A new check belongs in the existing `TEST_CASE`/`SECTION` covering that member or behaviour, matching the local idiom — not the nearest convenient spot or a catch-all case. A check in the right named section is self-documenting.
+* Use one `TEST_CASE` for each file-level entity (a class, a specialisation, an overload set, etc.) and one top-level `SECTION` for each member function or overload set.
+* Use nested sections for the combinations that the member supports: normally value category first, then type properties. Put constraint checks last. A test's place in the `TEST_CASE`/`SECTION` hierarchy should say what it tests; do not put it in the nearest convenient section or a catch-all case.
+* Choose the dimensions relevant to the interface under test. Common dimensions include the four cv/ref value categories (`&`, `const &`, `&&` and `const &&`) and properties of the participating types, such as whether they support default, copy or move construction and assignment, and whether those operations are trivial or nothrow. These examples are not exhaustive; they illustrate the range of cases a thorough unit test may need to cover.
+* Keep section names short. Use `SECTION`, not the BDD macros (`GIVEN`, `WHEN` and `THEN`).
+* Declare the subject alias and reusable probe lambdas once, at `TEST_CASE` scope, rather than redeclaring them in nested sections.
+* Use `TEMPLATE_TEST_CASE` only when the same test battery genuinely applies to several subjects. Because it is a macro, give template arguments containing commas a named alias before passing them to it.
+* When restructuring tests, run them and record Catch2's test-case and assertion counts before and after the change. The counts should not change accidentally: `SUCCEED()` contributes one assertion per leaf section, while an assertion in a parent section runs once for every leaf below it.
 
-### The kind of fact decides the assertion
+### Assertions
 
-* **A fact the compiler decides** — a `noexcept` specification, a type or a trait, overload viability, concept satisfaction — is asserted with `static_assert` alone. A runtime `CHECK` of such a fact cannot fail once the file compiles, and executes no library code: `CHECK(noexcept(f()))` is `CHECK(true)`. There is no coverage hole to fill either — a specifier has no executable lines. This is the rule to cite when a review asks for a runtime `CHECK` of a compile-time fact.
+Match the assertion to the kind of fact being tested.
 
-* **Behaviour the program performs** — a value computed, a side effect, a state change, an exception thrown — gets both a runtime `CHECK` and a constant-evaluation twin replaying the same operations inside a `static_assert`. The runtime check executes the instrumented lines — a `static_assert`-only executable branch is a coverage hole — and the twin is a UB detector: constant evaluation is required to diagnose UB, and users rely on the library in `constexpr` for exactly this. When a branch exists to give a guarantee, exercise both its failure and its success — a path tested only through `CHECK_THROWS_AS` never runs to completion.
+* Use `static_assert` without a runtime twin for a fact decided by the compiler: a `noexcept` specification, overload viability, concept satisfaction, a result type, or a property of default, copy or move construction and assignment, including whether an operation is trivial or nothrow. Do not apply a runtime assertion such as `CHECK` to a compiler-generated constant (for example, `noexcept(f())`); it adds neither coverage nor useful information.
+* Test behaviour performed by the program — a computed value, side effect or state change — both at runtime with `CHECK` and in constant evaluation with a `static_assert` twin that repeats the same operations. The runtime test provides coverage and lets sanitizers observe the execution. The `static_assert` verifies that users can perform the same operation in constant evaluation, allowing them to use the compiler to diagnose undefined behaviour.
+* For code that may throw, test the expected exception at runtime with `CHECK_THROWS_AS`. Also exercise the same operation in a non-throwing case, both at runtime and in constant evaluation: a throwing-path test alone never lets that code run to completion.
+* End a `SECTION` containing only compile-time assertions with `SUCCEED()`. This satisfies Catch2's no-assertion warning and makes such sections easy to find.
 
-* A `SECTION` containing only compile-time checks ends with `SUCCEED()` — it satisfies Catch2's no-assertion warning and makes such sections easy to find.
+### Compile-time probes
 
-### Negative assertions
+* Pair every negative assertion with its converse. For example, `static_assert(not noexcept(expr))` also passes if the specification is unconditionally false. Add a witness for which it is true, so the pair proves that the specification is conditional. Give a negative constraint or viability probe a positive control for the same reason, choosing witnesses that exercise the relevant corner cases.
+* Make the expression in a negative viability probe dependent on a template parameter. A requires-expression over concrete types is not a substitution context and an invalid requirement is a hard error. Put the dependent probe in a generic lambda or a type-keyed concept so that invalid substitution produces `false`.
 
-* **Every negative wants its converse.** `static_assert(not noexcept(expr))` alone also passes when the specification is unconditionally false — which is precisely the defect it exists to catch. Pair it with a witness that makes the specification true, so the pair shows the specification conditional rather than merely absent. Constraints likewise: a non-viability probe wants its positive control.
-
-* **Negative viability probes must be dependent.** A requires-expression written directly over concrete types hard-errors when a requirement is invalid — false-on-invalid applies only during template-argument substitution. Wrap the probe in a generic lambda returning `requires { … }`, or in a type-keyed concept, so the failure lands in an immediate context and yields `false`.
+Choose fixtures with care when probing exception specifications. `helper_t` has a separate constructor for each value category, and its non-const-lvalue copy constructor is always `noexcept`. A `helper_t` configured to throw is therefore not throwing for every value category, and a specification that remains `noexcept` for that constructor may be correct. Use a plain local type when the test needs every relevant construction to be potentially throwing.
 
 ## Versioning
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -18,11 +18,32 @@ For a quick check of a single example without the full CMake/Catch2 setup:
 g++ -std=c++20 -Iinclude examples/polygon/main.cpp -o /tmp/polygon
 ```
 
-## Test coverage
+## Unit tests
 
 In this project, 100% tests coverage does not actually mean much, because the most useful tests cases are around compile-time language elements, such as overload resolution, built-in conversions etc. Any meaningful tests must execute the same set of functions in many, subtly different ways, rather than simply execute each function and branch at least once.
 
-Two rules: every behaviour gets both a runtime `CHECK` and a constant-evaluation twin (`static_assert`), and a new check belongs in the existing `TEST_CASE`/`SECTION` covering that member or behaviour, matching the local idiom. The twin, because constant evaluation diagnoses UB at compile time — users rely on it — while a `static_assert`-only branch is a coverage hole; the placement, because a check in the right named section is self-documenting.
+An entity's tests span four dimensions: its observable behaviour at runtime, the same behaviour in constant evaluation, the exactness of its `noexcept` specification, and the accuracy of its constraints — positive and negative. (Entities that exist only at compile time — traits, concepts — have only the compile-time dimensions.)
+
+### Structure
+
+A `TEST_CASE` covers one entity, a top-level `SECTION` covers one member function or overload set, and nested `SECTION`s cover the product of dimensions that member spans — value category first, then type properties. Keep section names short, and use plain `SECTION` rather than the BDD macros (`WHEN`, `GIVEN`, `THEN`). `tests/pfn/expected.cpp` is the reference shape; when unsure how to organise a test, imitate it.
+
+* Declare the subject alias and the probe lambdas once, at `TEST_CASE` scope; nested sections use them rather than re-declaring their own.
+* A new check belongs in the existing `TEST_CASE`/`SECTION` covering that member or behaviour, matching the local idiom — not the nearest convenient spot or a catch-all case. A check in the right named section is self-documenting.
+
+### The kind of fact decides the assertion
+
+* **A fact the compiler decides** — a `noexcept` specification, a type or a trait, overload viability, concept satisfaction — is asserted with `static_assert` alone. A runtime `CHECK` of such a fact cannot fail once the file compiles, and executes no library code: `CHECK(noexcept(f()))` is `CHECK(true)`. There is no coverage hole to fill either — a specifier has no executable lines. This is the rule to cite when a review asks for a runtime `CHECK` of a compile-time fact.
+
+* **Behaviour the program performs** — a value computed, a side effect, a state change, an exception thrown — gets both a runtime `CHECK` and a constant-evaluation twin replaying the same operations inside a `static_assert`. The runtime check executes the instrumented lines — a `static_assert`-only executable branch is a coverage hole — and the twin is a UB detector: constant evaluation is required to diagnose UB, and users rely on the library in `constexpr` for exactly this. When a branch exists to give a guarantee, exercise both its failure and its success — a path tested only through `CHECK_THROWS_AS` never runs to completion.
+
+* A `SECTION` containing only compile-time checks ends with `SUCCEED()` — it satisfies Catch2's no-assertion warning and makes such sections easy to find.
+
+### Negative assertions
+
+* **Every negative wants its converse.** `static_assert(not noexcept(expr))` alone also passes when the specification is unconditionally false — which is precisely the defect it exists to catch. Pair it with a witness that makes the specification true, so the pair shows the specification conditional rather than merely absent. Constraints likewise: a non-viability probe wants its positive control.
+
+* **Negative viability probes must be dependent.** A requires-expression written directly over concrete types hard-errors when a requirement is invalid — false-on-invalid applies only during template-argument substitution. Wrap the probe in a generic lambda returning `requires { … }`, or in a type-keyed concept, so the failure lands in an immediate context and yields `false`.
 
 ## Versioning
 

--- a/cmake/Coverage.cmake
+++ b/cmake/Coverage.cmake
@@ -7,8 +7,6 @@
 
 set(CODE_COVERAGE_VERBOSE ON)
 set(CODE_COVERAGE_FORMAT "xml" CACHE STRING "Format of the coverage report.")
-set(CODE_COVERAGE_TEST "ctest" CACHE STRING "Command to run tests.")
-set(CODE_COVERAGE_TEST_ARGS -L tests_fn -j1 CACHE STRING "Parameters to the test command.")
 set(GCOVR_ADDITIONAL_ARGS
 --exclude-noncode-lines
 --exclude-unreachable-branches

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -13,7 +13,6 @@ set(TESTS_UTIL_HEADERS
 
 add_library(tests_util INTERFACE)
 set_property(TARGET tests_util PROPERTY CXX_STANDARD 20)
-target_compile_features(tests_util INTERFACE cxx_std_20)
 target_sources(tests_util INTERFACE
     FILE_SET tests_util_headers
     TYPE HEADERS

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -19,7 +19,7 @@ target_sources(tests_util INTERFACE
     TYPE HEADERS
     FILES ${TESTS_UTIL_HEADERS})
 target_include_directories(tests_util INTERFACE ${CMAKE_CURRENT_SOURCE_DIR})
-target_link_libraries(tests_util INTERFACE include_pfn)
+# No libfn dependency by design: the test utilities must not be built on what they are used to test.
 target_compile_features(tests_util INTERFACE cxx_std_20)
 
 # Generate sentinel target for each individual header, as a basic sanity check
@@ -149,7 +149,7 @@ foreach(mode 20 23)
         create_target_for_file(
             NAME "${target}"
             SOURCE "${source}"
-            DEPENDENCIES tests_util Catch2::Catch2WithMain
+            DEPENDENCIES include_fn tests_util Catch2::Catch2WithMain
         )
         append_compilation_options("${target}" WARNINGS OPTIMIZATION TESTS)
         add_dependencies("cxx${mode}" "${target}")

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -4,9 +4,8 @@ project(tests)
 set(CMAKE_CXX_EXTENSIONS OFF)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
-# tests_util: shared test helpers. Links include_pfn so static_check.hpp's fn
-# includes resolve at cxx_std_20 (include_pfn exposes include/, containing fn/).
-# Pls keep the filenames sorted
+### tests/util
+
 set(TESTS_UTIL_HEADERS
     util/helper_types.hpp
     util/static_check.hpp
@@ -14,12 +13,12 @@ set(TESTS_UTIL_HEADERS
 
 add_library(tests_util INTERFACE)
 set_property(TARGET tests_util PROPERTY CXX_STANDARD 20)
+target_compile_features(tests_util INTERFACE cxx_std_20)
 target_sources(tests_util INTERFACE
     FILE_SET tests_util_headers
     TYPE HEADERS
     FILES ${TESTS_UTIL_HEADERS})
 target_include_directories(tests_util INTERFACE ${CMAKE_CURRENT_SOURCE_DIR})
-# No libfn dependency by design: the test utilities must not be built on what they are used to test.
 target_compile_features(tests_util INTERFACE cxx_std_20)
 
 # Generate sentinel target for each individual header, as a basic sanity check

--- a/tests/fn/and_then.cpp
+++ b/tests/fn/and_then.cpp
@@ -361,6 +361,50 @@ TEST_CASE("and_then", "[and_then][expected][expected_value][pack]")
   static_assert(is::not_invocable_with_any([]() -> operand_t { throw 0; }));                      // bad arity
   static_assert(is::not_invocable_with_any([](int, int) -> operand_t { throw 0; }));              // bad arity
 
+  WHEN("noexcept")
+  {
+    constexpr auto fnNothrow = [](int i) noexcept -> operand_t { return {i + 1}; };
+    constexpr auto fnThrows = [](int i) noexcept(false) -> operand_t { return {i + 1}; };
+
+    // The member's spec is precise, and weighs BOTH sides: the callback, and the copy of the
+    // untouched error. Error carries a std::string, whose copy can throw on its own - so even a
+    // noexcept callback leaves the member potentially-throwing here.
+    static_assert(not std::is_nothrow_copy_constructible_v<Error>);
+    static_assert(not noexcept(std::declval<operand_t &>().and_then(fnNothrow)));
+    static_assert(not noexcept(std::declval<operand_t &>().and_then(fnThrows)));
+
+    // Give it an error whose copy cannot throw, and the callback alone decides.
+    using nothrow_t = fn::expected<int, int>;
+    constexpr auto fnNothrow2 = [](int i) noexcept -> nothrow_t { return {i + 1}; };
+    constexpr auto fnThrows2 = [](int i) noexcept(false) -> nothrow_t { return {i + 1}; };
+    static_assert(noexcept(std::declval<nothrow_t &>().and_then(fnNothrow2)));
+    static_assert(not noexcept(std::declval<nothrow_t &>().and_then(fnThrows2)));
+
+    // GAP #285: the verb then discards that answer. Every step of the pipeline - the nielbloid,
+    // operator|, _swap_invoke and apply - is unconditionally noexcept, so a throwing callback the
+    // member would propagate instead crosses a noexcept boundary and terminates.
+    static_assert(noexcept(std::declval<nothrow_t &>() | and_then(fnThrows2)));
+    static_assert(noexcept(std::declval<operand_t &>() | and_then(fnThrows)));
+    static_assert(noexcept(std::declval<operand_t &&>() | and_then(fnThrows)));
+
+    // Constructing the functor copies the callable into a pack, and that copy can throw too.
+    struct ThrowingCopy final {
+      ThrowingCopy() = default;
+      ThrowingCopy(ThrowingCopy const &) noexcept(false) {}
+      ThrowingCopy(ThrowingCopy &&) noexcept(false) {}
+      auto operator()(int i) const noexcept -> operand_t { return {i + 1}; }
+    };
+    static_assert(not std::is_nothrow_copy_constructible_v<ThrowingCopy>);
+    static_assert(noexcept(and_then(std::declval<ThrowingCopy const &>()))); // GAP #285
+
+    // fn::invoke reaches the very same apply, yet reports noexcept(false) even for a callback that
+    // cannot throw - the #45 traits behind it are stubbed false. The library's two entry points to
+    // one operation disagree, and each is wrong in the opposite direction.
+    static_assert(not noexcept(fn::invoke(and_then_t::apply{}, std::declval<operand_t &>(), fnNothrow)));
+
+    SUCCEED();
+  }
+
   WHEN("operand is lvalue")
   {
     WHEN("operand is value")
@@ -488,6 +532,28 @@ TEST_CASE("and_then", "[and_then][expected][expected_void]")
   static_assert(is::not_invocable_with_any([](int) -> operand_t { throw 0; }));        // bad arity
   static_assert(is::not_invocable_with_any([](int, int) -> operand_t { throw 0; }));   // bad arity
 
+  WHEN("noexcept")
+  {
+    constexpr auto fnNothrow = []() noexcept -> operand_t { return {}; };
+    constexpr auto fnThrows = []() noexcept(false) -> operand_t { return {}; };
+
+    // As for a non-void value: the member weighs the untouched error's copy too, and Error's can
+    // throw - so give it a nothrow error to see the callback alone decide.
+    static_assert(not noexcept(std::declval<operand_t &>().and_then(fnNothrow)));
+
+    using nothrow_t = fn::expected<void, int>;
+    constexpr auto fnNothrow2 = []() noexcept -> nothrow_t { return {}; };
+    constexpr auto fnThrows2 = []() noexcept(false) -> nothrow_t { return {}; };
+    static_assert(noexcept(std::declval<nothrow_t &>().and_then(fnNothrow2)));
+    static_assert(not noexcept(std::declval<nothrow_t &>().and_then(fnThrows2)));
+
+    // GAP #285: the verb is unconditionally noexcept regardless.
+    static_assert(noexcept(std::declval<nothrow_t &>() | and_then(fnThrows2)));
+    static_assert(noexcept(std::declval<operand_t &>() | and_then(fnThrows)));
+    static_assert(noexcept(std::declval<operand_t &&>() | and_then(fnThrows)));
+    SUCCEED();
+  }
+
   WHEN("operand is lvalue")
   {
     WHEN("operand is value")
@@ -591,6 +657,19 @@ TEST_CASE("and_then", "[and_then][optional][pack]")
   static_assert(is::not_invocable_with_any([](std::string) -> operand_t { throw 0; }));           // bad type
   static_assert(is::not_invocable_with_any([]() -> operand_t { throw 0; }));                      // bad arity
   static_assert(is::not_invocable_with_any([](int, int) -> operand_t { throw 0; }));              // bad arity
+
+  WHEN("noexcept")
+  {
+    constexpr auto fnNothrow = [](int i) noexcept -> operand_t { return {i + 1}; };
+    constexpr auto fnThrows = [](int i) noexcept(false) -> operand_t { return {i + 1}; };
+
+    // As for expected: the member is precise, the verb is not (GAP #285).
+    static_assert(noexcept(std::declval<operand_t &>().and_then(fnNothrow)));
+    static_assert(not noexcept(std::declval<operand_t &>().and_then(fnThrows)));
+    static_assert(noexcept(std::declval<operand_t &>() | and_then(fnThrows)));
+    static_assert(noexcept(std::declval<operand_t &&>() | and_then(fnThrows)));
+    SUCCEED();
+  }
 
   WHEN("operand is lvalue")
   {
@@ -718,6 +797,22 @@ TEST_CASE("and_then choice", "[and_then][choice]")
   static_assert(is::not_invocable_with_any([](int &) -> operand_t { throw 0; }));    // not enough types
   static_assert(is::not_invocable_with_any([]() -> operand_t { throw 0; }));         // bad arity
   static_assert(is::not_invocable_with_any([](int, int) -> operand_t { throw 0; })); // bad arity
+
+  WHEN("noexcept")
+  {
+    constexpr auto fnThrows = [](auto i) noexcept(false) -> operand_t { return {i + 1}; };
+
+    // GAP #280: choice differs from its siblings - its own and_then is unconditionally noexcept too
+    // (it dispatches through sum::invoke), so here even the MEMBER over-promises. The same monadic
+    // operation therefore has different exception behaviour depending on which monad it is written
+    // against: optional and expected propagate, choice terminates.
+    static_assert(noexcept(std::declval<operand_t &>().and_then(fnThrows)));
+
+    // GAP #285: the verb layer over-promises for every monad, choice included.
+    static_assert(noexcept(std::declval<operand_t &>() | and_then(fnThrows)));
+    static_assert(noexcept(std::declval<operand_t &&>() | and_then(fnThrows)));
+    SUCCEED();
+  }
 
   WHEN("operand is lvalue")
   {
@@ -1045,5 +1140,24 @@ static_assert(not invocable_and_then<decltype(fn_int_lvalue<expected<Value, Erro
 static_assert(invocable_and_then<decltype(fn_int_lvalue<expected<Value, Error>>), expected<int, Error> &>);
 static_assert(invocable_and_then<decltype(fn_int_rvalue<expected<Value, Error>>), expected<int, Error>>);
 static_assert(not invocable_and_then<decltype(fn_int_rvalue<expected<Value, Error>>), expected<int, Error> &>); // cannot bind lvalue to rvalue-ref
+
+// A sum error type grades the monad: the callback may then return an expected with a DIFFERENT error,
+// which the operation widens into the sum. Without one, the error types must match exactly - the two
+// disjuncts above and below are what tell those cases apart.
+static_assert(invocable_and_then<decltype(fn_int<expected<Value, sum<Error>>>), expected<int, sum<Error>>>);
+static_assert(invocable_and_then<decltype(fn_int<expected<Value, Xerror>>), expected<int, sum<Error>>>);         // widens the error
+static_assert(invocable_and_then<decltype(fn_int<expected<Value, Error>>), expected<int, sum<Error, Xerror>>>);  // already covered by the sum
+static_assert(not invocable_and_then<decltype(fn_int<expected<Value, Xerror>>), expected<int, Error>>);          // no sum: error must match
+static_assert(invocable_and_then<decltype(fn_generic<expected<Value, Xerror>>), expected<void, sum<Error>>>);    // ... and the same for void
+static_assert(not invocable_and_then<decltype(fn_generic<expected<Value, Xerror>>), expected<void, Error>>);
+
+// choice - the concept's remaining disjunct
+static_assert(invocable_and_then<decltype(fn_generic<choice<int>>), choice<int>>);
+static_assert(invocable_and_then<decltype(fn_generic<choice<Value>>), choice<int>>);                            // may change the type
+static_assert(not invocable_and_then<decltype(fn_generic<optional<int>>), choice<int>>);                        // must stay a choice
+static_assert(not invocable_and_then<decltype(fn_generic<expected<int, Error>>), choice<int>>);
+static_assert(not invocable_and_then<decltype(fn_generic<choice<int>>), optional<int>>);                        // mixed choice and optional
+static_assert(not invocable_and_then<decltype(fn_int_lvalue<choice<int>>), choice<int>>);                       // cannot bind temporary to lvalue
+static_assert(invocable_and_then<decltype(fn_int_lvalue<choice<int>>), choice<int> &>);
 // clang-format on
 } // namespace fn

--- a/tests/fn/and_then.cpp
+++ b/tests/fn/and_then.cpp
@@ -44,82 +44,96 @@ template <typename R> struct Xfn final {
   auto operator()(Xint const &&v) const noexcept -> R { return {v.value + 4}; }
 };
 
-namespace check_expected {
-using operand_t = fn::expected<Xint, Error>;
-using is = monadic_static_check<fn::and_then_t, operand_t>;
+using ExpectedXint = fn::expected<Xint, Error>;
+using OptionalXint = fn::optional<Xint>;
 
-static_assert(is::invocable_with_any(Xint::efn));
-static_assert(is::invocable<lvalue>(&Xint::efn1));
-static_assert(is::not_invocable<prvalue, cvalue, clvalue, rvalue, crvalue>(&Xint::efn1));
-static_assert(is::invocable_with_any(&Xint::efn2));
-static_assert(is::invocable<prvalue, rvalue>(&Xint::efn3));
-static_assert(is::not_invocable<cvalue, lvalue, clvalue, crvalue>(&Xint::efn3));
-static_assert(is::invocable<prvalue, cvalue, rvalue, crvalue>(&Xint::efn4));
-static_assert(is::not_invocable<lvalue, clvalue>(&Xint::efn4));
-} // namespace check_expected
+// One battery serves both monads: the member set differs only in the returned monad.
+template <typename Operand> struct member_fns;
+template <> struct member_fns<ExpectedXint> {
+  using result_t = fn::expected<int, Error>;
+  static constexpr auto fn0 = Xint::efn;
+  static constexpr auto fn1 = &Xint::efn1;
+  static constexpr auto fn2 = &Xint::efn2;
+  static constexpr auto fn3 = &Xint::efn3;
+  static constexpr auto fn4 = &Xint::efn4;
+};
+template <> struct member_fns<OptionalXint> {
+  using result_t = fn::optional<int>;
+  static constexpr auto fn0 = Xint::ofn;
+  static constexpr auto fn1 = &Xint::ofn1;
+  static constexpr auto fn2 = &Xint::ofn2;
+  static constexpr auto fn3 = &Xint::ofn3;
+  static constexpr auto fn4 = &Xint::ofn4;
+};
 
-namespace check_optional {
-using operand_t = fn::optional<Xint>;
-using is = monadic_static_check<fn::and_then_t, operand_t>;
+template <typename Operand> constexpr bool member_viability()
+{
+  using is = monadic_static_check<fn::and_then_t, Operand>;
+  using M = member_fns<Operand>;
 
-static_assert(is::invocable_with_any(Xint::ofn));
-static_assert(is::invocable<lvalue>(&Xint::ofn1));
-static_assert(is::not_invocable<prvalue, cvalue, clvalue, rvalue, crvalue>(&Xint::ofn1));
-static_assert(is::invocable_with_any(&Xint::ofn2));
-static_assert(is::invocable<prvalue, rvalue>(&Xint::ofn3));
-static_assert(is::not_invocable<cvalue, lvalue, clvalue, crvalue>(&Xint::ofn3));
-static_assert(is::invocable<prvalue, cvalue, rvalue, crvalue>(&Xint::ofn4));
-static_assert(is::not_invocable<lvalue, clvalue>(&Xint::ofn4));
-} // namespace check_optional
+  static_assert(is::invocable_with_any(M::fn0));
+  static_assert(is::template invocable<lvalue>(M::fn1));
+  static_assert(is::template not_invocable<prvalue, cvalue, clvalue, rvalue, crvalue>(M::fn1));
+  static_assert(is::invocable_with_any(M::fn2));
+  static_assert(is::template invocable<prvalue, rvalue>(M::fn3));
+  static_assert(is::template not_invocable<cvalue, lvalue, clvalue, crvalue>(M::fn3));
+  static_assert(is::template invocable<prvalue, cvalue, rvalue, crvalue>(M::fn4));
+  static_assert(is::template not_invocable<lvalue, clvalue>(M::fn4));
+  return true;
+}
+static_assert(member_viability<ExpectedXint>());
+static_assert(member_viability<OptionalXint>());
 } // namespace
 
-TEST_CASE("and_then_member", "[and_then][member_functions]")
+TEMPLATE_TEST_CASE("and_then member", "[and_then][member_functions]", ExpectedXint, OptionalXint)
 {
   using namespace fn;
 
-  WHEN("expected const")
+  using M = member_fns<TestType>;
+  constexpr Xfn<typename M::result_t> fn{};
+
+  SECTION("const")
   {
-    constexpr Xfn<fn::expected<int, Error>> fn{};
-    fn::expected<Xint, Error> const v{std::in_place, Xint{2}};
+    TestType const v{std::in_place, Xint{2}};
 
-    WHEN("static fn")
+    SECTION("static fn")
     {
-      static_assert(monadic_static_check<fn::and_then_t, decltype(v)>::invocable_with_any(Xint::efn));
+      static_assert(monadic_static_check<fn::and_then_t, decltype(v)>::invocable_with_any(M::fn0));
 
-      auto const r = fn::invoke(and_then_t::apply{}, v, Xint::efn);
+      auto const r = fn::invoke(and_then_t::apply{}, v, M::fn0);
       CHECK(r.value() == 2);
 
-      auto const q = v | and_then(&Xint::efn);
+      auto const q = v | and_then(M::fn0);
       CHECK(q.value() == 2);
     }
 
-    static_assert(monadic_static_check<fn::and_then_t, decltype(v)>::not_invocable<lvalue>(&Xint::efn1));
+    static_assert(monadic_static_check<fn::and_then_t, decltype(v)>::template not_invocable<lvalue>(M::fn1));
 
-    WHEN("const lvalue-ref")
+    SECTION("const lvalue-ref")
     {
-      static_assert(monadic_static_check<fn::and_then_t, decltype(v)>::invocable_with_any(&Xint::efn2));
+      static_assert(monadic_static_check<fn::and_then_t, decltype(v)>::invocable_with_any(M::fn2));
 
-      auto const r = fn::invoke(and_then_t::apply{}, v, &Xint::efn2);
+      auto const r = fn::invoke(and_then_t::apply{}, v, M::fn2);
       CHECK(r.value() == 4);
 
-      auto const q = v | and_then(&Xint::efn2);
+      auto const q = v | and_then(M::fn2);
       CHECK(q.value() == 4);
 
       auto const s = v | and_then(fn);
       CHECK(s.value() == 4);
     }
 
-    static_assert(monadic_static_check<fn::and_then_t, decltype(v)>::not_invocable<rvalue>(&Xint::efn3));
+    static_assert(monadic_static_check<fn::and_then_t, decltype(v)>::template not_invocable<rvalue>(M::fn3));
 
-    WHEN("const rvalue-ref")
+    SECTION("const rvalue-ref")
     {
       static_assert(
-          monadic_static_check<fn::and_then_t, decltype(v)>::invocable<prvalue, crvalue, cvalue>(&Xint::efn4));
+          monadic_static_check<fn::and_then_t, decltype(v)>::template invocable<prvalue, crvalue, cvalue>(M::fn4));
 
-      auto const r = fn::invoke(and_then_t::apply{}, std::move(v), &Xint::efn4);
+      auto const r = fn::invoke(and_then_t::apply{}, std::move(v), M::fn4);
       CHECK(r.value() == 6);
 
-      auto const q = std::move(v) | and_then(&Xint::efn4);
+      auto const q = std::move(v) | and_then(M::fn4);
       CHECK(q.value() == 6);
 
       auto const s = std::move(v) | and_then(fn);
@@ -127,199 +141,72 @@ TEST_CASE("and_then_member", "[and_then][member_functions]")
     }
   }
 
-  WHEN("expected mutable")
+  SECTION("mutable")
   {
-    constexpr Xfn<fn::expected<int, Error>> fn{};
-    fn::expected<Xint, Error> v{std::in_place, Xint{2}};
+    TestType v{std::in_place, Xint{2}};
 
-    WHEN("static fn")
+    SECTION("static fn")
     {
-      static_assert(monadic_static_check<fn::and_then_t, decltype(v)>::invocable_with_any(Xint::efn));
+      static_assert(monadic_static_check<fn::and_then_t, decltype(v)>::invocable_with_any(M::fn0));
 
-      auto const r = fn::invoke(and_then_t::apply{}, v, Xint::efn);
+      auto const r = fn::invoke(and_then_t::apply{}, v, M::fn0);
       CHECK(r.value() == 2);
 
-      auto const q = v | and_then(&Xint::efn);
+      auto const q = v | and_then(M::fn0);
       CHECK(q.value() == 2);
     }
 
-    WHEN("lvalue-ref")
+    SECTION("lvalue-ref")
     {
-      static_assert(monadic_static_check<fn::and_then_t, decltype(v)>::invocable<lvalue>(&Xint::efn1));
+      static_assert(monadic_static_check<fn::and_then_t, decltype(v)>::template invocable<lvalue>(M::fn1));
 
-      auto const r = fn::invoke(and_then_t::apply{}, v, &Xint::efn1);
+      auto const r = fn::invoke(and_then_t::apply{}, v, M::fn1);
       CHECK(r.value() == 3);
 
-      auto const q = v | and_then(&Xint::efn1);
+      auto const q = v | and_then(M::fn1);
       CHECK(q.value() == 3);
 
       auto const s = v | and_then(fn);
       CHECK(s.value() == 3);
     }
 
-    WHEN("const lvalue-ref")
+    SECTION("const lvalue-ref")
     {
-      static_assert(monadic_static_check<fn::and_then_t, decltype(v)>::invocable_with_any(&Xint::efn2));
+      static_assert(monadic_static_check<fn::and_then_t, decltype(v)>::invocable_with_any(M::fn2));
 
-      // rvalue-ref
-      auto const r = fn::invoke(and_then_t::apply{}, v, &Xint::efn2);
+      auto const r = fn::invoke(and_then_t::apply{}, v, M::fn2);
       CHECK(r.value() == 4);
 
-      auto const q = v | and_then(&Xint::efn2);
+      auto const q = v | and_then(M::fn2);
       CHECK(q.value() == 4);
 
       auto const s = std::as_const(v) | and_then(fn);
       CHECK(s.value() == 4);
     }
 
-    WHEN("rvalue-ref")
+    SECTION("rvalue-ref")
     {
-      static_assert(monadic_static_check<fn::and_then_t, decltype(v)>::invocable<prvalue, rvalue>(&Xint::efn3));
+      static_assert(monadic_static_check<fn::and_then_t, decltype(v)>::template invocable<prvalue, rvalue>(M::fn3));
 
-      auto const r = fn::invoke(and_then_t::apply{}, std::move(v), &Xint::efn3);
+      auto const r = fn::invoke(and_then_t::apply{}, std::move(v), M::fn3);
       CHECK(r.value() == 5);
 
-      auto const q = std::move(v) | and_then(&Xint::efn3);
+      auto const q = std::move(v) | and_then(M::fn3);
       CHECK(q.value() == 5);
 
       auto const s = std::move(v) | and_then(fn);
       CHECK(s.value() == 5);
     }
 
-    WHEN("const rvalue-ref")
+    SECTION("const rvalue-ref")
     {
       static_assert(
-          monadic_static_check<fn::and_then_t, decltype(v)>::invocable<prvalue, crvalue, cvalue>(&Xint::efn4));
+          monadic_static_check<fn::and_then_t, decltype(v)>::template invocable<prvalue, crvalue, cvalue>(M::fn4));
 
-      auto const r = fn::invoke(and_then_t::apply{}, std::move(v), &Xint::efn4);
+      auto const r = fn::invoke(and_then_t::apply{}, std::move(v), M::fn4);
       CHECK(r.value() == 6);
 
-      auto const q = std::move(v) | and_then(&Xint::efn4);
-      CHECK(q.value() == 6);
-
-      auto const s = std::move(std::as_const(v)) | and_then(fn);
-      CHECK(s.value() == 6);
-    }
-  }
-
-  WHEN("optional const")
-  {
-    constexpr Xfn<fn::optional<int>> fn{};
-    fn::optional<Xint> const v{std::in_place, Xint{2}};
-
-    WHEN("static fn")
-    {
-      static_assert(monadic_static_check<fn::and_then_t, decltype(v)>::invocable_with_any(&Xint::ofn));
-
-      auto const r = fn::invoke(and_then_t::apply{}, v, Xint::ofn);
-      CHECK(r.value() == 2);
-
-      auto const q = v | and_then(&Xint::ofn);
-      CHECK(q.value() == 2);
-    }
-
-    static_assert(monadic_static_check<fn::and_then_t, decltype(v)>::not_invocable<lvalue>(&Xint::ofn1));
-
-    WHEN("const lvalue-ref")
-    {
-      static_assert(monadic_static_check<fn::and_then_t, decltype(v)>::invocable_with_any(&Xint::ofn2));
-
-      auto const r = fn::invoke(and_then_t::apply{}, v, &Xint::ofn2);
-      CHECK(r.value() == 4);
-
-      auto const q = v | and_then(&Xint::ofn2);
-      CHECK(q.value() == 4);
-
-      auto const s = v | and_then(fn);
-      CHECK(s.value() == 4);
-    }
-
-    static_assert(monadic_static_check<fn::and_then_t, decltype(v)>::not_invocable<rvalue>(&Xint::ofn3));
-
-    WHEN("const rvalue-ref")
-    {
-      static_assert(
-          monadic_static_check<fn::and_then_t, decltype(v)>::invocable<prvalue, crvalue, cvalue>(&Xint::ofn4));
-
-      auto const r = fn::invoke(and_then_t::apply{}, std::move(v), &Xint::ofn4);
-      CHECK(r.value() == 6);
-
-      auto const q = std::move(v) | and_then(&Xint::ofn4);
-      CHECK(q.value() == 6);
-
-      auto const s = std::move(v) | and_then(fn);
-      CHECK(s.value() == 6);
-    }
-  }
-
-  WHEN("optional mutable")
-  {
-    constexpr Xfn<fn::optional<int>> fn{};
-    fn::optional<Xint> v{std::in_place, Xint{2}};
-
-    WHEN("static fn")
-    {
-      static_assert(monadic_static_check<fn::and_then_t, decltype(v)>::invocable_with_any(Xint::ofn));
-
-      auto const r = fn::invoke(and_then_t::apply{}, v, Xint::ofn);
-      CHECK(r.value() == 2);
-
-      auto const q = v | and_then(&Xint::ofn);
-      CHECK(q.value() == 2);
-    }
-
-    WHEN("lvalue-ref")
-    {
-      static_assert(monadic_static_check<fn::and_then_t, decltype(v)>::invocable<lvalue>(&Xint::ofn1));
-
-      auto const r = fn::invoke(and_then_t::apply{}, v, &Xint::ofn1);
-      CHECK(r.value() == 3);
-
-      auto const q = v | and_then(&Xint::ofn1);
-      CHECK(q.value() == 3);
-
-      auto const s = v | and_then(fn);
-      CHECK(s.value() == 3);
-    }
-
-    WHEN("const lvalue-ref")
-    {
-      static_assert(monadic_static_check<fn::and_then_t, decltype(v)>::invocable_with_any(&Xint::ofn2));
-
-      // rvalue-ref
-      auto const r = fn::invoke(and_then_t::apply{}, v, &Xint::ofn2);
-      CHECK(r.value() == 4);
-
-      auto const q = v | and_then(&Xint::ofn2);
-      CHECK(q.value() == 4);
-
-      auto const s = std::as_const(v) | and_then(fn);
-      CHECK(s.value() == 4);
-    }
-
-    WHEN("rvalue-ref")
-    {
-      static_assert(monadic_static_check<fn::and_then_t, decltype(v)>::invocable<prvalue, rvalue>(&Xint::ofn3));
-
-      auto const r = fn::invoke(and_then_t::apply{}, std::move(v), &Xint::ofn3);
-      CHECK(r.value() == 5);
-
-      auto const q = std::move(v) | and_then(&Xint::ofn3);
-      CHECK(q.value() == 5);
-
-      auto const s = std::move(v) | and_then(fn);
-      CHECK(s.value() == 5);
-    }
-
-    WHEN("const rvalue-ref")
-    {
-      static_assert(
-          monadic_static_check<fn::and_then_t, decltype(v)>::invocable<prvalue, crvalue, cvalue>(&Xint::ofn4));
-
-      auto const r = fn::invoke(and_then_t::apply{}, std::move(v), &Xint::ofn4);
-      CHECK(r.value() == 6);
-
-      auto const q = std::move(v) | and_then(&Xint::ofn4);
+      auto const q = std::move(v) | and_then(M::fn4);
       CHECK(q.value() == 6);
 
       auto const s = std::move(std::as_const(v)) | and_then(fn);
@@ -361,7 +248,7 @@ TEST_CASE("and_then", "[and_then][expected][expected_value][pack]")
   static_assert(is::not_invocable_with_any([]() -> operand_t { throw 0; }));                      // bad arity
   static_assert(is::not_invocable_with_any([](int, int) -> operand_t { throw 0; }));              // bad arity
 
-  WHEN("noexcept")
+  SECTION("noexcept")
   {
     constexpr auto fnNothrow = [](int i) noexcept -> operand_t { return {i + 1}; };
     constexpr auto fnThrows = [](int i) noexcept(false) -> operand_t { return {i + 1}; };
@@ -405,23 +292,23 @@ TEST_CASE("and_then", "[and_then][expected][expected_value][pack]")
     SUCCEED();
   }
 
-  WHEN("operand is lvalue")
+  SECTION("lvalue")
   {
-    WHEN("operand is value")
+    SECTION("value")
     {
       operand_t a{std::in_place, 12};
       using T = decltype(a | and_then(fnValue));
       static_assert(std::is_same_v<T, operand_t>);
       REQUIRE((a | and_then(fnValue)).value() == 13);
 
-      WHEN("fail")
+      SECTION("fail")
       {
         using T = decltype(a | and_then(fnFail));
         static_assert(std::is_same_v<T, operand_t>);
         REQUIRE((a | and_then(fnFail)).error().what == "Got 12");
       }
 
-      WHEN("change type")
+      SECTION("change type")
       {
         using T = decltype(a | and_then(fnXabs));
         static_assert(std::is_same_v<T, fn::expected<Xint, Error>>);
@@ -429,7 +316,7 @@ TEST_CASE("and_then", "[and_then][expected][expected_value][pack]")
       }
     }
 
-    WHEN("operand is error")
+    SECTION("error")
     {
       operand_t a{::fn::unexpect, Error{"Not good"}};
       using T = decltype(a | and_then(wrong));
@@ -441,7 +328,7 @@ TEST_CASE("and_then", "[and_then][expected][expected_value][pack]")
               == "Not good");
     }
 
-    WHEN("operand is pack")
+    SECTION("pack")
     {
       using operand_t = fn::expected<fn::pack<int, double>, Error>;
       operand_t a{std::in_place, fn::pack{84, 0.5}};
@@ -449,10 +336,10 @@ TEST_CASE("and_then", "[and_then][expected][expected_value][pack]")
       using T = decltype(a | and_then(fnPack));
       static_assert(std::is_same_v<T, fn::expected<int, Error>>);
 
-      WHEN("operand is value")
+      SECTION("value")
       {
         REQUIRE((a | and_then(fnPack)).value() == 42);
-        WHEN("fail")
+        SECTION("fail")
         {
           constexpr auto fnFail = [](int i, double d) constexpr -> fn::expected<int, Error> {
             return ::fn::unexpected<Error>(Error{"Got " + std::to_string(i) + " and " + std::to_string(d)});
@@ -463,7 +350,7 @@ TEST_CASE("and_then", "[and_then][expected][expected_value][pack]")
         }
       }
 
-      WHEN("operand is error")
+      SECTION("error")
       {
         constexpr auto wrong = [](auto...) -> operand_t { throw 0; };
         REQUIRE((operand_t{::fn::unexpect, Error{"Not good"}} | and_then(wrong)).error().what == "Not good");
@@ -471,29 +358,29 @@ TEST_CASE("and_then", "[and_then][expected][expected_value][pack]")
     }
   }
 
-  WHEN("operand is rvalue")
+  SECTION("rvalue")
   {
-    WHEN("operand is value")
+    SECTION("value")
     {
       using T = decltype(operand_t{std::in_place, 12} | and_then(fnValue));
       static_assert(std::is_same_v<T, operand_t>);
       REQUIRE((operand_t{std::in_place, 12} | and_then(fnValue)).value() == 13);
 
-      WHEN("fail")
+      SECTION("fail")
       {
         using T = decltype(operand_t{std::in_place, 12} | and_then(fnFail));
         static_assert(std::is_same_v<T, operand_t>);
         REQUIRE((operand_t{std::in_place, 12} | and_then(fnFail)).error().what == "Got 12");
       }
 
-      WHEN("change type")
+      SECTION("change type")
       {
         using T = decltype(operand_t{std::in_place, 12} | and_then(fnXabs));
         static_assert(std::is_same_v<T, fn::expected<Xint, Error>>);
         REQUIRE((operand_t{std::in_place, 12} | and_then(fnXabs)).value().value == 4);
       }
     }
-    WHEN("operand is error")
+    SECTION("error")
     {
       using T = decltype(operand_t{::fn::unexpect, Error{"Not good"}} | and_then(wrong));
       static_assert(std::is_same_v<T, operand_t>);
@@ -502,6 +389,144 @@ TEST_CASE("and_then", "[and_then][expected][expected_value][pack]")
                   .error()
                   .what
               == "Not good");
+    }
+  }
+
+  SECTION("constexpr")
+  {
+    enum class Error { ThresholdExceeded, SomethingElse };
+    using T = fn::expected<int, Error>;
+
+    SECTION("same value type")
+    {
+      constexpr auto fn = [](int i) constexpr noexcept -> T {
+        if (i < 3)
+          return {i + 1};
+        return ::fn::unexpected<Error>{Error::ThresholdExceeded};
+      };
+      constexpr auto r1 = T{0} | fn::and_then(fn);
+      static_assert(r1.value() == 1);
+      constexpr auto r2 = r1 | fn::and_then(fn) | fn::and_then(fn) | fn::and_then(fn);
+      static_assert(r2.error() == Error::ThresholdExceeded);
+
+      SUCCEED();
+    }
+
+    SECTION("different value type")
+    {
+      using T1 = fn::expected<bool, Error>;
+      constexpr auto fn = [](int i) constexpr noexcept -> T1 {
+        if (i == 1)
+          return {true};
+        if (i == 0)
+          return {false};
+        return ::fn::unexpected<Error>{Error::SomethingElse};
+      };
+      constexpr auto r1 = T{1} | fn::and_then(fn);
+      static_assert(std::is_same_v<decltype(r1), fn::expected<bool, Error> const>);
+      static_assert(r1.value() == true);
+      constexpr auto r2 = T{0} | fn::and_then(fn);
+      static_assert(r2.value() == false);
+      constexpr auto r3 = T{2} | fn::and_then(fn);
+      static_assert(r3.error() == Error::SomethingElse);
+
+      SUCCEED();
+    }
+
+    SECTION("sum")
+    {
+      enum class Error { ThresholdExceeded, SomethingElse, UnexpectedType };
+      using T = fn::expected<fn::sum_for<Xint, int>, Error>;
+
+      SECTION("same value type")
+      {
+        constexpr auto fn = fn::overload{[](int i) constexpr noexcept -> T {
+                                           if (i < 3)
+                                             return {i + 1};
+                                           return ::fn::unexpected<Error>{Error::ThresholdExceeded};
+                                         },
+                                         [](Xint v) constexpr noexcept -> T { return v; }};
+        constexpr auto r1 = T{0} | fn::and_then(fn);
+        static_assert(r1.value() == fn::sum{1});
+        constexpr auto r2 = r1 | fn::and_then(fn) | fn::and_then(fn) | fn::and_then(fn);
+        static_assert(r2.error() == Error::ThresholdExceeded);
+
+        SUCCEED();
+      }
+
+      SECTION("different value type")
+      {
+        using T1 = fn::expected<bool, Error>;
+        constexpr auto fn = fn::overload{
+            [](int i) constexpr noexcept -> T1 {
+              if (i == 1)
+                return {true};
+              if (i == 0)
+                return {false};
+              return ::fn::unexpected<Error>{Error::SomethingElse};
+            },
+            [](Xint) constexpr noexcept -> T1 { return ::fn::unexpected<Error>{Error::UnexpectedType}; }};
+        constexpr auto r1 = T{1} | fn::and_then(fn);
+        static_assert(std::is_same_v<decltype(r1), fn::expected<bool, Error> const>);
+        static_assert(r1.value() == true);
+        constexpr auto r2 = T{0} | fn::and_then(fn);
+        static_assert(r2.value() == false);
+        constexpr auto r3 = T{2} | fn::and_then(fn);
+        static_assert(r3.error() == Error::SomethingElse);
+
+        SUCCEED();
+      }
+    }
+
+    SECTION("graded")
+    {
+      enum class Error { InvalidValue };
+      using T = fn::expected<int, fn::sum<Error>>;
+
+      SECTION("same error type")
+      {
+        constexpr auto fn1 = [](int i) -> fn::expected<int, int> {
+          if (i < 2)
+            return {i + 1};
+          return ::fn::unexpected<int>{i};
+        };
+
+        constexpr auto r1 = T{0} | fn::and_then(fn1);
+        static_assert(std::is_same_v<decltype(r1), fn::expected<int, fn::sum_for<Error, int>> const>);
+        static_assert(r1.value() == 1);
+        constexpr auto r2 = r1 | fn::and_then(fn1);
+        static_assert(r2.value() == 2);
+        constexpr auto r3 = r2 | fn::and_then(fn1);
+        static_assert(r3.error() == fn::sum{2});
+        constexpr auto r4 = r3 | fn::and_then(fn1);
+        static_assert(r4.error() == fn::sum{2});
+
+        SUCCEED();
+      }
+
+      SECTION("accumulate errors")
+      {
+        constexpr auto fn2 = [](int i) -> fn::expected<bool, Error> {
+          if (i < 0 || i > 1)
+            return ::fn::unexpected<Error>{Error::InvalidValue};
+          return {i == 1};
+        };
+
+        constexpr auto r2 = T{1} | fn::and_then(fn2);
+        static_assert(std::is_same_v<decltype(r2), fn::expected<bool, fn::sum<Error>> const>);
+        static_assert(r2.value());
+        constexpr auto r3 = T{2} | fn::and_then(fn2);
+        static_assert(r3.error() == fn::sum{Error::InvalidValue});
+
+        constexpr auto fn3 = [](int i) -> fn::expected<int, int> { return {i + 1}; };
+        constexpr auto r4 = r3 | fn::and_then(fn3);
+        static_assert(std::is_same_v<decltype(r4), fn::expected<int, fn::sum_for<Error, int>> const>);
+        static_assert(r4.error() == fn::sum{Error::InvalidValue});
+        constexpr auto r5 = T{2} | fn::and_then(fn3);
+        static_assert(r5.value() == 3);
+
+        SUCCEED();
+      }
     }
   }
 }
@@ -532,7 +557,7 @@ TEST_CASE("and_then", "[and_then][expected][expected_void]")
   static_assert(is::not_invocable_with_any([](int) -> operand_t { throw 0; }));        // bad arity
   static_assert(is::not_invocable_with_any([](int, int) -> operand_t { throw 0; }));   // bad arity
 
-  WHEN("noexcept")
+  SECTION("noexcept")
   {
     constexpr auto fnNothrow = []() noexcept -> operand_t { return {}; };
     constexpr auto fnThrows = []() noexcept(false) -> operand_t { return {}; };
@@ -554,9 +579,9 @@ TEST_CASE("and_then", "[and_then][expected][expected_void]")
     SUCCEED();
   }
 
-  WHEN("operand is lvalue")
+  SECTION("lvalue")
   {
-    WHEN("operand is value")
+    SECTION("value")
     {
       operand_t a{std::in_place};
       using T = decltype(a | and_then(fnValue));
@@ -564,21 +589,21 @@ TEST_CASE("and_then", "[and_then][expected][expected_void]")
       (a | and_then(fnValue)).value();
       CHECK(count == 1);
 
-      WHEN("fail")
+      SECTION("fail")
       {
         using T = decltype(a | and_then(fnFail));
         static_assert(std::is_same_v<T, operand_t>);
         REQUIRE((a | and_then(fnFail)).error().what == "Got 2");
       }
 
-      WHEN("change type")
+      SECTION("change type")
       {
         using T = decltype(a | and_then(fnXabs));
         static_assert(std::is_same_v<T, fn::expected<Xint, Error>>);
         REQUIRE((a | and_then(fnXabs)).value().value == 2);
       }
     }
-    WHEN("operand is error")
+    SECTION("error")
     {
       operand_t a{::fn::unexpect, Error{"Not good"}};
       using T = decltype(a | and_then(wrong));
@@ -591,30 +616,30 @@ TEST_CASE("and_then", "[and_then][expected][expected_void]")
     }
   }
 
-  WHEN("operand is rvalue")
+  SECTION("rvalue")
   {
-    WHEN("operand is value")
+    SECTION("value")
     {
       using T = decltype(operand_t{std::in_place} | and_then(fnValue));
       static_assert(std::is_same_v<T, operand_t>);
       (operand_t{std::in_place} | and_then(fnValue)).value();
       CHECK(count == 1);
 
-      WHEN("fail")
+      SECTION("fail")
       {
         using T = decltype(operand_t{std::in_place} | and_then(fnFail));
         static_assert(std::is_same_v<T, operand_t>);
         REQUIRE((operand_t{std::in_place} | and_then(fnFail)).error().what == "Got 2");
       }
 
-      WHEN("change type")
+      SECTION("change type")
       {
         using T = decltype(operand_t{std::in_place} | and_then(fnXabs));
         static_assert(std::is_same_v<T, fn::expected<Xint, Error>>);
         REQUIRE((operand_t{std::in_place} | and_then(fnXabs)).value().value == 2);
       }
     }
-    WHEN("operand is error")
+    SECTION("error")
     {
       using T = decltype(operand_t{::fn::unexpect, Error{"Not good"}} | and_then(wrong));
       static_assert(std::is_same_v<T, operand_t>);
@@ -658,7 +683,7 @@ TEST_CASE("and_then", "[and_then][optional][pack]")
   static_assert(is::not_invocable_with_any([]() -> operand_t { throw 0; }));                      // bad arity
   static_assert(is::not_invocable_with_any([](int, int) -> operand_t { throw 0; }));              // bad arity
 
-  WHEN("noexcept")
+  SECTION("noexcept")
   {
     constexpr auto fnNothrow = [](int i) noexcept -> operand_t { return {i + 1}; };
     constexpr auto fnThrows = [](int i) noexcept(false) -> operand_t { return {i + 1}; };
@@ -671,30 +696,30 @@ TEST_CASE("and_then", "[and_then][optional][pack]")
     SUCCEED();
   }
 
-  WHEN("operand is lvalue")
+  SECTION("lvalue")
   {
-    WHEN("operand is value")
+    SECTION("value")
     {
       operand_t a{12};
       using T = decltype(a | and_then(fnValue));
       static_assert(std::is_same_v<T, operand_t>);
       REQUIRE((a | and_then(fnValue)).value() == 13);
 
-      WHEN("fail")
+      SECTION("fail")
       {
         using T = decltype(a | and_then(fnFail));
         static_assert(std::is_same_v<T, operand_t>);
         REQUIRE(not(a | and_then(fnFail)).has_value());
       }
 
-      WHEN("change type")
+      SECTION("change type")
       {
         using T = decltype(a | and_then(fnXabs));
         static_assert(std::is_same_v<T, fn::optional<Xint>>);
         REQUIRE((a | and_then(fnXabs)).value().value == 4);
       }
     }
-    WHEN("operand is error")
+    SECTION("error")
     {
       operand_t a{std::nullopt};
       using T = decltype(a | and_then(wrong));
@@ -703,7 +728,7 @@ TEST_CASE("and_then", "[and_then][optional][pack]")
     }
   }
 
-  WHEN("operand is pack")
+  SECTION("pack")
   {
     using operand_t = fn::optional<fn::pack<int, double>>;
     operand_t a{std::in_place, fn::pack{84, 0.5}};
@@ -711,11 +736,11 @@ TEST_CASE("and_then", "[and_then][optional][pack]")
     using T = decltype(a | and_then(fnPack));
     static_assert(std::is_same_v<T, fn::optional<int>>);
 
-    WHEN("operand is value")
+    SECTION("value")
     {
       REQUIRE((a | and_then(fnPack)).value() == 42);
 
-      WHEN("fail")
+      SECTION("fail")
       {
         constexpr auto fnFail = [](int, double) constexpr -> fn::optional<int> { return {std::nullopt}; };
         using T = decltype(a | and_then(fnFail));
@@ -724,42 +749,126 @@ TEST_CASE("and_then", "[and_then][optional][pack]")
       }
     }
 
-    WHEN("operand is error")
+    SECTION("error")
     {
       constexpr auto wrong = [](auto...) -> operand_t { throw 0; };
       REQUIRE(not(operand_t{std::nullopt} | and_then(wrong)).has_value());
     }
   }
 
-  WHEN("operand is rvalue")
+  SECTION("rvalue")
   {
-    WHEN("operand is value")
+    SECTION("value")
     {
       using T = decltype(operand_t{12} | and_then(fnValue));
       static_assert(std::is_same_v<T, operand_t>);
       REQUIRE((operand_t{12} | and_then(fnValue)).value() == 13);
 
-      WHEN("fail")
+      SECTION("fail")
       {
         using T = decltype(operand_t{12} | and_then(fnFail));
         static_assert(std::is_same_v<T, operand_t>);
         REQUIRE(not(operand_t{12} | and_then(fnFail)).has_value());
       }
 
-      WHEN("change type")
+      SECTION("change type")
       {
         using T = decltype(operand_t{12} | and_then(fnXabs));
         static_assert(std::is_same_v<T, fn::optional<Xint>>);
         REQUIRE((operand_t{12} | and_then(fnXabs)).value().value == 4);
       }
     }
-    WHEN("operand is error")
+    SECTION("error")
     {
       using T = decltype(operand_t{std::nullopt} | and_then(wrong));
       static_assert(std::is_same_v<T, operand_t>);
       REQUIRE(not(operand_t{std::nullopt} //
                   | and_then(wrong))
                      .has_value());
+    }
+  }
+
+  SECTION("constexpr")
+  {
+    using T = fn::optional<int>;
+
+    SECTION("same value type")
+    {
+      constexpr auto fn = [](int i) constexpr noexcept -> T {
+        if (i < 3)
+          return {i + 1};
+        return {};
+      };
+      constexpr auto r1 = T{0} | fn::and_then(fn);
+      static_assert(r1.value() == 1);
+      constexpr auto r2 = r1 | fn::and_then(fn) | fn::and_then(fn) | fn::and_then(fn);
+      static_assert(not r2.has_value());
+
+      SUCCEED();
+    }
+
+    SECTION("different value type")
+    {
+      using T1 = fn::optional<bool>;
+      constexpr auto fn = [](int i) constexpr noexcept -> T1 {
+        if (i == 1)
+          return {true};
+        if (i == 0)
+          return {false};
+        return {};
+      };
+      constexpr auto r1 = T{1} | fn::and_then(fn);
+      static_assert(std::is_same_v<decltype(r1), fn::optional<bool> const>);
+      static_assert(r1.value() == true);
+      constexpr auto r2 = T{0} | fn::and_then(fn);
+      static_assert(r2.value() == false);
+      constexpr auto r3 = T{2} | fn::and_then(fn);
+      static_assert(not r3.has_value());
+
+      SUCCEED();
+    }
+
+    SECTION("sum")
+    {
+      using T = fn::optional<fn::sum_for<Xint, int>>;
+
+      SECTION("same value type")
+      {
+        constexpr auto fn = fn::overload{[](int i) constexpr noexcept -> T {
+                                           if (i < 3)
+                                             return {i + 1};
+                                           return {};
+                                         },
+                                         [](Xint v) constexpr noexcept -> T { return v; }};
+        constexpr auto r1 = T{0} | fn::and_then(fn);
+        static_assert(r1.value() == fn::sum{1});
+        constexpr auto r2 = r1 | fn::and_then(fn) | fn::and_then(fn) | fn::and_then(fn);
+        static_assert(not r2.has_value());
+
+        SUCCEED();
+      }
+
+      SECTION("different value type")
+      {
+        using T1 = fn::optional<bool>;
+        constexpr auto fn = fn::overload{[](int i) constexpr noexcept -> T1 {
+                                           if (i == 1)
+                                             return {true};
+                                           if (i == 0)
+                                             return {false};
+                                           return {};
+                                         },
+                                         [](Xint) constexpr noexcept -> T1 { return {}; }};
+        constexpr auto r1 = T{1} | fn::and_then(fn);
+        static_assert(std::is_same_v<decltype(r1), fn::optional<bool> const>);
+        static_assert(r1.value() == true);
+        constexpr auto r2 = T{0} | fn::and_then(fn);
+        static_assert(r2.value() == false);
+        constexpr auto r3 = T{2} | fn::and_then(fn);
+        static_assert(not r3.has_value());
+
+        SUCCEED();
+      }
     }
   }
 }
@@ -798,7 +907,7 @@ TEST_CASE("and_then choice", "[and_then][choice]")
   static_assert(is::not_invocable_with_any([]() -> operand_t { throw 0; }));         // bad arity
   static_assert(is::not_invocable_with_any([](int, int) -> operand_t { throw 0; })); // bad arity
 
-  WHEN("noexcept")
+  SECTION("noexcept")
   {
     constexpr auto fnThrows = [](auto i) noexcept(false) -> operand_t { return {i + 1}; };
 
@@ -814,16 +923,16 @@ TEST_CASE("and_then choice", "[and_then][choice]")
     SUCCEED();
   }
 
-  WHEN("operand is lvalue")
+  SECTION("lvalue")
   {
-    WHEN("operand is value")
+    SECTION("value")
     {
       operand_t a{12};
       using T = decltype(a | and_then(fnValue));
       static_assert(std::is_same_v<T, operand_t>);
       REQUIRE(*(a | and_then(fnValue)).get_ptr<int>() == 13);
 
-      WHEN("change type")
+      SECTION("change type")
       {
         using T = decltype(a | and_then(fnXabs));
         static_assert(std::is_same_v<T, fn::choice<Xint>>);
@@ -832,15 +941,15 @@ TEST_CASE("and_then choice", "[and_then][choice]")
     }
   }
 
-  WHEN("operand is rvalue")
+  SECTION("rvalue")
   {
-    WHEN("operand is value")
+    SECTION("value")
     {
       using T = decltype(operand_t{12} | and_then(fnValue));
       static_assert(std::is_same_v<T, operand_t>);
       REQUIRE(*(operand_t{12} | and_then(fnValue)).get_ptr<int>() == 13);
 
-      WHEN("change type")
+      SECTION("change type")
       {
         using T = decltype(operand_t{12} | and_then(fnXabs));
         static_assert(std::is_same_v<T, fn::choice<Xint>>);
@@ -848,260 +957,50 @@ TEST_CASE("and_then choice", "[and_then][choice]")
       }
     }
   }
-}
 
-TEST_CASE("constexpr and_then expected", "[and_then][constexpr][expected]")
-{
-  enum class Error { ThresholdExceeded, SomethingElse };
-  using T = fn::expected<int, Error>;
-
-  WHEN("same value type")
+  SECTION("constexpr")
   {
-    constexpr auto fn = [](int i) constexpr noexcept -> T {
-      if (i < 3)
-        return {i + 1};
-      return ::fn::unexpected<Error>{Error::ThresholdExceeded};
-    };
-    constexpr auto r1 = T{0} | fn::and_then(fn);
-    static_assert(r1.value() == 1);
-    constexpr auto r2 = r1 | fn::and_then(fn) | fn::and_then(fn) | fn::and_then(fn);
-    static_assert(r2.error() == Error::ThresholdExceeded);
+    using T = fn::choice<double, int>;
+
+    SECTION("same value type")
+    {
+      constexpr auto fn = [](int i) constexpr noexcept -> T {
+        if (i < 3)
+          return {i + 1};
+        return {0.0};
+      };
+      constexpr auto r1 = T{0} | fn::and_then(fn);
+      static_assert(r1.invoke([](int i) -> int { return i; }) == 1);
+      constexpr auto r2 = T{0.5} | fn::and_then(fn);
+      static_assert(r2.invoke([](int i) -> int { return i; }) == 1);
+      constexpr auto r3 = r1 | fn::and_then(fn) | fn::and_then(fn) | fn::and_then(fn);
+      static_assert(r3.invoke([](double i) -> int { return i; }) == 0.0);
+
+      SUCCEED();
+    }
+
+    SECTION("different value type")
+    {
+      using T1 = fn::choice<bool, int>;
+      constexpr auto fn = [](int i) constexpr noexcept -> T1 {
+        if (i == 1)
+          return {true};
+        else if (i == 0)
+          return {false};
+        else
+          return {std::move(i)};
+      };
+      constexpr auto r1 = T{1} | fn::and_then(fn);
+      static_assert(std::is_same_v<decltype(r1), fn::choice<bool, int> const>);
+      static_assert(r1.invoke([](bool i) -> bool { return i; }) == true);
+      constexpr auto r2 = T{0} | fn::and_then(fn);
+      static_assert(r2.invoke([](bool i) -> bool { return i; }) == false);
+      constexpr auto r3 = T{2} | fn::and_then(fn);
+      static_assert(r3.invoke([](int i) -> int { return i; }) == 2);
+
+      SUCCEED();
+    }
   }
-
-  WHEN("different value type")
-  {
-    using T1 = fn::expected<bool, Error>;
-    constexpr auto fn = [](int i) constexpr noexcept -> T1 {
-      if (i == 1)
-        return {true};
-      if (i == 0)
-        return {false};
-      return ::fn::unexpected<Error>{Error::SomethingElse};
-    };
-    constexpr auto r1 = T{1} | fn::and_then(fn);
-    static_assert(std::is_same_v<decltype(r1), fn::expected<bool, Error> const>);
-    static_assert(r1.value() == true);
-    constexpr auto r2 = T{0} | fn::and_then(fn);
-    static_assert(r2.value() == false);
-    constexpr auto r3 = T{2} | fn::and_then(fn);
-    static_assert(r3.error() == Error::SomethingElse);
-  }
-
-  SUCCEED();
-}
-
-TEST_CASE("constexpr and_then expected with sum", "[and_then][constexpr][expected][sum]")
-{
-  enum class Error { ThresholdExceeded, SomethingElse, UnexpectedType };
-  using T = fn::expected<fn::sum_for<Xint, int>, Error>;
-
-  WHEN("same value type")
-  {
-    constexpr auto fn = fn::overload{[](int i) constexpr noexcept -> T {
-                                       if (i < 3)
-                                         return {i + 1};
-                                       return ::fn::unexpected<Error>{Error::ThresholdExceeded};
-                                     },
-                                     [](Xint v) constexpr noexcept -> T { return v; }};
-    constexpr auto r1 = T{0} | fn::and_then(fn);
-    static_assert(r1.value() == fn::sum{1});
-    constexpr auto r2 = r1 | fn::and_then(fn) | fn::and_then(fn) | fn::and_then(fn);
-    static_assert(r2.error() == Error::ThresholdExceeded);
-  }
-
-  WHEN("different value type")
-  {
-    using T1 = fn::expected<bool, Error>;
-    constexpr auto fn
-        = fn::overload{[](int i) constexpr noexcept -> T1 {
-                         if (i == 1)
-                           return {true};
-                         if (i == 0)
-                           return {false};
-                         return ::fn::unexpected<Error>{Error::SomethingElse};
-                       },
-                       [](Xint) constexpr noexcept -> T1 { return ::fn::unexpected<Error>{Error::UnexpectedType}; }};
-    constexpr auto r1 = T{1} | fn::and_then(fn);
-    static_assert(std::is_same_v<decltype(r1), fn::expected<bool, Error> const>);
-    static_assert(r1.value() == true);
-    constexpr auto r2 = T{0} | fn::and_then(fn);
-    static_assert(r2.value() == false);
-    constexpr auto r3 = T{2} | fn::and_then(fn);
-    static_assert(r3.error() == Error::SomethingElse);
-  }
-
-  SUCCEED();
-}
-
-TEST_CASE("constexpr and_then graded monad", "[and_then][constexpr][expected][graded]")
-{
-  enum class Error { InvalidValue };
-  using T = fn::expected<int, fn::sum<Error>>;
-
-  WHEN("same error type")
-  {
-    constexpr auto fn1 = [](int i) -> fn::expected<int, int> {
-      if (i < 2)
-        return {i + 1};
-      return ::fn::unexpected<int>{i};
-    };
-
-    constexpr auto r1 = T{0} | fn::and_then(fn1);
-    static_assert(std::is_same_v<decltype(r1), fn::expected<int, fn::sum_for<Error, int>> const>);
-    static_assert(r1.value() == 1);
-    constexpr auto r2 = r1 | fn::and_then(fn1);
-    static_assert(r2.value() == 2);
-    constexpr auto r3 = r2 | fn::and_then(fn1);
-    static_assert(r3.error() == fn::sum{2});
-    constexpr auto r4 = r3 | fn::and_then(fn1);
-    static_assert(r4.error() == fn::sum{2});
-  }
-
-  WHEN("accummulate errors")
-  {
-    constexpr auto fn2 = [](int i) -> fn::expected<bool, Error> {
-      if (i < 0 || i > 1)
-        return ::fn::unexpected<Error>{Error::InvalidValue};
-      return {i == 1};
-    };
-
-    constexpr auto r2 = T{1} | fn::and_then(fn2);
-    static_assert(std::is_same_v<decltype(r2), fn::expected<bool, fn::sum<Error>> const>);
-    static_assert(r2.value());
-    constexpr auto r3 = T{2} | fn::and_then(fn2);
-    static_assert(r3.error() == fn::sum{Error::InvalidValue});
-
-    constexpr auto fn3 = [](int i) -> fn::expected<int, int> { return {i + 1}; };
-    constexpr auto r4 = r3 | fn::and_then(fn3);
-    static_assert(std::is_same_v<decltype(r4), fn::expected<int, fn::sum_for<Error, int>> const>);
-    static_assert(r4.error() == fn::sum{Error::InvalidValue});
-    constexpr auto r5 = T{2} | fn::and_then(fn3);
-    static_assert(r5.value() == 3);
-  }
-
-  SUCCEED();
-}
-
-TEST_CASE("constexpr and_then optional", "[and_then][constexpr][optional]")
-{
-  using T = fn::optional<int>;
-
-  WHEN("same value type")
-  {
-    constexpr auto fn = [](int i) constexpr noexcept -> T {
-      if (i < 3)
-        return {i + 1};
-      return {};
-    };
-    constexpr auto r1 = T{0} | fn::and_then(fn);
-    static_assert(r1.value() == 1);
-    constexpr auto r2 = r1 | fn::and_then(fn) | fn::and_then(fn) | fn::and_then(fn);
-    static_assert(not r2.has_value());
-  }
-
-  WHEN("different value type")
-  {
-    using T1 = fn::optional<bool>;
-    constexpr auto fn = [](int i) constexpr noexcept -> T1 {
-      if (i == 1)
-        return {true};
-      if (i == 0)
-        return {false};
-      return {};
-    };
-    constexpr auto r1 = T{1} | fn::and_then(fn);
-    static_assert(std::is_same_v<decltype(r1), fn::optional<bool> const>);
-    static_assert(r1.value() == true);
-    constexpr auto r2 = T{0} | fn::and_then(fn);
-    static_assert(r2.value() == false);
-    constexpr auto r3 = T{2} | fn::and_then(fn);
-    static_assert(not r3.has_value());
-  }
-
-  SUCCEED();
-}
-
-TEST_CASE("constexpr and_then optional with sum", "[and_then][constexpr][optional][sum]")
-{
-  using T = fn::optional<fn::sum_for<Xint, int>>;
-
-  WHEN("same value type")
-  {
-    constexpr auto fn = fn::overload{[](int i) constexpr noexcept -> T {
-                                       if (i < 3)
-                                         return {i + 1};
-                                       return {};
-                                     },
-                                     [](Xint v) constexpr noexcept -> T { return v; }};
-    constexpr auto r1 = T{0} | fn::and_then(fn);
-    static_assert(r1.value() == fn::sum{1});
-    constexpr auto r2 = r1 | fn::and_then(fn) | fn::and_then(fn) | fn::and_then(fn);
-    static_assert(not r2.has_value());
-  }
-
-  WHEN("different value type")
-  {
-    using T1 = fn::optional<bool>;
-    constexpr auto fn = fn::overload{[](int i) constexpr noexcept -> T1 {
-                                       if (i == 1)
-                                         return {true};
-                                       if (i == 0)
-                                         return {false};
-                                       return {};
-                                     },
-                                     [](Xint) constexpr noexcept -> T1 { return {}; }};
-    constexpr auto r1 = T{1} | fn::and_then(fn);
-    static_assert(std::is_same_v<decltype(r1), fn::optional<bool> const>);
-    static_assert(r1.value() == true);
-    constexpr auto r2 = T{0} | fn::and_then(fn);
-    static_assert(r2.value() == false);
-    constexpr auto r3 = T{2} | fn::and_then(fn);
-    static_assert(not r3.has_value());
-  }
-
-  SUCCEED();
-}
-
-TEST_CASE("constexpr and_then choice", "[and_then][constexpr][choice]")
-{
-  using T = fn::choice<double, int>;
-
-  WHEN("same value type")
-  {
-    constexpr auto fn = [](int i) constexpr noexcept -> T {
-      if (i < 3)
-        return {i + 1};
-      return {0.0};
-    };
-    constexpr auto r1 = T{0} | fn::and_then(fn);
-    static_assert(r1.invoke([](int i) -> int { return i; }) == 1);
-    constexpr auto r2 = T{0.5} | fn::and_then(fn);
-    static_assert(r2.invoke([](int i) -> int { return i; }) == 1);
-    constexpr auto r3 = r1 | fn::and_then(fn) | fn::and_then(fn) | fn::and_then(fn);
-    static_assert(r3.invoke([](double i) -> int { return i; }) == 0.0);
-  }
-
-  WHEN("different value type")
-  {
-    using T1 = fn::choice<bool, int>;
-    constexpr auto fn = [](int i) constexpr noexcept -> T1 {
-      if (i == 1)
-        return {true};
-      else if (i == 0)
-        return {false};
-      else
-        return {std::move(i)};
-    };
-    constexpr auto r1 = T{1} | fn::and_then(fn);
-    static_assert(std::is_same_v<decltype(r1), fn::choice<bool, int> const>);
-    static_assert(r1.invoke([](bool i) -> bool { return i; }) == true);
-    constexpr auto r2 = T{0} | fn::and_then(fn);
-    static_assert(r2.invoke([](bool i) -> bool { return i; }) == false);
-    constexpr auto r3 = T{2} | fn::and_then(fn);
-    static_assert(r3.invoke([](int i) -> int { return i; }) == 2);
-  }
-
-  SUCCEED();
 }
 
 namespace fn {

--- a/tests/fn/choice.cpp
+++ b/tests/fn/choice.cpp
@@ -30,6 +30,18 @@ struct NonCopyable final {
   NonCopyable &operator=(NonCopyable const &) = delete;
 };
 
+// Every operation choice performs on an alternative - copy, move, compare - can throw here, while
+// the member wrapping it promises noexcept regardless. Witnesses the #280 tripwires below.
+struct Throwing final {
+  int v;
+
+  constexpr operator int() const { return v; }
+  constexpr Throwing(int i) noexcept : v(i) {}
+  constexpr Throwing(Throwing const &o) noexcept(false) : v(o.v) {}
+  constexpr Throwing(Throwing &&o) noexcept(false) : v(o.v) {}
+  constexpr bool operator==(Throwing const &o) const noexcept(false) { return v == o.v; }
+};
+
 } // anonymous namespace
 
 TEST_CASE("choice non-monadic functionality", "[choice]")
@@ -540,6 +552,52 @@ TEST_CASE("choice non-monadic functionality", "[choice]")
       }
     }
   }
+}
+
+TEST_CASE("choice noexcept", "[choice][noexcept]")
+{
+  using fn::choice;
+  using T = choice<Throwing>;
+
+  static_assert(not std::is_nothrow_copy_constructible_v<Throwing>);
+  static_assert(not std::is_nothrow_move_constructible_v<Throwing>);
+
+  // GAP #280: choice inherits sum's unconditional promise and adds its own. The copy and move
+  // constructors are defaulted noexcept over an alternative whose own copy and move can throw.
+  static_assert(std::is_nothrow_copy_constructible_v<T>);
+  static_assert(std::is_nothrow_move_constructible_v<T>);
+
+  // The monadic members are unconditionally noexcept whatever the callback promises. This is where
+  // choice parts company with fn::optional and fn::expected, whose specs for the same operations are
+  // precise - so the same monadic operation has different exception behaviour depending on which
+  // monad it is written against: those two propagate, choice terminates.
+  constexpr auto fnChoice = [](Throwing const &t) noexcept(false) -> choice<int> { return {t.v}; };
+  static_assert(noexcept(std::declval<T &>().and_then(fnChoice)));
+  static_assert(noexcept(std::declval<T const &>().and_then(fnChoice)));
+  static_assert(noexcept(std::declval<T &&>().and_then(fnChoice)));
+  static_assert(noexcept(std::declval<T const &&>().and_then(fnChoice)));
+
+  constexpr auto fnInt = [](Throwing const &t) noexcept(false) -> int { return t.v; };
+  static_assert(noexcept(std::declval<T &>().transform(fnInt)));
+  static_assert(noexcept(std::declval<T const &>().transform(fnInt)));
+  static_assert(noexcept(std::declval<T &>().invoke(fnInt)));
+  static_assert(noexcept(std::declval<T &>().template invoke_r<long>(fnInt)));
+
+  // The constructors that widen a sum into a choice carry it too - each copies or moves every
+  // alternative of the source across.
+  using W = fn::choice_for<Throwing, int>;
+  static_assert(noexcept(W{std::declval<fn::sum<Throwing> const &>()}));
+  static_assert(noexcept(W{std::declval<fn::sum<Throwing> &&>()}));
+
+  // The value constructors, as in sum, carry no noexcept specifier at all - the converse
+  // under-promise, reported potentially-throwing even where nothing can throw.
+  static_assert(not noexcept(choice<int>{42}));
+
+  // Inherited from sum, and accurate: reading the discriminator touches no alternative.
+  static_assert(noexcept(std::declval<T const &>().has_value(std::in_place_type<Throwing>)));
+  static_assert(noexcept(std::declval<T &>().get_ptr(std::in_place_type<Throwing>)));
+
+  SUCCEED();
 }
 
 TEST_CASE("choice and_then", "[choice][and_then]")

--- a/tests/fn/choice.cpp
+++ b/tests/fn/choice.cpp
@@ -143,19 +143,6 @@ TEST_CASE("choice non-monadic functionality", "[choice]")
     static_assert(not fn::typelist_invocable<decltype([](auto) {}), NonCopyable &>); // copy-constructor not available
   }
 
-  WHEN("check destructor call")
-  {
-    {
-      choice<TestType> s{std::in_place_type<TestType>};
-      static_assert(decltype(s)::has_type<TestType>);
-      static_assert(not decltype(s)::has_type<int>);
-      CHECK(s.has_value(std::in_place_type<TestType>));
-      CHECK(s.template has_value<TestType>());
-      CHECK(TestType::count == 1);
-    }
-    CHECK(TestType::count == 0);
-  }
-
   WHEN("single parameter constructor")
   {
     constexpr choice<int> a = 12;
@@ -393,84 +380,23 @@ TEST_CASE("choice non-monadic functionality", "[choice]")
     }
   }
 
-  WHEN("has_type type mismatch")
-  {
-    using type = choice<bool, int>;
-    static_assert(type::has_type<int>);
-    static_assert(type::has_type<bool>);
-    static_assert(not type::has_type<double>);
-    type a{std::in_place_type<int>, 42};
-    CHECK(a.has_value(std::in_place_type<int>));
-    CHECK(not a.has_value(std::in_place_type<bool>));
-    static_assert([](auto const &a) constexpr -> bool { //
-      return not requires { a.has_value(std::in_place_type<double>); };
-    }(a));                                              // double is not a type member
-    static_assert([](auto const &a) constexpr -> bool { //
-      return not requires { a.template has_value<double>(); };
-    }(a)); // double is not a type member
-  }
-
   WHEN("equality comparison")
   {
+    // The comparison operators are sum's - free functions taking sum<Ts...> const & - and sum.cpp
+    // owns their grid. What is choice's own is that a choice reaches them at all, through its public
+    // base; that, and the result type, is what is asserted here.
     using type = choice<bool, int>;
+    constexpr type a{std::in_place_type<int>, 42};
 
-    type const a{std::in_place_type<int>, 42};
     static_assert(std::is_same_v<bool, decltype(a == choice{42})>);
+    static_assert(a == type{42});
+    static_assert(a != type{41});
+    static_assert(a != type{true});
+    static_assert(a == choice<double, int>{42}); // and across differing alternative lists
+    static_assert(a != choice<double, int>{41});
+
     CHECK(a == type{42});
-    CHECK(type{42} == a);
     CHECK(a != type{41});
-    CHECK(type{41} != a);
-    CHECK(a != type{true});
-    CHECK(type{false} != a);
-    CHECK(a == choice{42});
-    CHECK(choice{42} == a);
-    CHECK(a != choice{41});
-    CHECK(choice{41} != a);
-    CHECK(a != choice{false});
-    CHECK(choice{true} != a);
-    CHECK(a == choice<double, int>{42});
-    CHECK(choice<double, int>{42} == a);
-    CHECK(a != choice<double, int>{41});
-    CHECK(choice<double, int>{41} != a);
-    CHECK(choice{0.5} != a);
-    CHECK(a != choice{0.5});
-
-    WHEN("constexpr")
-    {
-      constexpr type a{std::in_place_type<int>, 42};
-      static_assert(std::is_same_v<bool, decltype(a == choice{42})>);
-      static_assert(a == type{42});
-      static_assert(type{42} == a);
-      static_assert(a != type{41});
-      static_assert(type{41} != a);
-      static_assert(a != type{true});
-      static_assert(type{false} != a);
-      static_assert(a == choice{42});
-      static_assert(choice{42} == a);
-      static_assert(a != choice{41});
-      static_assert(choice{41} != a);
-      static_assert(a != choice{false});
-      static_assert(choice{true} != a);
-      static_assert(a == choice<double, int>{42});
-      static_assert(choice<double, int>{42} == a);
-      static_assert(a != choice<double, int>{41});
-      static_assert(choice<double, int>{41} != a);
-      static_assert(choice{0.5} != a);
-      static_assert(a != choice{0.5});
-
-      static_assert([](auto const &a) constexpr -> bool {
-        return not requires { a == 42; }; // no implicit conversion
-      }(a));
-      static_assert([](auto const &a) constexpr -> bool {
-        return not requires { a != 42; }; // no implicit conversion
-      }(a));
-      static_assert([](auto const &a) constexpr -> bool {
-        return not requires { a == 0.5; }; // no implicit conversion
-      }(a));
-      static_assert([](auto const &a) constexpr -> bool {
-        return not requires { a != 0.5; }; // no implicit conversion
-      }(a));
-    }
   }
 
   WHEN("invoke")

--- a/tests/fn/choice.cpp
+++ b/tests/fn/choice.cpp
@@ -411,8 +411,18 @@ TEST_CASE("choice non-monadic functionality", "[choice]")
     static_assert(a == choice<double, int>{42}); // and across differing alternative lists
     static_assert(a != choice<double, int>{41});
 
+    // the alternative held is absent from the other choice's list, so there is nothing to compare
+    // and the answer is false whatever it holds
+    constexpr type b{std::in_place_type<bool>, true};
+    static_assert(not(b == choice<double, int>{42}));
+    static_assert(b != choice<double, int>{42});
+
     CHECK(a == type{42});
     CHECK(a != type{41});
+    CHECK(a == choice<double, int>{42});
+    CHECK(a != choice<double, int>{41});
+    CHECK(not(b == choice<double, int>{42}));
+    CHECK(b != choice<double, int>{42});
   }
 
   SECTION("invoke")

--- a/tests/fn/choice.cpp
+++ b/tests/fn/choice.cpp
@@ -50,10 +50,10 @@ TEST_CASE("choice non-monadic functionality", "[choice]")
 
   using fn::choice;
 
-  WHEN("value")
+  SECTION("value")
   {
     // _for aliases: a choice's value_type is the sum of its alternatives, but the canonical order is
-    // platform-specific (see WHEN("choice_for") below), so normalize both sides per platform.
+    // platform-specific (see SECTION("choice_for") below), so normalize both sides per platform.
     static_assert(std::same_as<fn::sum_for<NonCopyable, int>, typename fn::choice_for<NonCopyable, int>::value_type>);
     static_assert(std::same_as<fn::sum<int>, typename choice<int>::value_type>);
 
@@ -78,7 +78,7 @@ TEST_CASE("choice non-monadic functionality", "[choice]")
     CHECK((std::move(s).value().invoke(fn)) == 45);
   }
 
-  WHEN("choice_for")
+  SECTION("choice_for")
   {
     static_assert(std::same_as<fn::choice_for<int>, fn::choice<int>>);
     static_assert(std::same_as<fn::choice_for<int, int>, fn::choice<int>>);
@@ -120,7 +120,7 @@ TEST_CASE("choice non-monadic functionality", "[choice]")
     static_assert(std::same_as<fn::choice_for<double, fn::sum<>, fn::sum<bool, int>>, fn::choice<bool, double, int>>);
   }
 
-  WHEN("invocable")
+  SECTION("invocable")
   {
     using type = fn::choice_for<TestType, int>; // choice<...> order is platform-specific; choice_for normalizes
     static_assert(fn::typelist_invocable<decltype([](auto) {}), type &>);
@@ -143,7 +143,7 @@ TEST_CASE("choice non-monadic functionality", "[choice]")
     static_assert(not fn::typelist_invocable<decltype([](auto) {}), NonCopyable &>); // copy-constructor not available
   }
 
-  WHEN("single parameter constructor")
+  SECTION("single parameter constructor")
   {
     constexpr choice<int> a = 12;
     static_assert(a == choice{12});
@@ -151,7 +151,7 @@ TEST_CASE("choice non-monadic functionality", "[choice]")
     constexpr choice<bool> b{false};
     static_assert(b == choice{false});
 
-    WHEN("CTAD")
+    SECTION("CTAD")
     {
       choice a{42};
       static_assert(std::is_same_v<decltype(a), choice<int>>);
@@ -166,7 +166,7 @@ TEST_CASE("choice non-monadic functionality", "[choice]")
       static_assert(c.invoke([](auto &&a) -> bool { return a.size() == 3 && a[0] == 3 && a[1] == 14 && a[2] == 15; }));
     }
 
-    WHEN("constexpr move from rvalue")
+    SECTION("constexpr move from rvalue")
     {
       using T = fn::choice<bool, helper>;
       constexpr auto fn = [](auto i) constexpr noexcept -> T { return {std::move(i)}; };
@@ -181,7 +181,7 @@ TEST_CASE("choice non-monadic functionality", "[choice]")
       static_assert(b.value().get_ptr<helper>()->v == 19 * from_rval);
     }
 
-    WHEN("move from rvalue")
+    SECTION("move from rvalue")
     {
       using T = fn::choice<bool, helper>;
       constexpr auto fn = [](auto i) noexcept -> T { return {std::move(i)}; };
@@ -196,7 +196,7 @@ TEST_CASE("choice non-monadic functionality", "[choice]")
       CHECK(b.value() == fn::sum{true});
     }
 
-    WHEN("constexpr move from const rvalue")
+    SECTION("constexpr move from const rvalue")
     {
       using T = fn::choice<bool, helper>;
       constexpr auto fn = [](auto const i) constexpr noexcept -> T { return {std::move(i)}; };
@@ -211,7 +211,7 @@ TEST_CASE("choice non-monadic functionality", "[choice]")
       static_assert(b.value().get_ptr<helper>()->v == 17 * from_rval_const);
     }
 
-    WHEN("move from const rvalue")
+    SECTION("move from const rvalue")
     {
       using T = fn::choice<bool, helper>;
       constexpr auto fn = [](auto const i) noexcept -> T { return {std::move(i)}; };
@@ -226,7 +226,7 @@ TEST_CASE("choice non-monadic functionality", "[choice]")
       CHECK(b.value() == fn::sum{true});
     }
 
-    WHEN("constexpr copy from lvalue")
+    SECTION("constexpr copy from lvalue")
     {
       using T = fn::choice<bool, helper>;
       constexpr auto fn = [](auto i) constexpr noexcept -> T { return {i}; };
@@ -241,7 +241,7 @@ TEST_CASE("choice non-monadic functionality", "[choice]")
       static_assert(b.value().get_ptr<helper>()->v == 17 * from_lval);
     }
 
-    WHEN("copy from lvalue")
+    SECTION("copy from lvalue")
     {
       using T = fn::choice<bool, helper>;
       constexpr auto fn = [](auto i) noexcept -> T { return {i}; };
@@ -256,7 +256,7 @@ TEST_CASE("choice non-monadic functionality", "[choice]")
       CHECK(b.value().get_ptr<helper>()->v == 13 * from_lval);
     }
 
-    WHEN("constexpr copy from const lvalue")
+    SECTION("constexpr copy from const lvalue")
     {
       using T = fn::choice<bool, helper>;
       constexpr auto fn = [](auto const i) constexpr noexcept -> T { return {i}; };
@@ -271,7 +271,7 @@ TEST_CASE("choice non-monadic functionality", "[choice]")
       static_assert(b.value().get_ptr<helper>()->v == 15 * from_lval_const);
     }
 
-    WHEN("copy from const lvalue")
+    SECTION("copy from const lvalue")
     {
       using T = fn::choice<bool, helper>;
       constexpr auto fn = [](auto const i) noexcept -> T { return {i}; };
@@ -286,7 +286,7 @@ TEST_CASE("choice non-monadic functionality", "[choice]")
       CHECK(b.value().get_ptr<helper>()->v == 5 * from_lval_const);
     }
 
-    WHEN("copy ctor")
+    SECTION("copy ctor")
     {
       using T = fn::choice<bool, helper>;
       auto a = T{helper{1}};
@@ -297,7 +297,7 @@ TEST_CASE("choice non-monadic functionality", "[choice]")
       CHECK(b.value().get_ptr<helper>()->v == 23 * from_lval_const);
     }
 
-    WHEN("move ctor")
+    SECTION("move ctor")
     {
       using T = fn::choice<bool, helper>;
       auto a = T{helper{1}};
@@ -309,17 +309,17 @@ TEST_CASE("choice non-monadic functionality", "[choice]")
     }
   }
 
-  WHEN("constructor from sum")
+  SECTION("constructor from sum")
   {
     using T = fn::choice<bool, helper>;
-    WHEN("move from rvalue")
+    SECTION("move from rvalue")
     {
       fn::sum h{helper{1}};
       h.get_ptr<helper>()->v = 17;
       T const a{std::move(h)};
       CHECK(a.value().get_ptr<helper>()->v == 17 * from_rval);
     }
-    WHEN("copy from const lvalue")
+    SECTION("copy from const lvalue")
     {
       fn::sum h{helper{1}};
       h.get_ptr<helper>()->v = 19;
@@ -328,12 +328,12 @@ TEST_CASE("choice non-monadic functionality", "[choice]")
     }
   }
 
-  WHEN("forwarding constructors (immovable)")
+  SECTION("forwarding constructors (immovable)")
   {
     choice<NonCopyable> a{std::in_place_type<NonCopyable>, 42};
     CHECK(a.invoke([](auto &i) -> bool { return i.i == 42; }));
 
-    WHEN("CTAD")
+    SECTION("CTAD")
     {
       constexpr auto a = choice{std::in_place_type<NonCopyable>, 42};
       static_assert(std::is_same_v<decltype(a), choice<NonCopyable> const>);
@@ -343,9 +343,9 @@ TEST_CASE("choice non-monadic functionality", "[choice]")
     }
   }
 
-  WHEN("forwarding constructors (aggregate)")
+  SECTION("forwarding constructors (aggregate)")
   {
-    WHEN("regular")
+    SECTION("regular")
     {
       choice<std::array<int, 3>> a{std::in_place_type<std::array<int, 3>>, 1, 2, 3};
       static_assert(decltype(a)::has_type<std::array<int, 3>>);
@@ -357,7 +357,7 @@ TEST_CASE("choice non-monadic functionality", "[choice]")
       }));
     }
 
-    WHEN("constexpr")
+    SECTION("constexpr")
     {
       constexpr choice<std::array<int, 3>> a{std::in_place_type<std::array<int, 3>>, 1, 2, 3};
       static_assert(decltype(a)::has_type<std::array<int, 3>>);
@@ -370,7 +370,7 @@ TEST_CASE("choice non-monadic functionality", "[choice]")
       }));
     }
 
-    WHEN("CTAD")
+    SECTION("CTAD")
     {
       constexpr auto a = choice{std::in_place_type<std::array<int, 3>>, 1, 2, 3};
       static_assert(std::is_same_v<decltype(a), choice<std::array<int, 3>> const>);
@@ -380,7 +380,7 @@ TEST_CASE("choice non-monadic functionality", "[choice]")
     }
   }
 
-  WHEN("equality comparison")
+  SECTION("equality comparison")
   {
     // The comparison operators are sum's - free functions taking sum<Ts...> const & - and sum.cpp
     // owns their grid. What is choice's own is that a choice reaches them at all, through its public
@@ -399,10 +399,10 @@ TEST_CASE("choice non-monadic functionality", "[choice]")
     CHECK(a != type{41});
   }
 
-  WHEN("invoke")
+  SECTION("invoke")
   {
     choice<int> a{std::in_place_type<int>, 42};
-    WHEN("value only")
+    SECTION("value only")
     {
       CHECK(a.invoke(  //
           fn::overload{//
@@ -424,7 +424,7 @@ TEST_CASE("choice non-monadic functionality", "[choice]")
                        [](int const &) -> bool { throw 0; }, [](int &&) -> bool { return true; },
                        [](int const &&) -> bool { throw 0; }}));
 
-      WHEN("constexpr")
+      SECTION("constexpr")
       {
         constexpr choice<int> a{std::in_place_type<int>, 42};
         static_assert(a.invoke(fn::overload{
@@ -439,10 +439,10 @@ TEST_CASE("choice non-monadic functionality", "[choice]")
     }
   }
 
-  WHEN("invoke_r")
+  SECTION("invoke_r")
   {
     choice<int> a{std::in_place_type<int>, 42};
-    WHEN("value only")
+    SECTION("value only")
     {
       CHECK(a.invoke_r<int>( //
           fn::overload{      //
@@ -464,7 +464,7 @@ TEST_CASE("choice non-monadic functionality", "[choice]")
                        [](int const &) -> bool { throw 0; }, [](int &&) -> bool { return true; },
                        [](int const &&) -> bool { throw 0; }}));
 
-      WHEN("constexpr")
+      SECTION("constexpr")
       {
         constexpr choice<int> a{std::in_place_type<int>, 42};
         static_assert(a.invoke_r<int>(fn::overload{
@@ -589,7 +589,7 @@ TEST_CASE("choice and_then", "[choice][and_then]")
 
 TEST_CASE("choice transform", "[choice][transform]")
 {
-  WHEN("size 2, only one set")
+  SECTION("size 2, only one set")
   {
     using type = fn::choice<bool, int>;
     constexpr auto init = std::in_place_type<int>;
@@ -649,7 +649,7 @@ TEST_CASE("choice transform", "[choice][transform]")
                   == fn::choice<double>{5.25});
   }
 
-  WHEN("size 2")
+  SECTION("size 2")
   {
     using ::fn::choice;
     using ::fn::sum;
@@ -658,11 +658,11 @@ TEST_CASE("choice transform", "[choice][transform]")
     using type = choice<double, int>;
     static_assert(type::size == 2);
 
-    WHEN("element v0 set")
+    SECTION("element v0 set")
     {
       type a{std::in_place_type<double>, 0.5};
       CHECK(a.data.v0 == 0.5);
-      WHEN("value only")
+      SECTION("value only")
       {
         static_assert(type{0.5}.transform(fn1) == choice{std::size_t{8}});
         CHECK(a.transform(     //
@@ -693,12 +693,12 @@ TEST_CASE("choice transform", "[choice][transform]")
       }
     }
 
-    WHEN("element v1 set")
+    SECTION("element v1 set")
     {
       type a{std::in_place_type<int>, 42};
       CHECK(a.data.v1 == 42);
 
-      WHEN("value only")
+      SECTION("value only")
       {
         static_assert(type{42}.transform(fn1) == choice{std::size_t{4}});
         CHECK(a.transform(     //

--- a/tests/fn/concepts.cpp
+++ b/tests/fn/concepts.cpp
@@ -285,6 +285,68 @@ static_assert(not same_kind<expected<void, Error> const && , expected<void, Xerr
 static_assert(not same_kind<expected<void, Error> const && , expected<void, Xerror> &&>);
 static_assert(not same_kind<expected<void, Error> const && , expected<void, Xerror> const &&>);
 // clang-format on
+
+namespace {
+struct Immovable final {
+  Immovable() = default;
+  Immovable(Immovable const &) = delete;
+  Immovable(Immovable &&) = delete;
+};
+
+struct Boolish final {
+  explicit operator bool() const noexcept { return true; }
+};
+} // namespace
+
+// same_value_kind is the symmetric twin of same_kind above: it pins the VALUE type and lets the error
+// vary, where same_kind pins the error and lets the value vary.
+static_assert(same_value_kind<expected<int, Error>, expected<int, Xerror>>);      // the error may differ
+static_assert(not same_value_kind<expected<int, Error>, expected<Value, Error>>); // the value may not
+static_assert(not same_kind<expected<int, Error>, expected<int, Xerror>>);        // ... and the other way round
+static_assert(same_kind<expected<int, Error>, expected<Value, Error>>);
+
+// a sum-valued expected matches any other sum-valued one, whatever the sums hold - the arm that lets
+// the value widen
+static_assert(same_value_kind<expected<sum<int>, Error>, expected<sum<Value>, Xerror>>);
+static_assert(not same_value_kind<expected<sum<int>, Error>, expected<int, Error>>);
+
+static_assert(same_value_kind<optional<int>, optional<int>>);
+static_assert(not same_value_kind<optional<int>, optional<Value>>);
+static_assert(same_value_kind<optional<sum<int>>, optional<sum<Value>>>);
+
+static_assert(same_value_kind<choice<int>, choice<Value>>);              // any two choices, as for same_kind
+static_assert(not same_value_kind<optional<int>, expected<int, Error>>); // but never across kinds
+static_assert(same_value_kind<expected<int, Error> const &, expected<int, Xerror> &&>); // cvref makes no difference
+
+// same_monadic_type_as is the conjunction of the two: value and error must both agree
+static_assert(same_monadic_type_as<expected<int, Error>, expected<int, Error>>);
+static_assert(not same_monadic_type_as<expected<int, Error>, expected<int, Xerror>>);  // the error differs
+static_assert(not same_monadic_type_as<expected<int, Error>, expected<Value, Error>>); // the value differs
+static_assert(same_monadic_type_as<optional<int>, optional<int>>);
+static_assert(not same_monadic_type_as<optional<int>, optional<Value>>);
+
+// convertible_to_bool is what filter holds its predicate to
+static_assert(convertible_to_bool<bool>);
+static_assert(convertible_to_bool<int>);
+static_assert(convertible_to_bool<int *>);
+static_assert(convertible_to_bool<Boolish>); // an explicit operator bool suffices - the concept casts
+static_assert(not convertible_to_bool<Error>);
+static_assert(not convertible_to_bool<Value>);
+
+// the convertible_to_* family each ask whether the monad can be built from the value by a cast, so an
+// operand with nothing to move or copy into it satisfies none of them
+static_assert(convertible_to_unexpected<Error>);
+static_assert(not convertible_to_unexpected<Immovable>);
+
+static_assert(convertible_to_expected<int, Error>);
+static_assert(convertible_to_expected<void, Error>); // void is admitted outright, by its own arm
+static_assert(not convertible_to_expected<Immovable, Error>);
+
+static_assert(convertible_to_optional<int>);
+static_assert(not convertible_to_optional<Immovable>);
+
+static_assert(convertible_to_choice<int>);
+static_assert(not convertible_to_choice<Immovable>);
 } // namespace fn
 
-TEST_CASE("Dummy") { SUCCEED(); }
+TEST_CASE("concepts", "[concepts]") { SUCCEED(); }

--- a/tests/fn/detail/pack_impl.cpp
+++ b/tests/fn/detail/pack_impl.cpp
@@ -69,6 +69,50 @@ TEST_CASE("pack_impl size and aggregate construction", "[pack_impl]")
   using PN = pack_impl<std::index_sequence_for<NonCopyable>, NonCopyable>;
   constexpr PN pn{NonCopyable{99}};
   static_assert(PN::_invoke(pn, [](NonCopyable const &n) { return n.v; }) == 99);
+
+  SUCCEED();
+}
+
+TEST_CASE("pack_impl noexcept", "[pack_impl][noexcept]")
+{
+  using fn::detail::pack_impl;
+
+  // An element whose copy and move can both throw, so that what the members promise can be compared
+  // with what they actually do.
+  struct Throwing final {
+    int v;
+
+    constexpr Throwing(int i) noexcept : v(i) {}
+    constexpr Throwing(Throwing const &o) noexcept(false) : v(o.v) {}
+    constexpr Throwing(Throwing &&o) noexcept(false) : v(o.v) {}
+  };
+  static_assert(not std::is_nothrow_copy_constructible_v<Throwing>);
+
+  using P = pack_impl<std::index_sequence_for<int, double>, int, double>;
+  using PT = pack_impl<std::index_sequence_for<Throwing>, Throwing>;
+
+  constexpr auto throwing_fn = [](auto &&...) noexcept(false) -> int { return 0; };
+
+  // GAP #285: _swap_invoke is the third of the pipeline's four unconditional noexcept boundaries -
+  // functor::operator| dispatches through it - and _invoke is declared the same way, so a callback
+  // that may throw is promised not to.
+  static_assert(noexcept(P::_swap_invoke(std::declval<P const &>(), throwing_fn)));
+  static_assert(noexcept(P::_invoke(std::declval<P const &>(), throwing_fn)));
+
+  // GAP #280: _append is unconditionally noexcept as well, though it constructs the appended element
+  // AND relocates every existing one into the new pack - each of which can throw here.
+  static_assert(noexcept(PT::template _append<int>(std::declval<PT const &>(), 1)));
+  static_assert(noexcept(P::template _append<Throwing>(std::declval<P const &>(), 1)));
+
+  // _get's promise is accurate: it only forms a reference to an element, touching nothing.
+  static_assert(noexcept(P::template _get<0>(std::declval<P const &>())));
+  static_assert(noexcept(PT::template _get<0>(std::declval<PT &>())));
+
+  // #282: a pack never holds a sum, and _append deletes the overload that would - but the deletion is
+  // dead code, because append_type<sum> is an ambiguous partial specialization and fails first.
+  // No probe is portable until that is fixed (it hard-errors on gcc, SFINAEs cleanly on clang).
+
+  SUCCEED();
 }
 
 TEST_CASE("pack_impl _swap_invoke", "[pack_impl][swap_invoke]")

--- a/tests/fn/detail/pack_impl.cpp
+++ b/tests/fn/detail/pack_impl.cpp
@@ -4,6 +4,7 @@
 // or copy at https://opensource.org/licenses/ISC
 
 #include <fn/detail/pack_impl.hpp>
+#include <fn/sum.hpp>
 
 #include <catch2/catch_all.hpp>
 
@@ -107,10 +108,6 @@ TEST_CASE("pack_impl noexcept", "[pack_impl][noexcept]")
   // _get's promise is accurate: it only forms a reference to an element, touching nothing.
   static_assert(noexcept(P::template _get<0>(std::declval<P const &>())));
   static_assert(noexcept(PT::template _get<0>(std::declval<PT &>())));
-
-  // #282: a pack never holds a sum, and _append deletes the overload that would - but the deletion is
-  // dead code, because append_type<sum> is an ambiguous partial specialization and fails first.
-  // No probe is portable until that is fixed (it hard-errors on gcc, SFINAEs cleanly on clang).
 
   SUCCEED();
 }
@@ -238,6 +235,8 @@ TEST_CASE("pack_impl _append and append_type", "[pack_impl][append][append_type]
   static_assert(not can_append<P0, int, int, int>);
   // positive control: single-arg int ctor accepted
   static_assert(can_append<P0, int, int>);
+  // SFINAE: a pack never holds a sum, so append_type<sum> names no type and the overload drops out
+  static_assert(not can_append<P0, ::fn::sum<int>, ::fn::sum<int>>);
 
   // append_type<T> alias resolves to ::fn::pack<Ts..., T>
   static_assert(std::same_as<P2::append_type<bool>, ::fn::pack<int, double, bool>>);

--- a/tests/fn/detail/variadic_union.cpp
+++ b/tests/fn/detail/variadic_union.cpp
@@ -98,7 +98,8 @@ template <typename U, std::size_t I> constexpr auto check_alternative() -> bool
 
   // invoke_type additionally passes in_place_type<T>, naming the alternative it dispatched to - and
   // passes exactly those two arguments
-  constexpr auto arity = [](auto &&...args) -> std::size_t { return sizeof...(args); };
+  // [[maybe_unused]]: only the pack's arity is read, and MSVC /W4 flags each expanded parameter
+  constexpr auto arity = []([[maybe_unused]] auto &&...args) -> std::size_t { return sizeof...(args); };
   ok = ok && invoke_type_variadic_union<std::size_t, U>(u, I, arity) == 2;
   ok = ok && invoke_type_variadic_union<bool, U>(u, I, []<typename X>(std::in_place_type_t<X>, auto) -> bool {
          return std::same_as<X, T>;

--- a/tests/fn/detail/variadic_union.cpp
+++ b/tests/fn/detail/variadic_union.cpp
@@ -9,10 +9,17 @@
 #include <catch2/catch_all.hpp>
 
 #include <concepts>
+#include <cstddef>
 #include <string>
 #include <string_view>
 #include <type_traits>
 #include <utility>
+
+using fn::detail::invoke_type_variadic_union;
+using fn::detail::invoke_variadic_union;
+using fn::detail::make_variadic_union;
+using fn::detail::ptr_variadic_union;
+using fn::detail::variadic_union;
 
 namespace {
 
@@ -24,407 +31,159 @@ struct NonCopyable final {
   NonCopyable(NonCopyable const &) = delete;
   NonCopyable &operator=(NonCopyable const &) = delete;
 };
+
+// Never an alternative of any union below, so every negative probe can name it.
+struct Absent final {};
+
+// Type-keyed rather than taking a value: the probe is used inside a constexpr function, whose locals
+// are not constant expressions and so cannot be fed to a static_assert.
+template <typename T, typename U>
+concept can_ptr = requires(U &u) { ptr_variadic_union<T, U>(u); };
+
+// Recovers the alternative pack from the union type, so a test can be written once and ranged over
+// the unions themselves rather than over a parallel list of their contents.
+template <typename U> struct alternatives;
+template <typename... Ts> struct alternatives<variadic_union<Ts...>> {
+  static constexpr std::size_t size = sizeof...(Ts);
+  template <std::size_t I> using nth = fn::detail::select_nth_t<I, Ts...>;
+};
+
+// A distinct witness value per alternative type, so a round trip through the union can be checked
+// for identity and not merely for compiling.
+template <typename T> struct witness;
+template <> struct witness<bool> {
+  static constexpr bool value = true;
+};
+template <> struct witness<int> {
+  static constexpr int value = 42;
+};
+template <> struct witness<double> {
+  static constexpr double value = 0.5;
+};
+template <> struct witness<float> {
+  static constexpr float value = 1.5f;
+};
+template <> struct witness<std::string_view> {
+  static constexpr std::string_view value = "hello";
+};
+
+// The whole battery for ONE alternative of ONE union: construction, typed access, and both dispatch
+// functions in their void and non-void flavours - which the header specializes separately per union
+// size, so every arity must run all of it. constexpr so a single definition serves both the
+// compile-time assertion and the runtime one (a static_assert alone would leave gcov holes).
+template <typename U, std::size_t I> constexpr auto check_alternative() -> bool
+{
+  using T = typename alternatives<U>::template nth<I>;
+  constexpr T v = witness<T>::value;
+
+  static_assert(U::template has_type<T>);
+
+  U const u = make_variadic_union<T, U>(v);
+  U m = make_variadic_union<T, U>(v);
+
+  // constness of the union propagates to the pointer, and an absent type is not accessible at all
+  static_assert(std::same_as<decltype(ptr_variadic_union<T, U>(u)), T const *>);
+  static_assert(std::same_as<decltype(ptr_variadic_union<T, U>(m)), T *>);
+  static_assert(can_ptr<T, U>);
+  static_assert(not can_ptr<Absent, U>);
+
+  bool ok = *ptr_variadic_union<T, U>(u) == v && *ptr_variadic_union<T, U>(m) == v;
+
+  // invoke passes the alternative alone; the result converts to whatever R asks for
+  constexpr auto size_of = [](auto x) -> std::size_t { return sizeof(x); };
+  static_assert(std::same_as<std::size_t, decltype(invoke_variadic_union<std::size_t, U>(u, I, size_of))>);
+  static_assert(std::same_as<long, decltype(invoke_variadic_union<long, U>(u, I, size_of))>);
+  ok = ok && invoke_variadic_union<std::size_t, U>(u, I, size_of) == sizeof(T);
+  ok = ok && invoke_variadic_union<long, U>(u, I, size_of) == static_cast<long>(sizeof(T));
+
+  // invoke_type additionally passes in_place_type<T>, naming the alternative it dispatched to - and
+  // passes exactly those two arguments
+  constexpr auto arity = [](auto &&...args) -> std::size_t { return sizeof...(args); };
+  ok = ok && invoke_type_variadic_union<std::size_t, U>(u, I, arity) == 2;
+  ok = ok && invoke_type_variadic_union<bool, U>(u, I, []<typename X>(std::in_place_type_t<X>, auto) -> bool {
+         return std::same_as<X, T>;
+       });
+
+  // both dispatchers have a separate void-returning overload per union size
+  static_assert(std::same_as<void, decltype(invoke_variadic_union<void, U>(u, I, size_of))>);
+  std::size_t seen = 0;
+  invoke_variadic_union<void, U>(u, I, [&seen](auto x) { seen = sizeof(x); });
+  ok = ok && seen == sizeof(T);
+
+  static_assert(std::same_as<void, decltype(invoke_type_variadic_union<void, U>(u, I, arity))>);
+  bool named = false;
+  invoke_type_variadic_union<void, U>(u, I, [&named]<typename X>(std::in_place_type_t<X>, auto) { //
+    named = std::same_as<X, T>;
+  });
+  ok = ok && named;
+
+  return ok;
+}
+
+template <typename U> constexpr auto check_union() -> bool
+{
+  return []<std::size_t... Is>(std::index_sequence<Is...>) { //
+    return (check_alternative<U, Is>() && ...);
+  }(std::make_index_sequence<alternatives<U>::size>{});
+}
+
+// Named, because a template argument list carries commas and TEMPLATE_TEST_CASE is a macro: the
+// commas inside variadic_union<bool, int> would be read as further macro arguments.
+using U1 = variadic_union<bool>;
+using U2 = variadic_union<bool, int>;
+using U3 = variadic_union<bool, int, double>;
+using U4 = variadic_union<bool, int, double, float>;
+using U5 = variadic_union<bool, int, double, float, std::string_view>;
+
 } // namespace
 
-TEST_CASE(
-    "variadic_union",
-    "[variadic_union][invoke_variadic_union][invoke_type_variadic_union][ptr_variadic_union][make_variadic_union]")
+// One battery, run against every specialization the header defines: sizes one through four, then the
+// recursive one that chains a nested union past the fourth alternative.
+TEMPLATE_TEST_CASE("variadic_union",
+                   "[variadic_union][make_variadic_union][ptr_variadic_union]"
+                   "[invoke_variadic_union][invoke_type_variadic_union]",
+                   U1, U2, U3, U4, U5)
 {
-  using fn::detail::invoke_variadic_union;
-  using fn::detail::make_variadic_union;
-  using fn::detail::ptr_variadic_union;
-  using fn::detail::variadic_union;
+  using U = TestType;
 
+  static_assert(U::size == alternatives<U>::size);
+  static_assert(not U::template has_type<Absent>);
+  static_assert(not U::template has_type<std::string>);
+
+  // The same battery twice over. Folded into one assertion at compile time; then run again per
+  // alternative, both so that coverage sees the lines execute and so that a failure names the
+  // alternative that broke rather than only the union it belongs to.
+  static_assert(check_union<U>());
+
+  []<std::size_t... Is>(std::index_sequence<Is...>) {
+    auto const one = []<std::size_t I>(std::integral_constant<std::size_t, I>) {
+      INFO("alternative " << I);
+      CHECK(check_alternative<U, I>());
+    };
+    (one(std::integral_constant<std::size_t, Is>{}), ...);
+  }(std::make_index_sequence<alternatives<U>::size>{});
+}
+
+TEST_CASE("variadic_union with a non-copyable alternative", "[variadic_union][make_variadic_union][ptr_variadic_union]")
+{
+  // The templated battery above copies its witness into the union, so a type that cannot be copied
+  // needs its own case: it is constructed in place from the arguments instead. A const alternative
+  // sits alongside a non-const one of the same underlying type, which the union must keep distinct.
   using T2 = variadic_union<NonCopyable, NonCopyable const>;
   constexpr T2 a2 = make_variadic_union<NonCopyable, T2>(12);
   static_assert(ptr_variadic_union<NonCopyable, T2>(a2)->v == 12);
   constexpr T2 a3 = make_variadic_union<NonCopyable const, T2>(36);
   static_assert(ptr_variadic_union<NonCopyable const, T2>(a3)->v == 36);
+  static_assert(T2::has_type<NonCopyable>);
+  static_assert(T2::has_type<NonCopyable const>);
+  static_assert(not T2::has_type<Absent>);
 
+  // and in the recursive specialization, where it lands past the fourth alternative
   using T6 = variadic_union<int, bool, double, float, NonCopyable>;
   constexpr T6 a4 = make_variadic_union<NonCopyable, T6>(42);
   static_assert(ptr_variadic_union<NonCopyable, T6>(a4)->v == 42);
+  // by const reference: a by-value callback would copy the alternative, which NonCopyable forbids
+  static_assert(invoke_variadic_union<int, T6>(a4, 4, [](auto const &i) -> int { return static_cast<int>(i); }) == 42);
 
-  using U1 = variadic_union<bool>;
-  constexpr U1 b1 = make_variadic_union<bool, U1>(true);
-  static_assert(decltype(b1)::has_type<bool>);
-  static_assert(not decltype(b1)::has_type<int>);
-  static_assert([](auto &&b) -> bool { return not requires { ptr_variadic_union<int, U1>(b); }; }(b1));
-  static_assert(std::same_as<decltype(ptr_variadic_union<bool, U1>(b1)), bool const *>);
-  static_assert(std::same_as<decltype(ptr_variadic_union<bool, U1>(U1{.v0 = false})), bool *>);
-  static_assert(*ptr_variadic_union<bool, U1>(b1));
-  static_assert(invoke_variadic_union<std::size_t, U1>(b1, 0, [](auto i) -> std::size_t { return sizeof(i); }) == 1);
-  static_assert(invoke_type_variadic_union<bool, U1>(b1, 0, []<typename T>(std::in_place_type_t<T>, auto i) -> bool {
-    if constexpr (std::same_as<T, bool>)
-      return i;
-    return false;
-  }));
-
-  using U2 = variadic_union<bool, int>;
-  constexpr U2 b2 = make_variadic_union<int, U2>(42);
-  static_assert(decltype(b2)::has_type<bool>);
-  static_assert(decltype(b2)::has_type<int>);
-  static_assert(not decltype(b2)::has_type<double>);
-  static_assert([](auto &&b) -> bool { return not requires { ptr_variadic_union<double, U2>(b); }; }(b2));
-  static_assert(std::same_as<decltype(ptr_variadic_union<bool, U2>(b2)), bool const *>);
-  static_assert(std::same_as<decltype(ptr_variadic_union<int, U2>(b2)), int const *>);
-  static_assert(std::same_as<decltype(ptr_variadic_union<bool, U2>(U2{.v0 = false})), bool *>);
-  static_assert(std::same_as<decltype(ptr_variadic_union<int, U2>(U2{.v1 = 12})), int *>);
-  static_assert(*ptr_variadic_union<int, U2>(b2) == 42);
-  static_assert(invoke_variadic_union<std::size_t, U2>(b2, 1, [](auto i) -> std::size_t { return sizeof(i); }) == 4);
-  static_assert(invoke_type_variadic_union<int, U2>(b2, 1,
-                                                    []<typename T>(std::in_place_type_t<T>, auto i) -> int {
-                                                      if constexpr (std::same_as<T, int>)
-                                                        return i / 2;
-                                                      return 0;
-                                                    })
-                == 21);
-
-  using U3 = variadic_union<bool, int, double>;
-  constexpr U3 b3 = make_variadic_union<double, U3>(0.5);
-  static_assert(decltype(b3)::has_type<bool>);
-  static_assert(decltype(b3)::has_type<int>);
-  static_assert(decltype(b3)::has_type<double>);
-  static_assert(not decltype(b3)::has_type<float>);
-  static_assert([](auto &&b) -> bool { return not requires { ptr_variadic_union<float, U3>(b); }; }(b3));
-  static_assert(std::same_as<decltype(ptr_variadic_union<bool, U3>(b3)), bool const *>);
-  static_assert(std::same_as<decltype(ptr_variadic_union<int, U3>(b3)), int const *>);
-  static_assert(std::same_as<decltype(ptr_variadic_union<double, U3>(b3)), double const *>);
-  static_assert(std::same_as<decltype(ptr_variadic_union<bool, U3>(U3{.v0 = false})), bool *>);
-  static_assert(std::same_as<decltype(ptr_variadic_union<int, U3>(U3{.v1 = 12})), int *>);
-  static_assert(*ptr_variadic_union<double, U3>(b3) == 0.5);
-  static_assert(invoke_variadic_union<std::size_t, U3>(b3, 2, [](auto i) -> std::size_t { return sizeof(i); }) == 8);
-  static_assert(invoke_type_variadic_union<int, U3>(b3, 2,
-                                                    []<typename T>(std::in_place_type_t<T>, auto i) -> int {
-                                                      if constexpr (std::same_as<T, double>)
-                                                        return i * 4;
-                                                      return 0;
-                                                    })
-                == 2);
-
-  using U4 = variadic_union<bool, int, double, float>;
-  constexpr U4 b4 = make_variadic_union<float, U4>(1.5f);
-  static_assert(decltype(b4)::has_type<bool>);
-  static_assert(decltype(b4)::has_type<int>);
-  static_assert(decltype(b4)::has_type<double>);
-  static_assert(decltype(b4)::has_type<float>);
-  static_assert(not decltype(b4)::has_type<std::string_view>);
-  static_assert([](auto &&b) -> bool { return not requires { ptr_variadic_union<std::string_view, U4>(b); }; }(b4));
-  static_assert(std::same_as<decltype(ptr_variadic_union<bool, U4>(b4)), bool const *>);
-  static_assert(std::same_as<decltype(ptr_variadic_union<int, U4>(b4)), int const *>);
-  static_assert(std::same_as<decltype(ptr_variadic_union<double, U4>(b4)), double const *>);
-  static_assert(std::same_as<decltype(ptr_variadic_union<float, U4>(b4)), float const *>);
-  static_assert(std::same_as<decltype(ptr_variadic_union<bool, U4>(U4{.v0 = false})), bool *>);
-  static_assert(std::same_as<decltype(ptr_variadic_union<int, U4>(U4{.v1 = 12})), int *>);
-  static_assert(*ptr_variadic_union<float, U4>(b4) == 1.5f);
-  static_assert(invoke_variadic_union<std::size_t, U4>(b4, 3, [](auto i) -> std::size_t { return sizeof(i); }) == 4);
-  static_assert(invoke_type_variadic_union<int, U4>(b4, 3,
-                                                    []<typename T>(std::in_place_type_t<T>, auto i) -> int {
-                                                      if constexpr (std::same_as<T, float>)
-                                                        return i * 4;
-                                                      return 0;
-                                                    })
-                == 6);
-
-  using U5 = variadic_union<bool, int, double, float, std::string_view>;
-  constexpr U5 b5 = make_variadic_union<std::string_view, U5>("hello");
-  static_assert(decltype(b5)::has_type<bool>);
-  static_assert(decltype(b5)::has_type<int>);
-  static_assert(decltype(b5)::has_type<double>);
-  static_assert(decltype(b5)::has_type<float>);
-  static_assert(decltype(b5)::has_type<std::string_view>);
-  static_assert(not decltype(b5)::has_type<std::string>);
-  static_assert([](auto &&b) -> bool { return not requires { ptr_variadic_union<std::string, U5>(b); }; }(b5));
-  static_assert(std::same_as<decltype(ptr_variadic_union<bool, U5>(b5)), bool const *>);
-  static_assert(std::same_as<decltype(ptr_variadic_union<int, U5>(b5)), int const *>);
-  static_assert(std::same_as<decltype(ptr_variadic_union<double, U5>(b5)), double const *>);
-  static_assert(std::same_as<decltype(ptr_variadic_union<float, U5>(b5)), float const *>);
-  static_assert(std::same_as<decltype(ptr_variadic_union<std::string_view, U5>(b5)), std::string_view const *>);
-  static_assert(std::same_as<decltype(ptr_variadic_union<bool, U5>(U5{.v0 = false})), bool *>);
-  static_assert(std::same_as<decltype(ptr_variadic_union<int, U5>(U5{.v1 = 12})), int *>);
-  static_assert(*ptr_variadic_union<std::string_view, U5>(b5) == std::string_view{"hello"});
-  static_assert(invoke_variadic_union<std::size_t, U5>(b5, 4, [](auto i) -> std::size_t { return sizeof(i); }) == 16);
-  static_assert(invoke_type_variadic_union<int, U5>(b5, 4,
-                                                    []<typename T>(std::in_place_type_t<T>, auto i) -> int {
-                                                      if constexpr (std::same_as<T, std::string_view>)
-                                                        return static_cast<int>(i.size());
-                                                      return 0;
-                                                    })
-                == 5);
-
-  SUCCEED();
-}
-
-TEST_CASE("variadic_unionc invoke only", "[variadic_union][invoke_variadic_union][invoke_type_variadic_union]")
-{
-  using fn::detail::invoke_variadic_union;
-  using fn::detail::make_variadic_union;
-  using fn::detail::variadic_union;
-
-  constexpr auto fn1 = [](auto i) { return static_cast<short>(i); };
-  int total = 0;
-  auto fn1L = [&total](auto i) { total += static_cast<int>(i); };
-  constexpr auto fn2 = [](fn::some_in_place_type auto, auto i) { return static_cast<short>(i * 2); };
-  auto fn2L = [&total](fn::some_in_place_type auto, auto i) { total += static_cast<int>(2 * i); };
-  auto fnAll = []([[maybe_unused]] auto &&...a) { return static_cast<int>(sizeof...(a)); };
-
-  WHEN("size == 1")
-  {
-    using type = variadic_union<int>;
-    auto const v0 = make_variadic_union<int, type>(42);
-    static_assert(std::is_same_v<void, decltype(invoke_variadic_union<void, type>(v0, 0, fn1L))>);
-    static_assert(std::is_same_v<void, decltype(invoke_type_variadic_union<void, type>(v0, 0, fn2L))>);
-    static_assert(std::is_same_v<int, decltype(invoke_variadic_union<int, type>(v0, 0, fn1))>);
-    static_assert(std::is_same_v<long, decltype(invoke_variadic_union<long, type>(v0, 0, fn1))>);
-    static_assert(std::is_same_v<int, decltype(invoke_type_variadic_union<int, type>(v0, 0, fn2))>);
-    static_assert(std::is_same_v<long, decltype(invoke_type_variadic_union<long, type>(v0, 0, fn2))>);
-
-    constexpr type a = make_variadic_union<int, type>(7);
-    static_assert(std::is_same_v<void, decltype(invoke_variadic_union<void, type>(a, 0, fnAll))>);
-    static_assert(invoke_type_variadic_union<int, type>(a, 0, fnAll) == 2);
-
-    CHECK(invoke_variadic_union<int, type>(v0, 0, fn1) == 42);
-    CHECK(invoke_type_variadic_union<int, type>(v0, 0, fn2) == 84);
-    auto const before = total;
-    invoke_variadic_union<void, type>(v0, 0, fn1L);
-    CHECK(total == before + 42);
-    invoke_type_variadic_union<void, type>(v0, 0, fn2L);
-    CHECK(total == before + 42 + 84);
-  }
-
-  WHEN("size == 2")
-  {
-    using type = variadic_union<int, short>;
-
-    static_assert(std::is_same_v<void, decltype(invoke_variadic_union<void, type>(std::declval<type>(), 0, fn1L))>);
-    static_assert(
-        std::is_same_v<void, decltype(invoke_type_variadic_union<void, type>(std::declval<type>(), 0, fn2L))>);
-    static_assert(std::is_same_v<int, decltype(invoke_variadic_union<int, type>(std::declval<type>(), 0, fn1))>);
-    static_assert(std::is_same_v<long, decltype(invoke_variadic_union<long, type>(std::declval<type>(), 0, fn1))>);
-    static_assert(std::is_same_v<int, decltype(invoke_type_variadic_union<int, type>(std::declval<type>(), 0, fn2))>);
-    static_assert(std::is_same_v<long, decltype(invoke_type_variadic_union<long, type>(std::declval<type>(), 0, fn2))>);
-
-    constexpr type a = make_variadic_union<int, type>(7);
-    static_assert(std::is_same_v<void, decltype(invoke_variadic_union<void, type>(a, 0, fnAll))>);
-    static_assert(invoke_type_variadic_union<int, type>(a, 0, fnAll) == 2);
-
-    WHEN("v0 set")
-    {
-      auto const v0 = make_variadic_union<int, type>(42);
-      CHECK(invoke_variadic_union<int, type>(v0, 0, fn1) == 42);
-      CHECK(invoke_type_variadic_union<int, type>(v0, 0, fn2) == 84);
-      auto const before = total;
-      invoke_variadic_union<void, type>(v0, 0, fn1L);
-      CHECK(total == before + 42);
-      invoke_type_variadic_union<void, type>(v0, 0, fn2L);
-      CHECK(total == before + 42 + 84);
-    }
-
-    WHEN("v1 set")
-    {
-      auto const v1 = make_variadic_union<short, type>((short)26);
-      CHECK(invoke_variadic_union<short, type>(v1, 1, fn1) == 26);
-      CHECK(invoke_type_variadic_union<short, type>(v1, 1, fn2) == 52);
-      auto const before = total;
-      invoke_variadic_union<void, type>(v1, 1, fn1L);
-      CHECK(total == before + 26);
-      invoke_type_variadic_union<void, type>(v1, 1, fn2L);
-      CHECK(total == before + 26 + 52);
-    }
-  }
-
-  WHEN("size == 3")
-  {
-    using type = variadic_union<int, short, long>;
-
-    static_assert(std::is_same_v<void, decltype(invoke_variadic_union<void, type>(std::declval<type>(), 0, fn1L))>);
-    static_assert(
-        std::is_same_v<void, decltype(invoke_type_variadic_union<void, type>(std::declval<type>(), 0, fn2L))>);
-    static_assert(std::is_same_v<int, decltype(invoke_variadic_union<int, type>(std::declval<type>(), 0, fn1))>);
-    static_assert(std::is_same_v<long, decltype(invoke_variadic_union<long, type>(std::declval<type>(), 0, fn1))>);
-    static_assert(std::is_same_v<int, decltype(invoke_type_variadic_union<int, type>(std::declval<type>(), 0, fn2))>);
-    static_assert(std::is_same_v<long, decltype(invoke_type_variadic_union<long, type>(std::declval<type>(), 0, fn2))>);
-
-    constexpr type a = make_variadic_union<int, type>(7);
-    static_assert(std::is_same_v<void, decltype(invoke_variadic_union<void, type>(a, 0, fnAll))>);
-    static_assert(invoke_type_variadic_union<int, type>(a, 0, fnAll) == 2);
-
-    WHEN("v0 set")
-    {
-      auto const v0 = make_variadic_union<int, type>(42);
-      CHECK(invoke_variadic_union<int, type>(v0, 0, fn1) == 42);
-      CHECK(invoke_type_variadic_union<int, type>(v0, 0, fn2) == 84);
-      auto const before = total;
-      invoke_variadic_union<void, type>(v0, 0, fn1L);
-      CHECK(total == before + 42);
-      invoke_type_variadic_union<void, type>(v0, 0, fn2L);
-      CHECK(total == before + 42 + 84);
-    }
-
-    WHEN("v1 set")
-    {
-      auto const v1 = make_variadic_union<short, type>((short)26);
-      CHECK(invoke_variadic_union<short, type>(v1, 1, fn1) == 26);
-      CHECK(invoke_type_variadic_union<short, type>(v1, 1, fn2) == 52);
-      auto const before = total;
-      invoke_variadic_union<void, type>(v1, 1, fn1L);
-      CHECK(total == before + 26);
-      invoke_type_variadic_union<void, type>(v1, 1, fn2L);
-      CHECK(total == before + 26 + 52);
-    }
-
-    WHEN("v2 set")
-    {
-      auto const v2 = make_variadic_union<long, type>(12);
-      CHECK(invoke_variadic_union<long, type>(v2, 2, fn1) == 12);
-      CHECK(invoke_type_variadic_union<long, type>(v2, 2, fn2) == 24);
-      auto const before = total;
-      invoke_variadic_union<void, type>(v2, 2, fn1L);
-      CHECK(total == before + 12);
-      invoke_type_variadic_union<void, type>(v2, 2, fn2L);
-      CHECK(total == before + 12 + 24);
-    }
-  }
-
-  WHEN("size == 4")
-  {
-    using type = variadic_union<int, short, long, double>;
-
-    static_assert(std::is_same_v<void, decltype(invoke_variadic_union<void, type>(std::declval<type>(), 0, fn1L))>);
-    static_assert(
-        std::is_same_v<void, decltype(invoke_type_variadic_union<void, type>(std::declval<type>(), 0, fn2L))>);
-    static_assert(std::is_same_v<int, decltype(invoke_variadic_union<int, type>(std::declval<type>(), 0, fn1))>);
-    static_assert(std::is_same_v<long, decltype(invoke_variadic_union<long, type>(std::declval<type>(), 0, fn1))>);
-    static_assert(std::is_same_v<int, decltype(invoke_type_variadic_union<int, type>(std::declval<type>(), 0, fn2))>);
-    static_assert(std::is_same_v<long, decltype(invoke_type_variadic_union<long, type>(std::declval<type>(), 0, fn2))>);
-
-    constexpr type a = make_variadic_union<int, type>(7);
-    static_assert(std::is_same_v<void, decltype(invoke_variadic_union<void, type>(a, 0, fnAll))>);
-    static_assert(invoke_type_variadic_union<int, type>(a, 0, fnAll) == 2);
-
-    WHEN("v0 set")
-    {
-      auto const v0 = make_variadic_union<int, type>(42);
-      CHECK(invoke_variadic_union<int, type>(v0, 0, fn1) == 42);
-      CHECK(invoke_type_variadic_union<int, type>(v0, 0, fn2) == 84);
-      auto const before = total;
-      invoke_variadic_union<void, type>(v0, 0, fn1L);
-      CHECK(total == before + 42);
-      invoke_type_variadic_union<void, type>(v0, 0, fn2L);
-      CHECK(total == before + 42 + 84);
-    }
-
-    WHEN("v1 set")
-    {
-      auto const v1 = make_variadic_union<short, type>((short)26);
-      CHECK(invoke_variadic_union<short, type>(v1, 1, fn1) == 26);
-      CHECK(invoke_type_variadic_union<short, type>(v1, 1, fn2) == 52);
-      auto const before = total;
-      invoke_variadic_union<void, type>(v1, 1, fn1L);
-      CHECK(total == before + 26);
-      invoke_type_variadic_union<void, type>(v1, 1, fn2L);
-      CHECK(total == before + 26 + 52);
-    }
-
-    WHEN("v2 set")
-    {
-      auto const v2 = make_variadic_union<long, type>(12);
-      CHECK(invoke_variadic_union<long, type>(v2, 2, fn1) == 12);
-      CHECK(invoke_type_variadic_union<long, type>(v2, 2, fn2) == 24);
-      auto const before = total;
-      invoke_variadic_union<void, type>(v2, 2, fn1L);
-      CHECK(total == before + 12);
-      invoke_type_variadic_union<void, type>(v2, 2, fn2L);
-      CHECK(total == before + 12 + 24);
-    }
-
-    WHEN("v3 set")
-    {
-      auto const v3 = make_variadic_union<double, type>(7.5);
-      CHECK(invoke_variadic_union<int, type>(v3, 3, fn1) == 7);
-      CHECK(invoke_type_variadic_union<int, type>(v3, 3, fn2) == 15);
-      auto const before = total;
-      invoke_variadic_union<void, type>(v3, 3, fn1L);
-      CHECK(total == before + 7);
-      invoke_type_variadic_union<void, type>(v3, 3, fn2L);
-      CHECK(total == before + 7 + 15);
-    }
-  }
-
-  WHEN("size == 5")
-  {
-    using type = variadic_union<int, short, long, double, float>;
-
-    static_assert(std::is_same_v<void, decltype(invoke_variadic_union<void, type>(std::declval<type>(), 0, fn1L))>);
-    static_assert(
-        std::is_same_v<void, decltype(invoke_type_variadic_union<void, type>(std::declval<type>(), 0, fn2L))>);
-    static_assert(std::is_same_v<int, decltype(invoke_variadic_union<int, type>(std::declval<type>(), 0, fn1))>);
-    static_assert(std::is_same_v<long, decltype(invoke_variadic_union<long, type>(std::declval<type>(), 0, fn1))>);
-    static_assert(std::is_same_v<int, decltype(invoke_type_variadic_union<int, type>(std::declval<type>(), 0, fn2))>);
-    static_assert(std::is_same_v<long, decltype(invoke_type_variadic_union<long, type>(std::declval<type>(), 0, fn2))>);
-
-    constexpr type a = make_variadic_union<int, type>(7);
-    static_assert(std::is_same_v<void, decltype(invoke_variadic_union<void, type>(a, 0, fnAll))>);
-    static_assert(invoke_type_variadic_union<int, type>(a, 0, fnAll) == 2);
-
-    WHEN("v0 set")
-    {
-      auto const v0 = make_variadic_union<int, type>(42);
-      CHECK(invoke_variadic_union<int, type>(v0, 0, fn1) == 42);
-      CHECK(invoke_type_variadic_union<int, type>(v0, 0, fn2) == 84);
-      auto const before = total;
-      invoke_variadic_union<void, type>(v0, 0, fn1L);
-      CHECK(total == before + 42);
-      invoke_type_variadic_union<void, type>(v0, 0, fn2L);
-      CHECK(total == before + 42 + 84);
-    }
-
-    WHEN("v1 set")
-    {
-      auto const v1 = make_variadic_union<short, type>((short)26);
-      CHECK(invoke_variadic_union<short, type>(v1, 1, fn1) == 26);
-      CHECK(invoke_type_variadic_union<short, type>(v1, 1, fn2) == 52);
-      auto const before = total;
-      invoke_variadic_union<void, type>(v1, 1, fn1L);
-      CHECK(total == before + 26);
-      invoke_type_variadic_union<void, type>(v1, 1, fn2L);
-      CHECK(total == before + 26 + 52);
-    }
-
-    WHEN("v2 set")
-    {
-      auto const v2 = make_variadic_union<long, type>(12);
-      CHECK(invoke_variadic_union<long, type>(v2, 2, fn1) == 12);
-      CHECK(invoke_type_variadic_union<long, type>(v2, 2, fn2) == 24);
-      auto const before = total;
-      invoke_variadic_union<void, type>(v2, 2, fn1L);
-      CHECK(total == before + 12);
-      invoke_type_variadic_union<void, type>(v2, 2, fn2L);
-      CHECK(total == before + 12 + 24);
-    }
-
-    WHEN("v3 set")
-    {
-      auto const v3 = make_variadic_union<double, type>(7.5);
-      CHECK(invoke_variadic_union<int, type>(v3, 3, fn1) == 7);
-      CHECK(invoke_type_variadic_union<int, type>(v3, 3, fn2) == 15);
-      auto const before = total;
-      invoke_variadic_union<void, type>(v3, 3, fn1L);
-      CHECK(total == before + 7);
-      invoke_type_variadic_union<void, type>(v3, 3, fn2L);
-      CHECK(total == before + 7 + 15);
-    }
-
-    WHEN("more set")
-    {
-      auto const v4 = make_variadic_union<float, type>(1.5f);
-      CHECK(invoke_variadic_union<int, type>(v4, 4, fn1) == 1);
-      CHECK(invoke_type_variadic_union<int, type>(v4, 4, fn2) == 3);
-      auto const before = total;
-      invoke_variadic_union<void, type>(v4, 4, fn1L);
-      CHECK(total == before + 1);
-      invoke_type_variadic_union<void, type>(v4, 4, fn2L);
-      CHECK(total == before + 1 + 3);
-    }
-  }
+  CHECK(ptr_variadic_union<NonCopyable, T6>(a4)->v == 42);
 }

--- a/tests/fn/discard.cpp
+++ b/tests/fn/discard.cpp
@@ -190,6 +190,21 @@ TEST_CASE("discard", "[discard][optional]")
   }
 }
 
+TEST_CASE("discard noexcept", "[discard][noexcept]")
+{
+  using namespace fn;
+
+  // The one verb whose unconditional noexcept is ACCURATE, and asserted here as such rather than as a
+  // tripwire: discard's apply takes the operand by reference, invokes no callback and returns void,
+  // so there is nothing in it that can throw. Contrast every other verb (#285).
+  static_assert(noexcept(discard_t::apply{}(std::declval<fn::expected<int, Error> &>())));
+  static_assert(noexcept(discard_t::apply{}(std::declval<fn::expected<void, Error> &>())));
+  static_assert(noexcept(discard_t::apply{}(std::declval<fn::optional<int> &>())));
+  static_assert(std::is_same_v<void, decltype(discard_t::apply{}(std::declval<fn::optional<int> &>()))>);
+
+  SUCCEED();
+}
+
 TEST_CASE("constexpr discard expected", "[discard][constexpr][expected]")
 {
   using namespace fn;

--- a/tests/fn/discard.cpp
+++ b/tests/fn/discard.cpp
@@ -38,9 +38,9 @@ TEST_CASE("discard", "[discard][expected][expected_value]")
   static_assert(is::invocable_with_any());
   static_assert(is::not_invocable_with_any([] {})); // no arguments allowed
 
-  WHEN("operand is lvalue")
+  SECTION("lvalue")
   {
-    WHEN("operand is value")
+    SECTION("value")
     {
       operand_t a{std::in_place, 42};
       a | discard();
@@ -48,7 +48,7 @@ TEST_CASE("discard", "[discard][expected][expected_value]")
       REQUIRE(a.value() == 42);
     }
 
-    WHEN("operand is error")
+    SECTION("error")
     {
       operand_t a{::fn::unexpect, Error{"Not good"}};
       a | discard();
@@ -57,19 +57,38 @@ TEST_CASE("discard", "[discard][expected][expected_value]")
     }
   }
 
-  WHEN("operand is rvalue")
+  SECTION("rvalue")
   {
-    WHEN("operand is value")
+    SECTION("value")
     {
       operand_t{std::in_place, 42} | discard();
       SUCCEED();
     }
 
-    WHEN("operand is error")
+    SECTION("error")
     {
       operand_t{::fn::unexpect, Error{"Not good"}} | discard();
       SUCCEED();
     }
+  }
+
+  SECTION("constexpr")
+  {
+    enum class Error { ThresholdExceeded, SomethingElse };
+    using T = fn::expected<int, Error>;
+
+    constexpr auto a = T{42};
+    constexpr auto b = T{::fn::unexpect, Error::ThresholdExceeded};
+
+    constexpr auto test = [](T v) {
+      v | discard();
+      return true;
+    };
+
+    static_assert(test(a));
+    static_assert(test(b));
+
+    SUCCEED();
   }
 }
 
@@ -77,25 +96,24 @@ TEST_CASE("discard with pack", "[discard][expected][expected_value][pack]")
 {
   using namespace fn;
 
-  WHEN("operand is a pack")
+  using operand_t = fn::expected<fn::pack<int, double>, Error>;
+  using is = monadic_static_check<discard_t, operand_t>;
+  static_assert(is::invocable_with_any());
+
+  SECTION("value")
   {
-    using operand_t = fn::expected<fn::pack<int, double>, Error>;
     constexpr operand_t a{std::in_place, fn::pack{84, 0.5}};
-
-    using is = monadic_static_check<discard_t, operand_t>;
-    static_assert(is::invocable_with_any());
-
     a | discard();
 
     REQUIRE(a.has_value());
+  }
 
-    WHEN("operand is error")
-    {
-      operand_t b{::fn::unexpect, Error{"Pack error"}};
-      b | discard();
+  SECTION("error")
+  {
+    operand_t b{::fn::unexpect, Error{"Pack error"}};
+    b | discard();
 
-      REQUIRE(b.error().what == "Pack error");
-    }
+    REQUIRE(b.error().what == "Pack error");
   }
 }
 
@@ -109,9 +127,9 @@ TEST_CASE("discard", "[discard][expected][expected_void]")
   static_assert(is::invocable_with_any());
   static_assert(is::not_invocable_with_any([] {})); // no arguments allowed
 
-  WHEN("operand is lvalue")
+  SECTION("lvalue")
   {
-    WHEN("operand is value")
+    SECTION("value")
     {
       operand_t a{std::in_place};
       a | discard();
@@ -119,7 +137,7 @@ TEST_CASE("discard", "[discard][expected][expected_void]")
       REQUIRE(a.has_value());
     }
 
-    WHEN("operand is error")
+    SECTION("error")
     {
       operand_t a{::fn::unexpect, Error{"Not good"}};
       a | discard();
@@ -128,15 +146,15 @@ TEST_CASE("discard", "[discard][expected][expected_void]")
     }
   }
 
-  WHEN("operand is rvalue")
+  SECTION("rvalue")
   {
-    WHEN("operand is value")
+    SECTION("value")
     {
       operand_t{std::in_place} | discard();
       SUCCEED();
     }
 
-    WHEN("operand is error")
+    SECTION("error")
     {
       operand_t{::fn::unexpect, Error{"Not good"}} | discard();
       SUCCEED();
@@ -154,9 +172,9 @@ TEST_CASE("discard", "[discard][optional]")
   static_assert(is::invocable_with_any());
   static_assert(is::not_invocable_with_any([] {})); // no arguments allowed
 
-  WHEN("operand is lvalue")
+  SECTION("lvalue")
   {
-    WHEN("operand is value")
+    SECTION("value")
     {
       operand_t a{42};
       a | discard();
@@ -165,7 +183,7 @@ TEST_CASE("discard", "[discard][optional]")
       REQUIRE(a.value() == 42);
     }
 
-    WHEN("operand is nullopt")
+    SECTION("nullopt")
     {
       operand_t a{std::nullopt};
       a | discard();
@@ -174,19 +192,37 @@ TEST_CASE("discard", "[discard][optional]")
     }
   }
 
-  WHEN("operand is rvalue")
+  SECTION("rvalue")
   {
-    WHEN("operand is value")
+    SECTION("value")
     {
       operand_t{42} | discard();
       SUCCEED();
     }
 
-    WHEN("operand is nullopt")
+    SECTION("nullopt")
     {
       operand_t{std::nullopt} | discard();
       SUCCEED();
     }
+  }
+
+  SECTION("constexpr")
+  {
+    using T = fn::optional<int>;
+
+    constexpr auto a = T{42};
+    constexpr auto b = T{std::nullopt};
+
+    constexpr auto test = [](T v) {
+      v | discard();
+      return true;
+    };
+
+    static_assert(test(a));
+    static_assert(test(b));
+
+    SUCCEED();
   }
 }
 
@@ -201,46 +237,6 @@ TEST_CASE("discard noexcept", "[discard][noexcept]")
   static_assert(noexcept(discard_t::apply{}(std::declval<fn::expected<void, Error> &>())));
   static_assert(noexcept(discard_t::apply{}(std::declval<fn::optional<int> &>())));
   static_assert(std::is_same_v<void, decltype(discard_t::apply{}(std::declval<fn::optional<int> &>()))>);
-
-  SUCCEED();
-}
-
-TEST_CASE("constexpr discard expected", "[discard][constexpr][expected]")
-{
-  using namespace fn;
-
-  enum class Error { ThresholdExceeded, SomethingElse };
-  using T = fn::expected<int, Error>;
-
-  constexpr auto a = T{42};
-  constexpr auto b = T{::fn::unexpect, Error::ThresholdExceeded};
-
-  constexpr auto test = [](T v) {
-    v | discard();
-    return true;
-  };
-
-  static_assert(test(a));
-  static_assert(test(b));
-
-  SUCCEED();
-}
-
-TEST_CASE("constexpr discard optional", "[discard][constexpr][optional]")
-{
-  using namespace fn;
-  using T = fn::optional<int>;
-
-  constexpr auto a = T{42};
-  constexpr auto b = T{std::nullopt};
-
-  constexpr auto test = [](T v) {
-    v | discard();
-    return true;
-  };
-
-  static_assert(test(a));
-  static_assert(test(b));
 
   SUCCEED();
 }

--- a/tests/fn/expected.cpp
+++ b/tests/fn/expected.cpp
@@ -945,7 +945,7 @@ TEST_CASE("expected pack support", "[expected][pack][and_then][transform][operat
     // noexcept: all eight operator& overloads are declared unconditionally noexcept
     // (expected.hpp:1032-1183) though joining copies/moves the operands' values into the
     // result -- for a throwing-copy value type this is a promise the join cannot keep. GAP:
-    // asserts current behaviour; flip to `not noexcept` when fixed.
+    // asserts current behaviour; flip to `not noexcept` when fixed (issue #279).
     struct throwing_copy {
       // defined, not just declared: the instantiated join references it (-Wundefined-internal)
       throwing_copy(throwing_copy const &) noexcept(false) {}
@@ -2463,7 +2463,7 @@ TEST_CASE("expected sum support or_else", "[expected][sum][or_else]")
   // constraints (extension, :167-168): invocability over the error sum's alternatives, tracking
   // their value category, AND copyability of the untouched value -- a move-only value type
   // cleanly drops every overload whose self would copy it (contrast transform_error, which
-  // lacks this conjunct; see "expected sum support transform_error")
+  // lacks this conjunct -- issue #278; see "expected sum support transform_error")
   constexpr auto can_or_else_lval = [](auto &&f) { return requires { std::declval<S &>().or_else(f); }; };
   constexpr auto can_or_else_rval = [](auto &&f) { return requires { std::declval<S &&>().or_else(f); }; };
   static_assert(can_or_else_lval(nothrow_lval));
@@ -2688,6 +2688,7 @@ TEST_CASE("expected sum support transform", "[expected][sum][transform]")
   // deduced-return body (:241) during candidate-signature formation, outside the immediate
   // context -- a bad callback is a hard error instead of SFINAE-dropping (no negative probe
   // here), and the visitors above take const& to serve every candidate, as in fn/optional.cpp
+  // (issue #277)
   constexpr auto can_transform = [](auto &&f) { return requires { std::declval<S &>().transform(f); }; };
   static_assert(can_transform(nothrow_visitor));
   // the error-copy conjunct (:239) IS constrained: a move-only error cleanly drops the
@@ -2804,7 +2805,8 @@ TEST_CASE("expected sum support transform_error", "[expected][sum][transform_err
   // spells it (pfn/detail/expected_base.hpp:904). With a move-only value type NO transform_error
   // call compiles from any category -- const& binds rvalues, so even an rvalue call forms the
   // const& candidate whose body copies the value -- where or_else's conjunct (:168) cleanly
-  // drops those candidates (see "expected sum support or_else"). Positive probe only.
+  // drops those candidates (see "expected sum support or_else"). Positive probe only
+  // (issues #277, #278).
   constexpr auto can_transform_error = [](auto &&f) { return requires { std::declval<S &>().transform_error(f); }; };
   static_assert(can_transform_error(nothrow_visitor));
 
@@ -3082,7 +3084,7 @@ TEST_CASE("expected pack support transform_error", "[expected][transform_error][
 
   // constraints (:283-284): pack-apply invocability -- but NOT the untouched value's copy
   // (:290), which pfn constrains (pfn/detail/expected_base.hpp:904); see the GAP note in
-  // "expected sum support transform_error"
+  // "expected sum support transform_error" (issue #278)
   constexpr auto can_te_lval = [](auto &&f) { return requires { std::declval<S &>().transform_error(f); }; };
   constexpr auto can_te_rval = [](auto &&f) { return requires { std::declval<S &&>().transform_error(f); }; };
   static_assert(can_te_lval(nothrow_two));

--- a/tests/fn/expected.cpp
+++ b/tests/fn/expected.cpp
@@ -25,14 +25,14 @@ struct Xint {
 
 TEST_CASE("graded monad", "[expected][sum][graded][and_then][or_else][sum_value][sum_error]")
 {
-  WHEN("unit")
+  SECTION("unit")
   {
     constexpr fn::expected<void, fn::sum<>> unit{};
     static_assert(unit.has_value());
 
-    WHEN("constexpr")
+    SECTION("constexpr")
     {
-      WHEN("and_then to value/sum<>")
+      SECTION("and_then to value/sum<>")
       {
         constexpr auto fn = []() -> fn::expected<int, fn::sum<>> { return {7}; };
         constexpr auto a = unit.and_then(fn);
@@ -40,7 +40,7 @@ TEST_CASE("graded monad", "[expected][sum][graded][and_then][or_else][sum_value]
         static_assert(a.value() == 7);
       }
 
-      WHEN("and_then to value")
+      SECTION("and_then to value")
       {
         constexpr auto fn = []() -> fn::expected<int, Error> { return {12}; };
         constexpr auto a = unit.and_then(fn);
@@ -48,7 +48,7 @@ TEST_CASE("graded monad", "[expected][sum][graded][and_then][or_else][sum_value]
         static_assert(a.value() == 12);
       }
 
-      WHEN("and_then to error")
+      SECTION("and_then to error")
       {
         constexpr auto fn = []() -> fn::expected<int, Error> { return ::fn::unexpected<Error>(FileNotFound); };
         constexpr auto a = unit.and_then(fn);
@@ -56,7 +56,7 @@ TEST_CASE("graded monad", "[expected][sum][graded][and_then][or_else][sum_value]
         static_assert(a.error() == fn::sum{FileNotFound});
       }
 
-      WHEN("transform to int")
+      SECTION("transform to int")
       {
         constexpr auto fn = []() -> int { return 144'000; };
         constexpr auto a = unit.transform(fn);
@@ -65,9 +65,9 @@ TEST_CASE("graded monad", "[expected][sum][graded][and_then][or_else][sum_value]
       }
     }
 
-    WHEN("runtime")
+    SECTION("runtime")
     {
-      WHEN("and_then to value/sum<>")
+      SECTION("and_then to value/sum<>")
       {
         constexpr auto fn = []() -> fn::expected<int, fn::sum<>> { return {7}; };
         auto a = unit.and_then(fn);
@@ -75,7 +75,7 @@ TEST_CASE("graded monad", "[expected][sum][graded][and_then][or_else][sum_value]
         CHECK(a.value() == 7);
       }
 
-      WHEN("and_then to value")
+      SECTION("and_then to value")
       {
         constexpr auto fn = []() -> fn::expected<int, Error> { return {12}; };
         auto a = unit.and_then(fn);
@@ -83,7 +83,7 @@ TEST_CASE("graded monad", "[expected][sum][graded][and_then][or_else][sum_value]
         CHECK(a.value() == 12);
       }
 
-      WHEN("and_then to error")
+      SECTION("and_then to error")
       {
         constexpr auto fn = []() -> fn::expected<int, Error> { return ::fn::unexpected<Error>(FileNotFound); };
         auto a = unit.and_then(fn);
@@ -91,7 +91,7 @@ TEST_CASE("graded monad", "[expected][sum][graded][and_then][or_else][sum_value]
         CHECK(a.error() == fn::sum{FileNotFound});
       }
 
-      WHEN("transform to int")
+      SECTION("transform to int")
       {
         constexpr auto fn = []() -> int { return 144'000; };
         auto a = unit.transform(fn);
@@ -99,7 +99,7 @@ TEST_CASE("graded monad", "[expected][sum][graded][and_then][or_else][sum_value]
         CHECK(a.value() == 144'000);
       }
 
-      WHEN("transform direct-initializes its result")
+      SECTION("transform direct-initializes its result")
       {
         // the value is direct-non-list-initialized from the callable's result: no extra
         // move, and an immovable type works
@@ -122,7 +122,7 @@ TEST_CASE("graded monad", "[expected][sum][graded][and_then][or_else][sum_value]
     }
   }
 
-  WHEN("sum_error from sum")
+  SECTION("sum_error from sum")
   {
     using T = fn::expected<int, fn::sum<Error>>;
     T s{12};
@@ -137,14 +137,14 @@ TEST_CASE("graded monad", "[expected][sum][graded][and_then][or_else][sum_value]
     static_assert(not noexcept(std::as_const(s).sum_error()));
     static_assert(not noexcept(std::move(std::as_const(s)).sum_error()));
     static_assert(not noexcept(std::move(s).sum_error()));
-    WHEN("value")
+    SECTION("value")
     {
       CHECK(s.sum_error().value() == 12);
       CHECK(std::as_const(s).sum_error().value() == 12);
       CHECK(std::move(std::as_const(s)).sum_error().value() == 12);
       CHECK(std::move(s).sum_error().value() == 12);
     }
-    WHEN("error")
+    SECTION("error")
     {
       T s{::fn::unexpect, Unknown};
       CHECK(s.sum_error().error() == fn::sum{Unknown});
@@ -156,7 +156,7 @@ TEST_CASE("graded monad", "[expected][sum][graded][and_then][or_else][sum_value]
     static_assert(std::is_same_v<decltype(fn::sum_error(s)), T &>);
   }
 
-  WHEN("sum_error from non-sum")
+  SECTION("sum_error from non-sum")
   {
     using T = fn::expected<int, Error>;
     T s{12};
@@ -170,14 +170,14 @@ TEST_CASE("graded monad", "[expected][sum][graded][and_then][or_else][sum_value]
     static_assert(not noexcept(std::as_const(s).sum_error()));
     static_assert(not noexcept(std::move(std::as_const(s)).sum_error()));
     static_assert(not noexcept(std::move(s).sum_error()));
-    WHEN("value")
+    SECTION("value")
     {
       CHECK(s.sum_error().value() == 12);
       CHECK(std::as_const(s).sum_error().value() == 12);
       CHECK(std::move(std::as_const(s)).sum_error().value() == 12);
       CHECK(std::move(s).sum_error().value() == 12);
     }
-    WHEN("error")
+    SECTION("error")
     {
       T s{::fn::unexpect, Unknown};
       CHECK(s.sum_error().error() == fn::sum{Unknown});
@@ -189,7 +189,7 @@ TEST_CASE("graded monad", "[expected][sum][graded][and_then][or_else][sum_value]
     static_assert(std::is_same_v<decltype(fn::sum_error(s)), fn::expected<int, fn::sum<Error>>>);
   }
 
-  WHEN("sum_error from non-sum, void value")
+  SECTION("sum_error from non-sum, void value")
   {
     using T = fn::expected<void, Error>;
     T s{};
@@ -204,14 +204,14 @@ TEST_CASE("graded monad", "[expected][sum][graded][and_then][or_else][sum_value]
     static_assert(not noexcept(std::as_const(s).sum_error()));
     static_assert(not noexcept(std::move(std::as_const(s)).sum_error()));
     static_assert(not noexcept(std::move(s).sum_error()));
-    WHEN("value")
+    SECTION("value")
     {
       CHECK(s.sum_error().has_value());
       CHECK(std::as_const(s).sum_error().has_value());
       CHECK(std::move(std::as_const(s)).sum_error().has_value());
       CHECK(std::move(s).sum_error().has_value());
     }
-    WHEN("error")
+    SECTION("error")
     {
       T s{::fn::unexpect, Unknown};
       CHECK(s.sum_error().error() == fn::sum{Unknown});
@@ -223,7 +223,7 @@ TEST_CASE("graded monad", "[expected][sum][graded][and_then][or_else][sum_value]
     static_assert(std::is_same_v<decltype(fn::sum_error(s)), fn::expected<void, fn::sum<Error>>>);
   }
 
-  WHEN("sum_error from sum, void value")
+  SECTION("sum_error from sum, void value")
   {
     using T = fn::expected<void, fn::sum<Error>>;
     T s{};
@@ -237,14 +237,14 @@ TEST_CASE("graded monad", "[expected][sum][graded][and_then][or_else][sum_value]
     static_assert(not noexcept(std::as_const(s).sum_error()));
     static_assert(not noexcept(std::move(std::as_const(s)).sum_error()));
     static_assert(not noexcept(std::move(s).sum_error()));
-    WHEN("value")
+    SECTION("value")
     {
       CHECK(s.sum_error().has_value());
       CHECK(std::as_const(s).sum_error().has_value());
       CHECK(std::move(std::as_const(s)).sum_error().has_value());
       CHECK(std::move(s).sum_error().has_value());
     }
-    WHEN("error")
+    SECTION("error")
     {
       T s{::fn::unexpect, Unknown};
       CHECK(s.sum_error().error() == fn::sum{Unknown});
@@ -256,7 +256,7 @@ TEST_CASE("graded monad", "[expected][sum][graded][and_then][or_else][sum_value]
     static_assert(std::is_same_v<decltype(fn::sum_error(s)), T &>);
   }
 
-  WHEN("sum_value from sum")
+  SECTION("sum_value from sum")
   {
     using T = fn::expected<fn::sum<int>, Error>;
     T s{12};
@@ -270,14 +270,14 @@ TEST_CASE("graded monad", "[expected][sum][graded][and_then][or_else][sum_value]
     static_assert(not noexcept(std::as_const(s).sum_value()));
     static_assert(not noexcept(std::move(std::as_const(s)).sum_value()));
     static_assert(not noexcept(std::move(s).sum_value()));
-    WHEN("value")
+    SECTION("value")
     {
       CHECK(s.sum_value().value() == fn::sum{12});
       CHECK(std::as_const(s).sum_value().value() == fn::sum{12});
       CHECK(std::move(std::as_const(s)).sum_value().value() == fn::sum{12});
       CHECK(std::move(s).sum_value().value() == fn::sum{12});
     }
-    WHEN("error")
+    SECTION("error")
     {
       T s{::fn::unexpect, Unknown};
       CHECK(s.sum_value().error() == Unknown);
@@ -289,7 +289,7 @@ TEST_CASE("graded monad", "[expected][sum][graded][and_then][or_else][sum_value]
     static_assert(std::is_same_v<decltype(fn::sum_value(s)), T &>);
   }
 
-  WHEN("sum_value from non-sum")
+  SECTION("sum_value from non-sum")
   {
     using T = fn::expected<int, Error>;
     T s{12};
@@ -303,14 +303,14 @@ TEST_CASE("graded monad", "[expected][sum][graded][and_then][or_else][sum_value]
     static_assert(not noexcept(std::as_const(s).sum_value()));
     static_assert(not noexcept(std::move(std::as_const(s)).sum_value()));
     static_assert(not noexcept(std::move(s).sum_value()));
-    WHEN("value")
+    SECTION("value")
     {
       CHECK(s.sum_value().value() == fn::sum{12});
       CHECK(std::as_const(s).sum_value().value() == fn::sum{12});
       CHECK(std::move(std::as_const(s)).sum_value().value() == fn::sum{12});
       CHECK(std::move(s).sum_value().value() == fn::sum{12});
     }
-    WHEN("error")
+    SECTION("error")
     {
       T s{::fn::unexpect, Unknown};
       CHECK(s.sum_value().error() == Unknown);
@@ -322,7 +322,7 @@ TEST_CASE("graded monad", "[expected][sum][graded][and_then][or_else][sum_value]
     static_assert(std::is_same_v<decltype(fn::sum_value(s)), fn::expected<fn::sum<int>, Error>>);
   }
 
-  WHEN("sum_value absent for void value")
+  SECTION("sum_value absent for void value")
   {
     // by design: a void value cannot be sum-wrapped -- the void specialization has no
     // sum_value member and the free fn::sum_value is constrained some_expected_non_void
@@ -336,9 +336,9 @@ TEST_CASE("graded monad", "[expected][sum][graded][and_then][or_else][sum_value]
     SUCCEED();
   }
 
-  WHEN("and_then")
+  SECTION("and_then")
   {
-    WHEN("value to value")
+    SECTION("value to value")
     {
       fn::expected<int, fn::sum<Error>> s{12};
 
@@ -359,7 +359,7 @@ TEST_CASE("graded monad", "[expected][sum][graded][and_then][or_else][sum_value]
       constexpr auto fn8 = [](int) -> fn::expected<Xint, fn::sum_for<Error, bool, int>> { throw 0; };
       static_assert(std::is_same_v<decltype(s.and_then(fn8)), fn::expected<Xint, fn::sum_for<Error, bool, int>>>);
 
-      WHEN("value to value")
+      SECTION("value to value")
       {
         constexpr auto fn = [](int i) -> fn::expected<int, bool> { return {i + 12}; };
         static_assert(std::is_same_v<decltype(s.and_then(fn)), fn::expected<int, fn::sum_for<Error, bool>>>);
@@ -369,7 +369,7 @@ TEST_CASE("graded monad", "[expected][sum][graded][and_then][or_else][sum_value]
         CHECK(std::move(s).and_then(fn).value() == 24);
       }
 
-      WHEN("value to error")
+      SECTION("value to error")
       {
         constexpr auto fn = [](int i) -> fn::expected<int, bool> { return ::fn::unexpected<bool>(i >= 1); };
         static_assert(std::is_same_v<decltype(s.and_then(fn)), fn::expected<int, fn::sum_for<Error, bool>>>);
@@ -379,7 +379,7 @@ TEST_CASE("graded monad", "[expected][sum][graded][and_then][or_else][sum_value]
         CHECK(std::move(s).and_then(fn).error() == fn::sum{true});
       }
 
-      WHEN("error")
+      SECTION("error")
       {
         fn::expected<int, fn::sum<Error>> s{::fn::unexpect, fn::sum{FileNotFound}};
         constexpr auto fn = [](int) -> fn::expected<int, bool> { throw 0; };
@@ -393,7 +393,7 @@ TEST_CASE("graded monad", "[expected][sum][graded][and_then][or_else][sum_value]
       }
     }
 
-    WHEN("void to value")
+    SECTION("void to value")
     {
       fn::expected<void, fn::sum<Error>> s{};
 
@@ -412,7 +412,7 @@ TEST_CASE("graded monad", "[expected][sum][graded][and_then][or_else][sum_value]
       constexpr auto fn7 = []() -> fn::expected<int, fn::sum_for<Error, bool, int>> { throw 0; };
       static_assert(std::is_same_v<decltype(s.and_then(fn7)), fn::expected<int, fn::sum_for<Error, bool, int>>>);
 
-      WHEN("value to value")
+      SECTION("value to value")
       {
         constexpr auto fn = []() -> fn::expected<int, bool> { return {12}; };
         static_assert(std::is_same_v<decltype(s.and_then(fn)), fn::expected<int, fn::sum_for<Error, bool>>>);
@@ -422,7 +422,7 @@ TEST_CASE("graded monad", "[expected][sum][graded][and_then][or_else][sum_value]
         CHECK(std::move(s).and_then(fn).value() == 12);
       }
 
-      WHEN("value to error")
+      SECTION("value to error")
       {
         constexpr auto fn = []() -> fn::expected<int, bool> { return ::fn::unexpected<bool>(true); };
         static_assert(std::is_same_v<decltype(s.and_then(fn)), fn::expected<int, fn::sum_for<Error, bool>>>);
@@ -432,7 +432,7 @@ TEST_CASE("graded monad", "[expected][sum][graded][and_then][or_else][sum_value]
         CHECK(std::move(s).and_then(fn).error() == fn::sum{true});
       }
 
-      WHEN("error")
+      SECTION("error")
       {
         fn::expected<void, fn::sum<Error>> s{::fn::unexpect, fn::sum{FileNotFound}};
         constexpr auto fn = []() -> fn::expected<int, bool> { throw 0; };
@@ -446,7 +446,7 @@ TEST_CASE("graded monad", "[expected][sum][graded][and_then][or_else][sum_value]
       }
     }
 
-    WHEN("value to void")
+    SECTION("value to void")
     {
       fn::expected<int, fn::sum<Error>> s{12};
 
@@ -465,7 +465,7 @@ TEST_CASE("graded monad", "[expected][sum][graded][and_then][or_else][sum_value]
       constexpr auto fn7 = [](int) -> fn::expected<void, fn::sum_for<Error, bool, int>> { throw 0; };
       static_assert(std::is_same_v<decltype(s.and_then(fn7)), fn::expected<void, fn::sum_for<Error, bool, int>>>);
 
-      WHEN("value to value")
+      SECTION("value to value")
       {
         constexpr auto fn = [](int) -> fn::expected<void, bool> { return {}; };
         static_assert(std::is_same_v<decltype(s.and_then(fn)), fn::expected<void, fn::sum_for<Error, bool>>>);
@@ -475,7 +475,7 @@ TEST_CASE("graded monad", "[expected][sum][graded][and_then][or_else][sum_value]
         CHECK(std::move(s).and_then(fn).has_value());
       }
 
-      WHEN("value to error")
+      SECTION("value to error")
       {
         constexpr auto fn = [](int i) -> fn::expected<void, bool> { return ::fn::unexpected<bool>(i >= 1); };
         static_assert(std::is_same_v<decltype(s.and_then(fn)), fn::expected<void, fn::sum_for<Error, bool>>>);
@@ -485,7 +485,7 @@ TEST_CASE("graded monad", "[expected][sum][graded][and_then][or_else][sum_value]
         CHECK(std::move(s).and_then(fn).error() == fn::sum{true});
       }
 
-      WHEN("error")
+      SECTION("error")
       {
         fn::expected<int, fn::sum<Error>> s{::fn::unexpect, fn::sum{FileNotFound}};
         constexpr auto fn = [](int) -> fn::expected<void, bool> { throw 0; };
@@ -499,7 +499,7 @@ TEST_CASE("graded monad", "[expected][sum][graded][and_then][or_else][sum_value]
       }
     }
 
-    WHEN("void to void")
+    SECTION("void to void")
     {
       fn::expected<void, fn::sum<Error>> s{};
 
@@ -518,7 +518,7 @@ TEST_CASE("graded monad", "[expected][sum][graded][and_then][or_else][sum_value]
       constexpr auto fn7 = []() -> fn::expected<void, fn::sum_for<Error, bool, int>> { throw 0; };
       static_assert(std::is_same_v<decltype(s.and_then(fn7)), fn::expected<void, fn::sum_for<Error, bool, int>>>);
 
-      WHEN("value to value")
+      SECTION("value to value")
       {
         constexpr auto fn = []() -> fn::expected<void, bool> { return {}; };
         static_assert(std::is_same_v<decltype(s.and_then(fn)), fn::expected<void, fn::sum_for<Error, bool>>>);
@@ -528,7 +528,7 @@ TEST_CASE("graded monad", "[expected][sum][graded][and_then][or_else][sum_value]
         CHECK(std::move(s).and_then(fn).has_value());
       }
 
-      WHEN("value to error")
+      SECTION("value to error")
       {
         constexpr auto fn = []() -> fn::expected<void, bool> { return ::fn::unexpected<bool>(true); };
         static_assert(std::is_same_v<decltype(s.and_then(fn)), fn::expected<void, fn::sum_for<Error, bool>>>);
@@ -538,7 +538,7 @@ TEST_CASE("graded monad", "[expected][sum][graded][and_then][or_else][sum_value]
         CHECK(std::move(s).and_then(fn).error() == fn::sum{true});
       }
 
-      WHEN("error")
+      SECTION("error")
       {
         fn::expected<void, fn::sum<Error>> s{::fn::unexpect, fn::sum{FileNotFound}};
         constexpr auto fn = []() -> fn::expected<void, bool> { throw 0; };
@@ -553,7 +553,7 @@ TEST_CASE("graded monad", "[expected][sum][graded][and_then][or_else][sum_value]
     }
   }
 
-  WHEN("or_else")
+  SECTION("or_else")
   {
     fn::expected<fn::sum<int>, Error> s{::fn::unexpect, FileNotFound};
 
@@ -574,7 +574,7 @@ TEST_CASE("graded monad", "[expected][sum][graded][and_then][or_else][sum_value]
     constexpr auto fn8 = [](int) -> fn::expected<fn::sum_for<Xint, int, long>, std::string> { throw 0; };
     static_assert(std::is_same_v<decltype(s.or_else(fn8)), fn::expected<fn::sum_for<Xint, int, long>, std::string>>);
 
-    WHEN("error to value")
+    SECTION("error to value")
     {
       constexpr auto fn = [](Error) -> fn::expected<Xint, std::string> { return {Xint{12}}; };
       static_assert(std::is_same_v<decltype(s.or_else(fn)), fn::expected<fn::sum_for<Xint, int>, std::string>>);
@@ -584,7 +584,7 @@ TEST_CASE("graded monad", "[expected][sum][graded][and_then][or_else][sum_value]
       CHECK(std::move(s).or_else(fn).value() == fn::sum{Xint{12}});
     }
 
-    WHEN("error to error")
+    SECTION("error to error")
     {
       constexpr auto fn = [](Error) -> fn::expected<Xint, std::string> { return ::fn::unexpected<std::string>("Boo"); };
       static_assert(std::is_same_v<decltype(s.or_else(fn)), fn::expected<fn::sum_for<Xint, int>, std::string>>);
@@ -594,7 +594,7 @@ TEST_CASE("graded monad", "[expected][sum][graded][and_then][or_else][sum_value]
       CHECK(std::move(s).or_else(fn).error() == "Boo");
     }
 
-    WHEN("value")
+    SECTION("value")
     {
       fn::expected<fn::sum<int>, Error> s{fn::sum{12}};
       constexpr auto fn = [](int) -> fn::expected<Xint, std::string> { throw 0; };
@@ -605,7 +605,7 @@ TEST_CASE("graded monad", "[expected][sum][graded][and_then][or_else][sum_value]
       CHECK(std::move(s).or_else(fn).value() == fn::sum{12});
     }
 
-    WHEN("engaged void source, immovable error type in the result")
+    SECTION("engaged void source, immovable error type in the result")
     {
       // the value-state path must compile even though the result cannot be moved (the
       // clang<=18 miscompile workaround must not force a move)
@@ -627,9 +627,9 @@ TEST_CASE("graded monad constexpr and runtime", "[constexpr][and_then][or_else][
   enum class Error : int { Unknown, InvalidValue };
   using T = fn::expected<int, fn::sum<Error>>;
 
-  WHEN("and_then constexpr")
+  SECTION("and_then constexpr")
   {
-    WHEN("same error type")
+    SECTION("same error type")
     {
       constexpr auto fn1 = [](int i) -> fn::expected<int, int> {
         if (i < 2)
@@ -650,7 +650,7 @@ TEST_CASE("graded monad constexpr and runtime", "[constexpr][and_then][or_else][
       SUCCEED();
     }
 
-    WHEN("accummulate errors")
+    SECTION("accummulate errors")
     {
       constexpr auto fn2 = [](int i) -> fn::expected<bool, Error> {
         if (i < 0 || i > 1)
@@ -679,9 +679,9 @@ TEST_CASE("graded monad constexpr and runtime", "[constexpr][and_then][or_else][
     }
   }
 
-  WHEN("and_then runtime")
+  SECTION("and_then runtime")
   {
-    WHEN("same error type")
+    SECTION("same error type")
     {
       constexpr auto fn1 = [](int i) -> fn::expected<int, int> {
         if (i < 2)
@@ -700,7 +700,7 @@ TEST_CASE("graded monad constexpr and runtime", "[constexpr][and_then][or_else][
       CHECK(r4.error() == fn::sum{2});
     }
 
-    WHEN("accummulate errors")
+    SECTION("accummulate errors")
     {
       constexpr auto fn2 = [](int i) -> fn::expected<bool, Error> {
         if (i < 0 || i > 1)
@@ -723,7 +723,7 @@ TEST_CASE("graded monad constexpr and runtime", "[constexpr][and_then][or_else][
     }
   }
 
-  WHEN("or_else constexpr")
+  SECTION("or_else constexpr")
   {
     using T = fn::expected<fn::sum<int>, Error>;
 
@@ -744,7 +744,7 @@ TEST_CASE("graded monad constexpr and runtime", "[constexpr][and_then][or_else][
     SUCCEED();
   }
 
-  WHEN("or_else runtime")
+  SECTION("or_else runtime")
   {
     using T = fn::expected<fn::sum<int>, Error>;
 
@@ -766,7 +766,7 @@ TEST_CASE("graded monad constexpr and runtime", "[constexpr][and_then][or_else][
 
 TEST_CASE("expected pack support", "[expected][pack][and_then][transform][operator_and][graded][sum]")
 {
-  WHEN("and_then")
+  SECTION("and_then")
   {
     using S = fn::expected<fn::pack<int, std::string_view>, Error>;
 
@@ -787,7 +787,7 @@ TEST_CASE("expected pack support", "[expected][pack][and_then][transform][operat
     static_assert(not can_and_then_lval([](int &) -> fn::expected<bool, Error> { throw 0; })); // wrong arity
     static_assert(not can_and_then_lval(42));
 
-    WHEN("value")
+    SECTION("value")
     {
       fn::expected<fn::pack<int, std::string_view>, Error> s{
           fn::pack<int>{12}.append(std::in_place_type<std::string_view>, "bar")};
@@ -821,7 +821,7 @@ TEST_CASE("expected pack support", "[expected][pack][and_then][transform][operat
                 .value());
     }
 
-    WHEN("error")
+    SECTION("error")
     {
       fn::expected<fn::pack<int, std::string_view>, Error> s{::fn::unexpect, FileNotFound};
       CHECK(s.and_then( //
@@ -846,7 +846,7 @@ TEST_CASE("expected pack support", "[expected][pack][and_then][transform][operat
     }
   }
 
-  WHEN("transform")
+  SECTION("transform")
   {
     using S = fn::expected<fn::pack<int, std::string_view>, Error>;
 
@@ -863,7 +863,7 @@ TEST_CASE("expected pack support", "[expected][pack][and_then][transform][operat
     static_assert(not can_transform([](int &) -> bool { throw 0; })); // wrong arity
     static_assert(not can_transform(42));
 
-    WHEN("value")
+    SECTION("value")
     {
       fn::expected<fn::pack<int, std::string_view>, Error> s{
           fn::pack<int>{12}.append(std::in_place_type<std::string_view>, "bar")};
@@ -897,7 +897,7 @@ TEST_CASE("expected pack support", "[expected][pack][and_then][transform][operat
                 .value());
     }
 
-    WHEN("void result")
+    SECTION("void result")
     {
       fn::expected<fn::pack<int, std::string_view>, Error> s{
           fn::pack<int>{12}.append(std::in_place_type<std::string_view>, "bar")};
@@ -927,7 +927,7 @@ TEST_CASE("expected pack support", "[expected][pack][and_then][transform][operat
                 .has_value());
     }
 
-    WHEN("error")
+    SECTION("error")
     {
       fn::expected<fn::pack<int, std::string_view>, Error> s{::fn::unexpect, FileNotFound};
       CHECK(s.transform([](auto...) -> bool { throw 0; }).error() == FileNotFound);
@@ -940,7 +940,7 @@ TEST_CASE("expected pack support", "[expected][pack][and_then][transform][operat
     }
   }
 
-  WHEN("operator &")
+  SECTION("operator &")
   {
     // noexcept: all eight operator& overloads are declared unconditionally noexcept
     // (expected.hpp:1032-1183) though joining copies/moves the operands' values into the
@@ -961,9 +961,9 @@ TEST_CASE("expected pack support", "[expected][pack][and_then][transform][operat
     enum class other_error {};
     static_assert(not can_amp(fn::expected<int, other_error>{1})); // mismatched non-graded error
 
-    WHEN("same error type")
+    SECTION("same error type")
     {
-      WHEN("value & void yield value")
+      SECTION("value & void yield value")
       {
         static_assert(
             std::same_as<decltype(std::declval<fn::expected<int, Error>>() & std::declval<fn::expected<void, Error>>()),
@@ -987,7 +987,7 @@ TEST_CASE("expected pack support", "[expected][pack][and_then][transform][operat
               == FileNotFound);
       }
 
-      WHEN("void & value yield value")
+      SECTION("void & value yield value")
       {
         static_assert(
             std::same_as<decltype(std::declval<fn::expected<void, Error>>() & std::declval<fn::expected<int, Error>>()),
@@ -1011,7 +1011,7 @@ TEST_CASE("expected pack support", "[expected][pack][and_then][transform][operat
               == FileNotFound);
       }
 
-      WHEN("void & void yield void")
+      SECTION("void & void yield void")
       {
         static_assert(std::same_as<decltype(std::declval<fn::expected<void, Error>>()
                                             & std::declval<fn::expected<void, Error>>()),
@@ -1034,7 +1034,7 @@ TEST_CASE("expected pack support", "[expected][pack][and_then][transform][operat
               == FileNotFound);
       }
 
-      WHEN("value & value yield pack")
+      SECTION("value & value yield pack")
       {
         static_assert(std::same_as<decltype(std::declval<fn::expected<int, Error>>()
                                             & std::declval<fn::expected<double, Error>>()),
@@ -1058,7 +1058,7 @@ TEST_CASE("expected pack support", "[expected][pack][and_then][transform][operat
               == FileNotFound);
       }
 
-      WHEN("value & pack yield pack")
+      SECTION("value & pack yield pack")
       {
         static_assert(std::same_as<decltype(std::declval<fn::expected<int, Error>>()
                                             & std::declval<fn::expected<fn::pack<bool, int>, Error>>()),
@@ -1082,7 +1082,7 @@ TEST_CASE("expected pack support", "[expected][pack][and_then][transform][operat
               == FileNotFound);
       }
 
-      WHEN("pack & value yield pack")
+      SECTION("pack & value yield pack")
       {
         static_assert(std::same_as<decltype(std::declval<fn::expected<fn::pack<double, bool>, Error>>()
                                             & std::declval<fn::expected<int, Error>>()),
@@ -1106,7 +1106,7 @@ TEST_CASE("expected pack support", "[expected][pack][and_then][transform][operat
               == FileNotFound);
       }
 
-      WHEN("pack & pack yield pack")
+      SECTION("pack & pack yield pack")
       {
         static_assert(std::same_as<decltype(std::declval<fn::expected<fn::pack<double, bool>, Error>>()
                                             & std::declval<fn::expected<fn::pack<bool, int>, Error>>()),
@@ -1132,7 +1132,7 @@ TEST_CASE("expected pack support", "[expected][pack][and_then][transform][operat
               == FileNotFound);
       }
 
-      WHEN("pack & void yield pack")
+      SECTION("pack & void yield pack")
       {
         static_assert(std::same_as<decltype(std::declval<fn::expected<fn::pack<double, bool>, Error>>()
                                             & std::declval<fn::expected<void, Error>>()),
@@ -1156,7 +1156,7 @@ TEST_CASE("expected pack support", "[expected][pack][and_then][transform][operat
               == FileNotFound);
       }
 
-      WHEN("void & pack yield pack")
+      SECTION("void & pack yield pack")
       {
         static_assert(std::same_as<decltype(std::declval<fn::expected<void, Error>>()
                                             & std::declval<fn::expected<fn::pack<double, bool>, Error>>()),
@@ -1180,7 +1180,7 @@ TEST_CASE("expected pack support", "[expected][pack][and_then][transform][operat
               == FileNotFound);
       }
 
-      WHEN("sum on both sides")
+      SECTION("sum on both sides")
       {
         using Lh = fn::expected<fn::sum<double, int>, Error>;
         using Rh = fn::expected<fn::sum<bool, int>, Error>;
@@ -1200,7 +1200,7 @@ TEST_CASE("expected pack support", "[expected][pack][and_then][transform][operat
         CHECK((Lh{fn::sum{0.5}} & Rh{::fn::unexpect, Unknown}).error() == Unknown);
         CHECK((Lh{::fn::unexpect, FileNotFound} & Rh{::fn::unexpect, Unknown}).error() == FileNotFound);
 
-        WHEN("sum of packs on left")
+        SECTION("sum of packs on left")
         {
           using Lh = fn::expected<fn::sum_for<fn::pack<double, bool>, fn::pack<double, int>>, Error>;
           static_assert(std::same_as<decltype(std::declval<Lh>() & std::declval<Rh>()),
@@ -1220,7 +1220,7 @@ TEST_CASE("expected pack support", "[expected][pack][and_then][transform][operat
           CHECK((Lh{::fn::unexpect, FileNotFound} & Rh{::fn::unexpect, Unknown}).error() == FileNotFound);
         }
 
-        WHEN("sum of packs on right")
+        SECTION("sum of packs on right")
         {
           using Rh = fn::expected<fn::sum_for<fn::pack<double, bool>, fn::pack<double, int>>, Error>;
           static_assert(std::same_as<decltype(std::declval<Lh>() & std::declval<Rh>()),
@@ -1241,7 +1241,7 @@ TEST_CASE("expected pack support", "[expected][pack][and_then][transform][operat
         }
       }
 
-      WHEN("sum on left side only")
+      SECTION("sum on left side only")
       {
         using Lh = fn::expected<fn::sum<double, int>, Error>;
         using Rh = fn::expected<int, Error>;
@@ -1260,7 +1260,7 @@ TEST_CASE("expected pack support", "[expected][pack][and_then][transform][operat
         CHECK((Lh{fn::sum{0.5}} & Rh{::fn::unexpect, Unknown}).error() == Unknown);
         CHECK((Lh{::fn::unexpect, FileNotFound} & Rh{::fn::unexpect, Unknown}).error() == FileNotFound);
 
-        WHEN("sum of packs on left")
+        SECTION("sum of packs on left")
         {
           using Lh = fn::expected<fn::sum_for<fn::pack<double, bool>, fn::pack<double, int>>, Error>;
           static_assert(std::same_as<decltype(std::declval<Lh>() & std::declval<Rh>()),
@@ -1279,7 +1279,7 @@ TEST_CASE("expected pack support", "[expected][pack][and_then][transform][operat
           CHECK((Lh{::fn::unexpect, FileNotFound} & Rh{::fn::unexpect, Unknown}).error() == FileNotFound);
         }
 
-        WHEN("pack on right")
+        SECTION("pack on right")
         {
           using Rh = fn::expected<fn::pack<double, bool>, Error>;
           static_assert(std::same_as<decltype(std::declval<Lh>() & std::declval<Rh>()),
@@ -1299,7 +1299,7 @@ TEST_CASE("expected pack support", "[expected][pack][and_then][transform][operat
         }
       }
 
-      WHEN("sum on right side only")
+      SECTION("sum on right side only")
       {
         using Lh = fn::expected<double, Error>;
         using Rh = fn::expected<fn::sum<bool, int>, Error>;
@@ -1318,7 +1318,7 @@ TEST_CASE("expected pack support", "[expected][pack][and_then][transform][operat
         CHECK((Lh{0.5} & Rh{::fn::unexpect, Unknown}).error() == Unknown);
         CHECK((Lh{::fn::unexpect, FileNotFound} & Rh{::fn::unexpect, Unknown}).error() == FileNotFound);
 
-        WHEN("pack on left")
+        SECTION("pack on left")
         {
           using Lh = fn::expected<fn::pack<double, int>, Error>;
           static_assert(std::same_as<decltype(std::declval<Lh>() & std::declval<Rh>()),
@@ -1339,7 +1339,7 @@ TEST_CASE("expected pack support", "[expected][pack][and_then][transform][operat
       }
     }
 
-    WHEN("graded monad as left operand")
+    SECTION("graded monad as left operand")
     {
       static_assert(std::same_as<decltype(std::declval<fn::expected<int, fn::sum<Error>>>()
                                           & std::declval<fn::expected<void, Error>>()),
@@ -1361,7 +1361,7 @@ TEST_CASE("expected pack support", "[expected][pack][and_then][transform][operat
                                           & std::declval<fn::expected<void, fn::sum<Error>>>()),
                                  fn::expected<int, fn::sum_for<Error, bool, int>>>);
 
-      WHEN("value & void yield value")
+      SECTION("value & void yield value")
       {
         static_assert(std::same_as<decltype(std::declval<fn::expected<int, fn::sum<Error>>>()
                                             & std::declval<fn::expected<void, int>>()),
@@ -1385,7 +1385,7 @@ TEST_CASE("expected pack support", "[expected][pack][and_then][transform][operat
               == fn::sum{FileNotFound});
       }
 
-      WHEN("void & value yield value")
+      SECTION("void & value yield value")
       {
         static_assert(std::same_as<decltype(std::declval<fn::expected<void, fn::sum<Error>>>()
                                             & std::declval<fn::expected<int, int>>()),
@@ -1409,7 +1409,7 @@ TEST_CASE("expected pack support", "[expected][pack][and_then][transform][operat
               == fn::sum{FileNotFound});
       }
 
-      WHEN("void & void yield void")
+      SECTION("void & void yield void")
       {
         static_assert(std::same_as<decltype(std::declval<fn::expected<void, fn::sum<Error>>>()
                                             & std::declval<fn::expected<void, int>>()),
@@ -1432,7 +1432,7 @@ TEST_CASE("expected pack support", "[expected][pack][and_then][transform][operat
               == fn::sum{FileNotFound});
       }
 
-      WHEN("value & value yield pack")
+      SECTION("value & value yield pack")
       {
         static_assert(std::same_as<decltype(std::declval<fn::expected<int, fn::sum<Error>>>()
                                             & std::declval<fn::expected<double, int>>()),
@@ -1456,7 +1456,7 @@ TEST_CASE("expected pack support", "[expected][pack][and_then][transform][operat
               == fn::sum{FileNotFound});
       }
 
-      WHEN("pack & value yield pack")
+      SECTION("pack & value yield pack")
       {
         static_assert(std::same_as<decltype(std::declval<fn::expected<fn::pack<double, bool>, fn::sum<Error>>>()
                                             & std::declval<fn::expected<int, int>>()),
@@ -1480,7 +1480,7 @@ TEST_CASE("expected pack support", "[expected][pack][and_then][transform][operat
               == fn::sum{FileNotFound});
       }
 
-      WHEN("pack & void yield pack")
+      SECTION("pack & void yield pack")
       {
         static_assert(std::same_as<decltype(std::declval<fn::expected<fn::pack<double, bool>, fn::sum<Error>>>()
                                             & std::declval<fn::expected<void, int>>()),
@@ -1504,7 +1504,7 @@ TEST_CASE("expected pack support", "[expected][pack][and_then][transform][operat
               == fn::sum{FileNotFound});
       }
 
-      WHEN("void & pack yield pack")
+      SECTION("void & pack yield pack")
       {
         static_assert(std::same_as<decltype(std::declval<fn::expected<void, fn::sum<Error>>>()
                                             & std::declval<fn::expected<fn::pack<double, bool>, int>>()),
@@ -1528,7 +1528,7 @@ TEST_CASE("expected pack support", "[expected][pack][and_then][transform][operat
               == fn::sum{FileNotFound});
       }
 
-      WHEN("sum on both sides")
+      SECTION("sum on both sides")
       {
         using Lh = fn::expected<fn::sum<double, int>, fn::sum<Error>>;
         using Rh = fn::expected<fn::sum<bool, int>, int>;
@@ -1548,7 +1548,7 @@ TEST_CASE("expected pack support", "[expected][pack][and_then][transform][operat
         CHECK((Lh{fn::sum{0.5}} & Rh{::fn::unexpect, 13}).error() == fn::sum{13});
         CHECK((Lh{::fn::unexpect, fn::sum{FileNotFound}} & Rh{::fn::unexpect, 13}).error() == fn::sum{FileNotFound});
 
-        WHEN("sum of packs on left")
+        SECTION("sum of packs on left")
         {
           using Lh = fn::expected<fn::sum_for<fn::pack<double, bool>, fn::pack<double, int>>, fn::sum<Error>>;
           static_assert(std::same_as<decltype(std::declval<Lh>() & std::declval<Rh>()),
@@ -1569,7 +1569,7 @@ TEST_CASE("expected pack support", "[expected][pack][and_then][transform][operat
         }
       }
 
-      WHEN("sum on left side only")
+      SECTION("sum on left side only")
       {
         using Lh = fn::expected<fn::sum<double, int>, fn::sum<Error>>;
         using Rh = fn::expected<int, int>;
@@ -1588,7 +1588,7 @@ TEST_CASE("expected pack support", "[expected][pack][and_then][transform][operat
         CHECK((Lh{fn::sum{0.5}} & Rh{::fn::unexpect, 13}).error() == fn::sum{13});
         CHECK((Lh{::fn::unexpect, fn::sum{FileNotFound}} & Rh{::fn::unexpect, 13}).error() == fn::sum{FileNotFound});
 
-        WHEN("sum of packs on left")
+        SECTION("sum of packs on left")
         {
           using Lh = fn::expected<fn::sum_for<fn::pack<double, bool>, fn::pack<double, int>>, fn::sum<Error>>;
           static_assert(std::same_as<decltype(std::declval<Lh>() & std::declval<Rh>()),
@@ -1608,7 +1608,7 @@ TEST_CASE("expected pack support", "[expected][pack][and_then][transform][operat
         }
       }
 
-      WHEN("sum on right side only")
+      SECTION("sum on right side only")
       {
         using Lh = fn::expected<double, fn::sum<Error>>;
         using Rh = fn::expected<fn::sum<bool, int>, int>;
@@ -1627,7 +1627,7 @@ TEST_CASE("expected pack support", "[expected][pack][and_then][transform][operat
         CHECK((Lh{0.5} & Rh{::fn::unexpect, 13}).error() == fn::sum{13});
         CHECK((Lh{::fn::unexpect, fn::sum{FileNotFound}} & Rh{::fn::unexpect, 13}).error() == fn::sum{FileNotFound});
 
-        WHEN("pack on left")
+        SECTION("pack on left")
         {
           using Lh = fn::expected<fn::pack<double, int>, fn::sum<Error>>;
           static_assert(std::same_as<decltype(std::declval<Lh>() & std::declval<Rh>()),
@@ -1648,7 +1648,7 @@ TEST_CASE("expected pack support", "[expected][pack][and_then][transform][operat
       }
     }
 
-    WHEN("graded monad as right operand")
+    SECTION("graded monad as right operand")
     {
       static_assert(std::same_as<decltype(std::declval<fn::expected<void, Error>>()
                                           & std::declval<fn::expected<int, fn::sum<Error>>>()),
@@ -1670,7 +1670,7 @@ TEST_CASE("expected pack support", "[expected][pack][and_then][transform][operat
                                           & std::declval<fn::expected<void, fn::sum<Error>>>()),
                                  fn::expected<int, fn::sum_for<Error, bool, int>>>);
 
-      WHEN("value & void & yield value")
+      SECTION("value & void & yield value")
       {
         static_assert(std::same_as<decltype(std::declval<fn::expected<int, int>>()
                                             & std::declval<fn::expected<void, fn::sum<Error>>>()),
@@ -1694,7 +1694,7 @@ TEST_CASE("expected pack support", "[expected][pack][and_then][transform][operat
               == fn::sum{13});
       }
 
-      WHEN("void & value yield value")
+      SECTION("void & value yield value")
       {
         static_assert(std::same_as<decltype(std::declval<fn::expected<void, int>>()
                                             & std::declval<fn::expected<int, fn::sum<Error>>>()),
@@ -1718,7 +1718,7 @@ TEST_CASE("expected pack support", "[expected][pack][and_then][transform][operat
               == fn::sum{13});
       }
 
-      WHEN("void & void yield void")
+      SECTION("void & void yield void")
       {
         static_assert(std::same_as<decltype(std::declval<fn::expected<void, int>>()
                                             & std::declval<fn::expected<void, fn::sum<Error>>>()),
@@ -1741,7 +1741,7 @@ TEST_CASE("expected pack support", "[expected][pack][and_then][transform][operat
               == fn::sum{13});
       }
 
-      WHEN("value & value yield pack")
+      SECTION("value & value yield pack")
       {
         static_assert(std::same_as<decltype(std::declval<fn::expected<double, int>>()
                                             & std::declval<fn::expected<int, fn::sum<Error>>>()),
@@ -1765,7 +1765,7 @@ TEST_CASE("expected pack support", "[expected][pack][and_then][transform][operat
               == fn::sum{13});
       }
 
-      WHEN("pack & value yield pack")
+      SECTION("pack & value yield pack")
       {
         static_assert(std::same_as<decltype(std::declval<fn::expected<fn::pack<double, bool>, int>>()
                                             & std::declval<fn::expected<int, fn::sum<Error>>>()),
@@ -1789,7 +1789,7 @@ TEST_CASE("expected pack support", "[expected][pack][and_then][transform][operat
               == fn::sum{13});
       }
 
-      WHEN("pack & void yield pack")
+      SECTION("pack & void yield pack")
       {
         static_assert(std::same_as<decltype(std::declval<fn::expected<fn::pack<double, bool>, int>>()
                                             & std::declval<fn::expected<void, fn::sum<Error>>>()),
@@ -1813,7 +1813,7 @@ TEST_CASE("expected pack support", "[expected][pack][and_then][transform][operat
               == fn::sum{13});
       }
 
-      WHEN("void & pack yield pack")
+      SECTION("void & pack yield pack")
       {
         static_assert(std::same_as<decltype(std::declval<fn::expected<void, int>>()
                                             & std::declval<fn::expected<fn::pack<double, bool>, fn::sum<Error>>>()),
@@ -1837,7 +1837,7 @@ TEST_CASE("expected pack support", "[expected][pack][and_then][transform][operat
               == fn::sum{13});
       }
 
-      WHEN("sum on both sides")
+      SECTION("sum on both sides")
       {
         using Lh = fn::expected<fn::sum<double, int>, Error>;
         using Rh = fn::expected<fn::sum<bool, int>, fn::sum<int>>;
@@ -1857,7 +1857,7 @@ TEST_CASE("expected pack support", "[expected][pack][and_then][transform][operat
         CHECK((Lh{fn::sum{0.5}} & Rh{::fn::unexpect, fn::sum{13}}).error() == fn::sum{13});
         CHECK((Lh{::fn::unexpect, FileNotFound} & Rh{::fn::unexpect, fn::sum{13}}).error() == fn::sum{FileNotFound});
 
-        WHEN("sum of packs on left")
+        SECTION("sum of packs on left")
         {
           using Lh = fn::expected<fn::sum_for<fn::pack<double, bool>, fn::pack<double, int>>, Error>;
           static_assert(std::same_as<decltype(std::declval<Lh>() & std::declval<Rh>()),
@@ -1878,7 +1878,7 @@ TEST_CASE("expected pack support", "[expected][pack][and_then][transform][operat
         }
       }
 
-      WHEN("sum on left side only")
+      SECTION("sum on left side only")
       {
         using Lh = fn::expected<fn::sum<double, int>, Error>;
         using Rh = fn::expected<int, fn::sum<int>>;
@@ -1897,7 +1897,7 @@ TEST_CASE("expected pack support", "[expected][pack][and_then][transform][operat
         CHECK((Lh{fn::sum{0.5}} & Rh{::fn::unexpect, 13}).error() == fn::sum{13});
         CHECK((Lh{::fn::unexpect, FileNotFound} & Rh{::fn::unexpect, 13}).error() == fn::sum{FileNotFound});
 
-        WHEN("sum of packs on left")
+        SECTION("sum of packs on left")
         {
           using Lh = fn::expected<fn::sum_for<fn::pack<double, bool>, fn::pack<double, int>>, Error>;
           static_assert(std::same_as<decltype(std::declval<Lh>() & std::declval<Rh>()),
@@ -1917,7 +1917,7 @@ TEST_CASE("expected pack support", "[expected][pack][and_then][transform][operat
         }
       }
 
-      WHEN("sum on right side only")
+      SECTION("sum on right side only")
       {
         using Lh = fn::expected<double, Error>;
         using Rh = fn::expected<fn::sum<bool, int>, fn::sum<int>>;
@@ -1936,7 +1936,7 @@ TEST_CASE("expected pack support", "[expected][pack][and_then][transform][operat
         CHECK((Lh{0.5} & Rh{::fn::unexpect, fn::sum{13}}).error() == fn::sum{13});
         CHECK((Lh{::fn::unexpect, FileNotFound} & Rh{::fn::unexpect, fn::sum{13}}).error() == fn::sum{FileNotFound});
 
-        WHEN("pack on left")
+        SECTION("pack on left")
         {
           using Lh = fn::expected<fn::pack<double, int>, Error>;
           static_assert(std::same_as<decltype(std::declval<Lh>() & std::declval<Rh>()),
@@ -1957,13 +1957,13 @@ TEST_CASE("expected pack support", "[expected][pack][and_then][transform][operat
       }
     }
 
-    WHEN("graded monad on both ides")
+    SECTION("graded monad on both sides")
     {
       static_assert(std::same_as<decltype(std::declval<fn::expected<int, fn::sum<bool, int>>>()
                                           & std::declval<fn::expected<void, fn::sum<Error>>>()),
                                  fn::expected<int, fn::sum_for<Error, bool, int>>>);
 
-      WHEN("value & void & yield value")
+      SECTION("value & void & yield value")
       {
         using Lh = fn::expected<int, fn::sum<bool, int>>;
         using Rh = fn::expected<void, fn::sum<Error>>;
@@ -1976,7 +1976,7 @@ TEST_CASE("expected pack support", "[expected][pack][and_then][transform][operat
         CHECK((Lh{::fn::unexpect, fn::sum{13}} & Rh{::fn::unexpect, fn::sum{FileNotFound}}).error() == fn::sum{13});
       }
 
-      WHEN("void & value yield value")
+      SECTION("void & value yield value")
       {
         using Lh = fn::expected<void, fn::sum<bool, int>>;
         using Rh = fn::expected<int, fn::sum<Error>>;
@@ -1989,7 +1989,7 @@ TEST_CASE("expected pack support", "[expected][pack][and_then][transform][operat
         CHECK((Lh{::fn::unexpect, fn::sum{13}} & Rh{::fn::unexpect, fn::sum{FileNotFound}}).error() == fn::sum{13});
       }
 
-      WHEN("void & void yield void")
+      SECTION("void & void yield void")
       {
         using Lh = fn::expected<void, fn::sum<bool, int>>;
         using Rh = fn::expected<void, fn::sum<Error>>;
@@ -2002,7 +2002,7 @@ TEST_CASE("expected pack support", "[expected][pack][and_then][transform][operat
         CHECK((Lh{::fn::unexpect, fn::sum{13}} & Rh{::fn::unexpect, fn::sum{FileNotFound}}).error() == fn::sum{13});
       }
 
-      WHEN("value & value yield pack")
+      SECTION("value & value yield pack")
       {
         using Lh = fn::expected<double, fn::sum<bool, int>>;
         using Rh = fn::expected<int, fn::sum<Error>>;
@@ -2017,7 +2017,7 @@ TEST_CASE("expected pack support", "[expected][pack][and_then][transform][operat
         CHECK((Lh{::fn::unexpect, fn::sum{13}} & Rh{::fn::unexpect, fn::sum{FileNotFound}}).error() == fn::sum{13});
       }
 
-      WHEN("pack & value yield pack")
+      SECTION("pack & value yield pack")
       {
         using Lh = fn::expected<fn::pack<double, bool>, fn::sum<bool, int>>;
         using Rh = fn::expected<int, fn::sum<Error>>;
@@ -2042,7 +2042,7 @@ TEST_CASE("expected pack support", "[expected][pack][and_then][transform][operat
               == fn::sum{13});
       }
 
-      WHEN("pack & void yield pack")
+      SECTION("pack & void yield pack")
       {
         using Lh = fn::expected<fn::pack<double, bool>, fn::sum<bool, int>>;
         using Rh = fn::expected<void, fn::sum<Error>>;
@@ -2058,7 +2058,7 @@ TEST_CASE("expected pack support", "[expected][pack][and_then][transform][operat
         CHECK((Lh{::fn::unexpect, fn::sum{13}} & Rh{::fn::unexpect, fn::sum{FileNotFound}}).error() == fn::sum{13});
       }
 
-      WHEN("void & pack yield pack")
+      SECTION("void & pack yield pack")
       {
         using Lh = fn::expected<void, fn::sum<bool, int>>;
         using Rh = fn::expected<fn::pack<double, bool>, fn::sum<Error>>;
@@ -2074,7 +2074,7 @@ TEST_CASE("expected pack support", "[expected][pack][and_then][transform][operat
         CHECK((Lh{::fn::unexpect, fn::sum{13}} & Rh{::fn::unexpect, fn::sum{FileNotFound}}).error() == fn::sum{13});
       }
 
-      WHEN("sum on both sides")
+      SECTION("sum on both sides")
       {
         using Lh = fn::expected<fn::sum<double, int>, fn::sum<Error>>;
         using Rh = fn::expected<fn::sum<bool, int>, fn::sum<bool, int>>;
@@ -2095,7 +2095,7 @@ TEST_CASE("expected pack support", "[expected][pack][and_then][transform][operat
         CHECK((Lh{::fn::unexpect, fn::sum{FileNotFound}} & Rh{::fn::unexpect, fn::sum{13}}).error()
               == fn::sum{FileNotFound});
 
-        WHEN("sum of packs on left")
+        SECTION("sum of packs on left")
         {
           using Lh = fn::expected<fn::sum_for<fn::pack<double, bool>, fn::pack<double, int>>, fn::sum<Error>>;
           static_assert(std::same_as<decltype(std::declval<Lh>() & std::declval<Rh>()),
@@ -2123,7 +2123,7 @@ TEST_CASE("expected pack support", "[expected][pack][and_then][transform][operat
         }
       }
 
-      WHEN("sum on left side only")
+      SECTION("sum on left side only")
       {
         using Lh = fn::expected<fn::sum<double, int>, fn::sum<Error>>;
         using Rh = fn::expected<int, fn::sum<bool, int>>;
@@ -2142,7 +2142,7 @@ TEST_CASE("expected pack support", "[expected][pack][and_then][transform][operat
         CHECK((Lh{fn::sum{0.5}} & Rh{::fn::unexpect, 13}).error() == fn::sum{13});
         CHECK((Lh{::fn::unexpect, fn::sum{FileNotFound}} & Rh{::fn::unexpect, 13}).error() == fn::sum{FileNotFound});
 
-        WHEN("sum of packs on left")
+        SECTION("sum of packs on left")
         {
           using Lh = fn::expected<fn::sum_for<fn::pack<double, bool>, fn::pack<double, int>>, fn::sum<Error>>;
           static_assert(std::same_as<decltype(std::declval<Lh>() & std::declval<Rh>()),
@@ -2169,7 +2169,7 @@ TEST_CASE("expected pack support", "[expected][pack][and_then][transform][operat
         }
       }
 
-      WHEN("sum on right side only")
+      SECTION("sum on right side only")
       {
         using Lh = fn::expected<double, fn::sum<Error>>;
         using Rh = fn::expected<fn::sum<bool, int>, fn::sum<bool, int>>;
@@ -2188,7 +2188,7 @@ TEST_CASE("expected pack support", "[expected][pack][and_then][transform][operat
         CHECK((Lh{0.5} & Rh{::fn::unexpect, fn::sum{13}}).error() == fn::sum{13});
         CHECK((Lh{::fn::unexpect, FileNotFound} & Rh{::fn::unexpect, fn::sum{13}}).error() == fn::sum{FileNotFound});
 
-        WHEN("pack on left")
+        SECTION("pack on left")
         {
           using Lh = fn::expected<fn::pack<double, int>, fn::sum<Error>>;
           static_assert(std::same_as<decltype(std::declval<Lh>() & std::declval<Rh>()),
@@ -2216,14 +2216,14 @@ TEST_CASE("expected pack support", "[expected][pack][and_then][transform][operat
       }
     }
 
-    WHEN("unit error grade sum<>")
+    SECTION("unit error grade sum<>")
     {
       // A never-erroring expected<T, sum<>> composes with a fallible one: the sum<> operand adds no
       // alternative to the widened error, only its value to the pack. Previously ill-formed, because the
       // sum<> side made operator&'s error lambda deduce void and poisoned _join's return type.
       using Unit = fn::expected<int, fn::sum<>>;
 
-      WHEN("different error, unit on left")
+      SECTION("different error, unit on left")
       {
         using Rh = fn::expected<int, Error>;
         static_assert(std::same_as<decltype(std::declval<Unit>() & std::declval<Rh>()),
@@ -2240,7 +2240,7 @@ TEST_CASE("expected pack support", "[expected][pack][and_then][transform][operat
         CHECK((Unit{7} & Rh{::fn::unexpect, FileNotFound}).error() == fn::sum{FileNotFound});
       }
 
-      WHEN("different error, unit on right")
+      SECTION("different error, unit on right")
       {
         using Lh = fn::expected<int, Error>;
         static_assert(std::same_as<decltype(std::declval<Lh>() & std::declval<Unit>()),
@@ -2257,7 +2257,7 @@ TEST_CASE("expected pack support", "[expected][pack][and_then][transform][operat
         CHECK((Lh{::fn::unexpect, FileNotFound} & Unit{7}).error() == fn::sum{FileNotFound});
       }
 
-      WHEN("unit meets a sum grade, either order")
+      SECTION("unit meets a sum grade, either order")
       {
         using Rh = fn::expected<int, fn::sum<Error>>;
         static_assert(std::same_as<decltype(std::declval<Unit>() & std::declval<Rh>()),
@@ -2272,7 +2272,7 @@ TEST_CASE("expected pack support", "[expected][pack][and_then][transform][operat
         CHECK((Rh{::fn::unexpect, fn::sum{FileNotFound}} & Unit{7}).error() == fn::sum{FileNotFound});
       }
 
-      WHEN("same error, both unit")
+      SECTION("same error, both unit")
       {
         static_assert(std::same_as<decltype(std::declval<Unit>() & std::declval<Unit>()),
                                    fn::expected<fn::pack<int, int>, fn::sum<>>>);
@@ -2285,7 +2285,7 @@ TEST_CASE("expected pack support", "[expected][pack][and_then][transform][operat
                   .value());
       }
 
-      WHEN("void operand carries the unit error")
+      SECTION("void operand carries the unit error")
       {
         using VoidUnit = fn::expected<void, fn::sum<>>;
         using Rh = fn::expected<int, Error>;
@@ -2306,7 +2306,7 @@ TEST_CASE("expected pack support", "[expected][pack][and_then][transform][operat
       }
     }
 
-    WHEN("constexpr")
+    SECTION("constexpr")
     {
       // the graded/unit shapes have constant-evaluation asserts above; these cover the plain
       // same-error shapes, which had none
@@ -2354,7 +2354,7 @@ TEST_CASE("expected sum support and_then", "[expected][sum][and_then]")
   static_assert(not can_and_then_M_lval(generic_fn)); // error copy required, E move-only
   static_assert(can_and_then_M_rval(generic_fn));     // error moved
 
-  WHEN("value")
+  SECTION("value")
   {
     fn::expected<fn::sum_for<int, std::string_view>, Error> s{fn::sum{12}};
 
@@ -2406,7 +2406,7 @@ TEST_CASE("expected sum support and_then", "[expected][sum][and_then]")
               .value());
   }
 
-  WHEN("error")
+  SECTION("error")
   {
     fn::expected<fn::sum_for<int, std::string_view>, Error> s{::fn::unexpect, FileNotFound};
     CHECK(s.and_then( //
@@ -2430,7 +2430,7 @@ TEST_CASE("expected sum support and_then", "[expected][sum][and_then]")
           == FileNotFound);
   }
 
-  WHEN("constexpr")
+  SECTION("constexpr")
   {
     constexpr auto fn = fn::overload{[](int &) -> fn::expected<bool, Error> { throw 0; },
                                      [](int const &i) -> fn::expected<bool, Error> { return i == 42; },
@@ -2480,7 +2480,7 @@ TEST_CASE("expected sum support or_else", "[expected][sum][or_else]")
   static_assert(not can_or_else_M_lval(generic_fn)); // value copy required, T move-only
   static_assert(can_or_else_M_rval(generic_fn));     // value moved
 
-  WHEN("value")
+  SECTION("value")
   {
     fn::expected<double, fn::sum_for<int, std::string_view>> s{::fn::unexpect, fn::sum{12}};
 
@@ -2535,7 +2535,7 @@ TEST_CASE("expected sum support or_else", "[expected][sum][or_else]")
               .value()
           == 12);
 
-    WHEN("value")
+    SECTION("value")
     {
       fn::expected<double, fn::sum_for<int, std::string_view>> s{1.5};
       CHECK(s.or_else( //
@@ -2559,7 +2559,7 @@ TEST_CASE("expected sum support or_else", "[expected][sum][or_else]")
             == 1.5);
     }
 
-    WHEN("constexpr")
+    SECTION("constexpr")
     {
       constexpr auto fn = fn::overload{[](int &) -> fn::expected<double, Error> { throw 0; },
                                        [](int const &i) -> fn::expected<double, Error> { return {i}; },
@@ -2575,7 +2575,7 @@ TEST_CASE("expected sum support or_else", "[expected][sum][or_else]")
     }
   }
 
-  WHEN("void")
+  SECTION("void")
   {
     fn::expected<void, fn::sum_for<int, std::string_view>> s{::fn::unexpect, fn::sum{12}};
 
@@ -2633,7 +2633,7 @@ TEST_CASE("expected sum support or_else", "[expected][sum][or_else]")
             .error()
         == FileNotFound);
 
-    WHEN("value")
+    SECTION("value")
     {
       fn::expected<void, fn::sum_for<int, std::string_view>> s{};
       CHECK(s.or_else( //
@@ -2653,7 +2653,7 @@ TEST_CASE("expected sum support or_else", "[expected][sum][or_else]")
                 .has_value());
     }
 
-    WHEN("constexpr")
+    SECTION("constexpr")
     {
       constexpr auto fn
           = fn::overload{[](int &) -> fn::expected<void, Error> { throw 0; },
@@ -2702,7 +2702,7 @@ TEST_CASE("expected sum support transform", "[expected][sum][transform]")
   static_assert(not can_transform_M_lval(nothrow_visitor));
   static_assert(can_transform_M_rval(nothrow_visitor));
 
-  WHEN("value")
+  SECTION("value")
   {
     fn::expected<fn::sum_for<int, std::string_view>, Error> s{fn::sum{12}};
 
@@ -2746,7 +2746,7 @@ TEST_CASE("expected sum support transform", "[expected][sum][transform]")
               .has_value<std::monostate>());
   }
 
-  WHEN("error")
+  SECTION("error")
   {
     fn::expected<fn::sum_for<int, std::string_view>, Error> s{::fn::unexpect, FileNotFound};
     CHECK(s.transform( //
@@ -2770,7 +2770,7 @@ TEST_CASE("expected sum support transform", "[expected][sum][transform]")
           == FileNotFound);
   }
 
-  WHEN("constexpr")
+  SECTION("constexpr")
   {
     constexpr auto fn = fn::overload{[](int &) -> bool { throw 0; },
                                      [](int const &) -> bool { return true; },
@@ -2810,7 +2810,7 @@ TEST_CASE("expected sum support transform_error", "[expected][sum][transform_err
   constexpr auto can_transform_error = [](auto &&f) { return requires { std::declval<S &>().transform_error(f); }; };
   static_assert(can_transform_error(nothrow_visitor));
 
-  WHEN("value")
+  SECTION("value")
   {
     fn::expected<double, fn::sum_for<int, std::string_view>> s{::fn::unexpect, fn::sum{12}};
 
@@ -2853,7 +2853,7 @@ TEST_CASE("expected sum support transform_error", "[expected][sum][transform_err
               .error()
           == fn::sum{true});
 
-    WHEN("value")
+    SECTION("value")
     {
       fn::expected<double, fn::sum_for<int, std::string_view>> s{1.5};
       CHECK(s.transform_error( //
@@ -2877,7 +2877,7 @@ TEST_CASE("expected sum support transform_error", "[expected][sum][transform_err
             == 1.5);
     }
 
-    WHEN("constexpr")
+    SECTION("constexpr")
     {
       constexpr auto fn = fn::overload{[](int &) -> bool { throw 0; },
                                        [](int const &i) -> bool { return i == 42; },
@@ -2893,7 +2893,7 @@ TEST_CASE("expected sum support transform_error", "[expected][sum][transform_err
     }
   }
 
-  WHEN("void")
+  SECTION("void")
   {
     fn::expected<void, fn::sum_for<int, std::string_view>> s{::fn::unexpect, fn::sum{12}};
 
@@ -2936,7 +2936,7 @@ TEST_CASE("expected sum support transform_error", "[expected][sum][transform_err
               .error()
           == fn::sum{12});
 
-    WHEN("value")
+    SECTION("value")
     {
       fn::expected<void, fn::sum_for<int, std::string_view>> s{};
       CHECK(s.transform_error( //
@@ -2956,7 +2956,7 @@ TEST_CASE("expected sum support transform_error", "[expected][sum][transform_err
                 .has_value());
     }
 
-    WHEN("constexpr")
+    SECTION("constexpr")
     {
       constexpr auto fn = fn::overload{[](int &) -> int { throw 0; },
                                        [](int const &i) -> int { return i; },
@@ -2994,7 +2994,7 @@ TEST_CASE("expected pack support or_else", "[expected][or_else][pack]")
   static_assert(not can_or_else_lval([](Error &) -> fn::expected<int, Error> { throw 0; })); // wrong arity
   static_assert(not can_or_else_lval(42));
 
-  WHEN("value")
+  SECTION("value")
   {
     fn::expected<int, fn::pack<int, Error>> s{::fn::unexpect, fn::pack{12, FileNotFound}};
     CHECK(s.or_else( //
@@ -3026,7 +3026,7 @@ TEST_CASE("expected pack support or_else", "[expected][or_else][pack]")
               .value());
   }
 
-  WHEN("void")
+  SECTION("void")
   {
     fn::expected<void, fn::pack<int, Error>> s{::fn::unexpect, fn::pack{12, FileNotFound}};
     CHECK(s.or_else( //
@@ -3058,7 +3058,7 @@ TEST_CASE("expected pack support or_else", "[expected][or_else][pack]")
               .has_value());
   }
 
-  WHEN("constexpr")
+  SECTION("constexpr")
   {
     constexpr S a{::fn::unexpect, fn::pack{12, FileNotFound}};
     static_assert(a.or_else([](int i, Error const &e) -> fn::expected<int, Error> {
@@ -3092,7 +3092,7 @@ TEST_CASE("expected pack support transform_error", "[expected][transform_error][
   static_assert(not can_te_lval([](Error &) -> bool { throw 0; })); // wrong arity
   static_assert(not can_te_lval(42));
 
-  WHEN("value")
+  SECTION("value")
   {
     fn::expected<int, fn::pack<int, Error>> s{::fn::unexpect, fn::pack{12, FileNotFound}};
     CHECK(s.transform_error( //
@@ -3120,7 +3120,7 @@ TEST_CASE("expected pack support transform_error", "[expected][transform_error][
               .error());
   }
 
-  WHEN("void")
+  SECTION("void")
   {
     fn::expected<void, fn::pack<int, Error>> s{::fn::unexpect, fn::pack{12, FileNotFound}};
     CHECK(s.transform_error( //
@@ -3146,7 +3146,7 @@ TEST_CASE("expected pack support transform_error", "[expected][transform_error][
             .error());
   }
 
-  WHEN("constexpr")
+  SECTION("constexpr")
   {
     constexpr S a{::fn::unexpect, fn::pack{12, FileNotFound}};
     static_assert(

--- a/tests/fn/expected.cpp
+++ b/tests/fn/expected.cpp
@@ -684,8 +684,6 @@ TEST_CASE("graded monad", "[expected][sum][graded][and_then][or_else][sum_value]
   }
 
   SECTION("noexcept")
-
-  SECTION("noexcept")
   {
     // the widening arms relocate BOTH sides into the summed result - self's, and the callback's -
     // and weigh both, rather than reporting potentially-throwing merely because the shape changed

--- a/tests/fn/expected.cpp
+++ b/tests/fn/expected.cpp
@@ -2206,6 +2206,38 @@ TEST_CASE("expected pack support", "[expected][pack][and_then][transform][operat
 
 TEST_CASE("expected sum support and_then", "[expected][sum][and_then]")
 {
+  using S = fn::expected<fn::sum_for<int, std::string_view>, Error>;
+
+  // noexcept (extension, expected.hpp:77-81): same-error-type result AND nothrow invoke AND
+  // nothrow error copy. A visitor set is not invocable on the whole sum, so the borrowed std
+  // trait is conservatively false even with nothrow handlers (GH #254); a generic callback IS
+  // invocable on the whole sum, and the spec then reports true from a call shape the
+  // per-alternative dispatch never makes.
+  constexpr auto nothrow_lval
+      = fn::overload{[](int &) noexcept -> fn::expected<bool, Error> { return {true}; },
+                     [](std::string_view &) noexcept -> fn::expected<bool, Error> { return {false}; }};
+  static_assert(not noexcept(std::declval<S &>().and_then(nothrow_lval)));
+  constexpr auto nothrow_generic = [](auto &&) noexcept -> fn::expected<bool, Error> { return {true}; };
+  static_assert(noexcept(std::declval<S &>().and_then(nothrow_generic)));
+
+  // constraints (extension, :82-83): exhaustive invocability over the sum's alternatives,
+  // tracking their value category, AND copyability of the untouched error
+  constexpr auto can_and_then_lval = [](auto &&f) { return requires { std::declval<S &>().and_then(f); }; };
+  constexpr auto can_and_then_rval = [](auto &&f) { return requires { std::declval<S &&>().and_then(f); }; };
+  static_assert(can_and_then_lval(nothrow_lval));
+  static_assert(not can_and_then_rval(nothrow_lval)); // no rvalue handlers
+  static_assert(not can_and_then_lval(fn::overload{[](int &) -> fn::expected<bool, Error> { throw 0; }})); // partial
+  static_assert(not can_and_then_lval(42));
+  struct move_only_error {
+    move_only_error(move_only_error &&) = default;
+  };
+  using M = fn::expected<fn::sum<int>, move_only_error>;
+  constexpr auto generic_fn = [](auto &&) -> fn::expected<bool, move_only_error> { throw 0; };
+  constexpr auto can_and_then_M_lval = [](auto &&f) { return requires { std::declval<M &>().and_then(f); }; };
+  constexpr auto can_and_then_M_rval = [](auto &&f) { return requires { std::declval<M &&>().and_then(f); }; };
+  static_assert(not can_and_then_M_lval(generic_fn)); // error copy required, E move-only
+  static_assert(can_and_then_M_rval(generic_fn));     // error moved
+
   WHEN("value")
   {
     fn::expected<fn::sum_for<int, std::string_view>, Error> s{fn::sum{12}};
@@ -2300,6 +2332,38 @@ TEST_CASE("expected sum support and_then", "[expected][sum][and_then]")
 
 TEST_CASE("expected sum support or_else", "[expected][sum][or_else]")
 {
+  using S = fn::expected<double, fn::sum_for<int, std::string_view>>;
+
+  // noexcept (extension, expected.hpp:159-166): same-value-type result AND nothrow invoke AND
+  // nothrow value copy. A visitor set is not invocable on the whole sum, so the borrowed std
+  // trait is conservatively false (GH #254); a generic same-value-type callback reports true.
+  constexpr auto nothrow_lval
+      = fn::overload{[](int &) noexcept -> fn::expected<double, Error> { return {0.5}; },
+                     [](std::string_view &) noexcept -> fn::expected<double, Error> { return {0.5}; }};
+  static_assert(not noexcept(std::declval<S &>().or_else(nothrow_lval)));
+  constexpr auto nothrow_generic = [](auto &&) noexcept -> fn::expected<double, Error> { return {0.5}; };
+  static_assert(noexcept(std::declval<S &>().or_else(nothrow_generic)));
+
+  // constraints (extension, :167-168): invocability over the error sum's alternatives, tracking
+  // their value category, AND copyability of the untouched value -- a move-only value type
+  // cleanly drops every overload whose self would copy it (contrast transform_error, which
+  // lacks this conjunct; see "expected sum support transform_error")
+  constexpr auto can_or_else_lval = [](auto &&f) { return requires { std::declval<S &>().or_else(f); }; };
+  constexpr auto can_or_else_rval = [](auto &&f) { return requires { std::declval<S &&>().or_else(f); }; };
+  static_assert(can_or_else_lval(nothrow_lval));
+  static_assert(not can_or_else_rval(nothrow_lval)); // no rvalue handlers
+  static_assert(not can_or_else_lval(fn::overload{[](int &) -> fn::expected<double, Error> { throw 0; }})); // partial
+  static_assert(not can_or_else_lval(42));
+  struct move_only {
+    move_only(move_only &&) = default;
+  };
+  using M = fn::expected<move_only, fn::sum<int>>;
+  constexpr auto generic_fn = [](auto &&) -> fn::expected<move_only, Error> { throw 0; };
+  constexpr auto can_or_else_M_lval = [](auto &&f) { return requires { std::declval<M &>().or_else(f); }; };
+  constexpr auto can_or_else_M_rval = [](auto &&f) { return requires { std::declval<M &&>().or_else(f); }; };
+  static_assert(not can_or_else_M_lval(generic_fn)); // value copy required, T move-only
+  static_assert(can_or_else_M_rval(generic_fn));     // value moved
+
   WHEN("value")
   {
     fn::expected<double, fn::sum_for<int, std::string_view>> s{::fn::unexpect, fn::sum{12}};
@@ -2493,6 +2557,34 @@ TEST_CASE("expected sum support or_else", "[expected][sum][or_else]")
 
 TEST_CASE("expected sum support transform", "[expected][sum][transform]")
 {
+  using S = fn::expected<fn::sum_for<int, std::string_view>, Error>;
+
+  // noexcept: the sum-case _transform (expected.hpp:238) carries no noexcept spec at all --
+  // noexcept(false) even for callbacks whose and_then counterpart reports true (GH #254)
+  constexpr auto nothrow_visitor = fn::overload{[](int const &) noexcept -> bool { return true; },
+                                                [](std::string_view const &) noexcept -> bool { return false; }};
+  static_assert(not noexcept(std::declval<S &>().transform(nothrow_visitor)));
+  constexpr auto nothrow_generic = [](auto &&) noexcept -> bool { return true; };
+  static_assert(not noexcept(std::declval<S &>().transform(nothrow_generic)));
+
+  // GAP: unlike and_then (expected.hpp:82) and the non-sum transform (:219), the sum-case
+  // _transform (:239) has no callback-invocability constraint; validity surfaces in its
+  // deduced-return body (:241) during candidate-signature formation, outside the immediate
+  // context -- a bad callback is a hard error instead of SFINAE-dropping (no negative probe
+  // here), and the visitors above take const& to serve every candidate, as in fn/optional.cpp
+  constexpr auto can_transform = [](auto &&f) { return requires { std::declval<S &>().transform(f); }; };
+  static_assert(can_transform(nothrow_visitor));
+  // the error-copy conjunct (:239) IS constrained: a move-only error cleanly drops the
+  // overloads whose self would copy it, before the unconstrained body could hard-error
+  struct move_only_error {
+    move_only_error(move_only_error &&) = default;
+  };
+  using M = fn::expected<fn::sum<int>, move_only_error>;
+  constexpr auto can_transform_M_lval = [](auto &&f) { return requires { std::declval<M &>().transform(f); }; };
+  constexpr auto can_transform_M_rval = [](auto &&f) { return requires { std::declval<M &&>().transform(f); }; };
+  static_assert(not can_transform_M_lval(nothrow_visitor));
+  static_assert(can_transform_M_rval(nothrow_visitor));
+
   WHEN("value")
   {
     fn::expected<fn::sum_for<int, std::string_view>, Error> s{fn::sum{12}};
@@ -2580,6 +2672,26 @@ TEST_CASE("expected sum support transform", "[expected][sum][transform]")
 
 TEST_CASE("expected sum support transform_error", "[expected][sum][transform_error]")
 {
+  using S = fn::expected<double, fn::sum_for<int, std::string_view>>;
+
+  // noexcept: the sum-case _transform_error (expected.hpp:301) carries no noexcept spec at all
+  // (GH #254)
+  constexpr auto nothrow_visitor = fn::overload{[](int const &) noexcept -> bool { return true; },
+                                                [](std::string_view const &) noexcept -> bool { return false; }};
+  static_assert(not noexcept(std::declval<S &>().transform_error(nothrow_visitor)));
+  constexpr auto nothrow_generic = [](auto &&) noexcept -> bool { return true; };
+  static_assert(not noexcept(std::declval<S &>().transform_error(nothrow_generic)));
+
+  // GAP: the sum-case _transform_error (:302) is constrained only on some_sum<E> -- neither the
+  // callback (checked in the deduced-return body :304, hard error instead of SFINAE) nor the
+  // untouched value's copy (:308), which the non-sum overload (:283-284) also omits where pfn
+  // spells it (pfn/detail/expected_base.hpp:904). With a move-only value type NO transform_error
+  // call compiles from any category -- const& binds rvalues, so even an rvalue call forms the
+  // const& candidate whose body copies the value -- where or_else's conjunct (:168) cleanly
+  // drops those candidates (see "expected sum support or_else"). Positive probe only.
+  constexpr auto can_transform_error = [](auto &&f) { return requires { std::declval<S &>().transform_error(f); }; };
+  static_assert(can_transform_error(nothrow_visitor));
+
   WHEN("value")
   {
     fn::expected<double, fn::sum_for<int, std::string_view>> s{::fn::unexpect, fn::sum{12}};
@@ -2745,6 +2857,25 @@ TEST_CASE("expected sum support transform_error", "[expected][sum][transform_err
 
 TEST_CASE("expected pack support or_else", "[expected][or_else][pack]")
 {
+  using S = fn::expected<int, fn::pack<int, Error>>;
+
+  // noexcept (extension, expected.hpp:159-166): a multi-argument visitor is not invocable on
+  // the whole pack, so the borrowed std trait is conservatively false (GH #254); a generic
+  // same-value-type callback IS, and reports true
+  constexpr auto nothrow_two = [](int, Error &) noexcept -> fn::expected<int, Error> { return {1}; };
+  static_assert(not noexcept(std::declval<S &>().or_else(nothrow_two)));
+  constexpr auto nothrow_generic = [](auto &&...) noexcept -> fn::expected<int, Error> { return {1}; };
+  static_assert(noexcept(std::declval<S &>().or_else(nothrow_generic)));
+
+  // constraints (extension, :167-168): pack-apply invocability tracking the pack's value
+  // category; wrong arity or a non-callable SFINAE-drops
+  constexpr auto can_or_else_lval = [](auto &&f) { return requires { std::declval<S &>().or_else(f); }; };
+  constexpr auto can_or_else_rval = [](auto &&f) { return requires { std::declval<S &&>().or_else(f); }; };
+  static_assert(can_or_else_lval(nothrow_two));
+  static_assert(not can_or_else_rval(nothrow_two));                                          // lvalue-only visitor
+  static_assert(not can_or_else_lval([](Error &) -> fn::expected<int, Error> { throw 0; })); // wrong arity
+  static_assert(not can_or_else_lval(42));
+
   WHEN("value")
   {
     fn::expected<int, fn::pack<int, Error>> s{::fn::unexpect, fn::pack{12, FileNotFound}};
@@ -2808,10 +2939,41 @@ TEST_CASE("expected pack support or_else", "[expected][or_else][pack]")
                                [](int, Error const &&) -> fn::expected<void, Error> { throw 0; }})
               .has_value());
   }
+
+  WHEN("constexpr")
+  {
+    constexpr S a{::fn::unexpect, fn::pack{12, FileNotFound}};
+    static_assert(a.or_else([](int i, Error const &e) -> fn::expected<int, Error> {
+                     return {i == 12 && e == FileNotFound};
+                   }).value());
+    constexpr S b{1};
+    static_assert(b.or_else([](auto &&...) -> fn::expected<int, Error> { throw 0; }).value() == 1);
+    SUCCEED();
+  }
 }
 
 TEST_CASE("expected pack support transform_error", "[expected][transform_error][pack]")
 {
+  using S = fn::expected<int, fn::pack<int, Error>>;
+
+  // noexcept (extension, expected.hpp:279-282): nothrow invoke AND nothrow value copy; a
+  // multi-argument visitor is not invocable on the whole pack, so conservatively false (GH
+  // #254); a generic callback reports true (int value, nothrow copy)
+  constexpr auto nothrow_two = [](int, Error &) noexcept -> bool { return true; };
+  static_assert(not noexcept(std::declval<S &>().transform_error(nothrow_two)));
+  constexpr auto nothrow_generic = [](auto &&...) noexcept -> bool { return true; };
+  static_assert(noexcept(std::declval<S &>().transform_error(nothrow_generic)));
+
+  // constraints (:283-284): pack-apply invocability -- but NOT the untouched value's copy
+  // (:290), which pfn constrains (pfn/detail/expected_base.hpp:904); see the GAP note in
+  // "expected sum support transform_error"
+  constexpr auto can_te_lval = [](auto &&f) { return requires { std::declval<S &>().transform_error(f); }; };
+  constexpr auto can_te_rval = [](auto &&f) { return requires { std::declval<S &&>().transform_error(f); }; };
+  static_assert(can_te_lval(nothrow_two));
+  static_assert(not can_te_rval(nothrow_two));                      // lvalue-only visitor
+  static_assert(not can_te_lval([](Error &) -> bool { throw 0; })); // wrong arity
+  static_assert(not can_te_lval(42));
+
   WHEN("value")
   {
     fn::expected<int, fn::pack<int, Error>> s{::fn::unexpect, fn::pack{12, FileNotFound}};
@@ -2864,5 +3026,15 @@ TEST_CASE("expected pack support transform_error", "[expected][transform_error][
                 fn::overload{[](int, Error &) -> bool { throw 0; }, [](int, Error const &) -> bool { throw 0; },
                              [](int, Error &&) -> bool { return true; }, [](int, Error const &&) -> bool { throw 0; }})
             .error());
+  }
+
+  WHEN("constexpr")
+  {
+    constexpr S a{::fn::unexpect, fn::pack{12, FileNotFound}};
+    static_assert(
+        a.transform_error([](int i, Error const &e) -> bool { return i == 12 && e == FileNotFound; }).error());
+    constexpr S b{1};
+    static_assert(b.transform_error([](auto &&...) -> bool { throw 0; }).value() == 1);
+    SUCCEED();
   }
 }

--- a/tests/fn/expected.cpp
+++ b/tests/fn/expected.cpp
@@ -130,6 +130,13 @@ TEST_CASE("graded monad", "[expected][sum][graded][and_then][or_else][sum_value]
     static_assert(std::is_same_v<decltype(std::as_const(s).sum_error()), T const &>);
     static_assert(std::is_same_v<decltype(std::move(std::as_const(s)).sum_error()), T const &&>);
     static_assert(std::is_same_v<decltype(std::move(s).sum_error()), T &&>);
+    // GAP: these overloads return *this by reference but are not declared noexcept
+    // (include/fn/expected.hpp:649-664; issue #276 -- filed for sum_value, sum_error is the
+    // same gap); asserts current behaviour until fixed.
+    static_assert(not noexcept(s.sum_error()));
+    static_assert(not noexcept(std::as_const(s).sum_error()));
+    static_assert(not noexcept(std::move(std::as_const(s)).sum_error()));
+    static_assert(not noexcept(std::move(s).sum_error()));
     WHEN("value")
     {
       CHECK(s.sum_error().value() == 12);
@@ -157,6 +164,12 @@ TEST_CASE("graded monad", "[expected][sum][graded][and_then][or_else][sum_value]
     static_assert(std::is_same_v<decltype(std::as_const(s).sum_error()), fn::expected<int, fn::sum<Error>>>);
     static_assert(std::is_same_v<decltype(std::move(std::as_const(s)).sum_error()), fn::expected<int, fn::sum<Error>>>);
     static_assert(std::is_same_v<decltype(std::move(s).sum_error()), fn::expected<int, fn::sum<Error>>>);
+    // GAP: sum_error() here wraps into a fresh expected and is likewise not declared noexcept
+    // (include/fn/expected.hpp:631/640, issue #276), even for nothrow value and error types.
+    static_assert(not noexcept(s.sum_error()));
+    static_assert(not noexcept(std::as_const(s).sum_error()));
+    static_assert(not noexcept(std::move(std::as_const(s)).sum_error()));
+    static_assert(not noexcept(std::move(s).sum_error()));
     WHEN("value")
     {
       CHECK(s.sum_error().value() == 12);
@@ -185,6 +198,12 @@ TEST_CASE("graded monad", "[expected][sum][graded][and_then][or_else][sum_value]
     static_assert(
         std::is_same_v<decltype(std::move(std::as_const(s)).sum_error()), fn::expected<void, fn::sum<Error>>>);
     static_assert(std::is_same_v<decltype(std::move(s).sum_error()), fn::expected<void, fn::sum<Error>>>);
+    // GAP: the void-value constructing overloads are not declared noexcept either
+    // (include/fn/expected.hpp:970/979, issue #276).
+    static_assert(not noexcept(s.sum_error()));
+    static_assert(not noexcept(std::as_const(s).sum_error()));
+    static_assert(not noexcept(std::move(std::as_const(s)).sum_error()));
+    static_assert(not noexcept(std::move(s).sum_error()));
     WHEN("value")
     {
       CHECK(s.sum_error().has_value());
@@ -212,6 +231,12 @@ TEST_CASE("graded monad", "[expected][sum][graded][and_then][or_else][sum_value]
     static_assert(std::is_same_v<decltype(std::as_const(s).sum_error()), T const &>);
     static_assert(std::is_same_v<decltype(std::move(std::as_const(s)).sum_error()), T const &&>);
     static_assert(std::is_same_v<decltype(std::move(s).sum_error()), T &&>);
+    // GAP: the void-value self-return overloads are not declared noexcept either
+    // (include/fn/expected.hpp:988-1003, issue #276).
+    static_assert(not noexcept(s.sum_error()));
+    static_assert(not noexcept(std::as_const(s).sum_error()));
+    static_assert(not noexcept(std::move(std::as_const(s)).sum_error()));
+    static_assert(not noexcept(std::move(s).sum_error()));
     WHEN("value")
     {
       CHECK(s.sum_error().has_value());
@@ -239,6 +264,12 @@ TEST_CASE("graded monad", "[expected][sum][graded][and_then][or_else][sum_value]
     static_assert(std::is_same_v<decltype(std::as_const(s).sum_value()), T const &>);
     static_assert(std::is_same_v<decltype(std::move(std::as_const(s)).sum_value()), T const &&>);
     static_assert(std::is_same_v<decltype(std::move(s).sum_value()), T &&>);
+    // GAP: these overloads return *this by reference but are not declared noexcept
+    // (include/fn/expected.hpp:688-703, issue #276); asserts current behaviour until fixed.
+    static_assert(not noexcept(s.sum_value()));
+    static_assert(not noexcept(std::as_const(s).sum_value()));
+    static_assert(not noexcept(std::move(std::as_const(s)).sum_value()));
+    static_assert(not noexcept(std::move(s).sum_value()));
     WHEN("value")
     {
       CHECK(s.sum_value().value() == fn::sum{12});
@@ -266,6 +297,12 @@ TEST_CASE("graded monad", "[expected][sum][graded][and_then][or_else][sum_value]
     static_assert(std::is_same_v<decltype(std::as_const(s).sum_value()), fn::expected<fn::sum<int>, Error>>);
     static_assert(std::is_same_v<decltype(std::move(std::as_const(s)).sum_value()), fn::expected<fn::sum<int>, Error>>);
     static_assert(std::is_same_v<decltype(std::move(s).sum_value()), fn::expected<fn::sum<int>, Error>>);
+    // GAP: sum_value() here wraps into a fresh expected and is likewise not declared noexcept
+    // (include/fn/expected.hpp:670/679, issue #276), even for nothrow value and error types.
+    static_assert(not noexcept(s.sum_value()));
+    static_assert(not noexcept(std::as_const(s).sum_value()));
+    static_assert(not noexcept(std::move(std::as_const(s)).sum_value()));
+    static_assert(not noexcept(std::move(s).sum_value()));
     WHEN("value")
     {
       CHECK(s.sum_value().value() == fn::sum{12});
@@ -283,6 +320,20 @@ TEST_CASE("graded monad", "[expected][sum][graded][and_then][or_else][sum_value]
     }
 
     static_assert(std::is_same_v<decltype(fn::sum_value(s)), fn::expected<fn::sum<int>, Error>>);
+  }
+
+  WHEN("sum_value absent for void value")
+  {
+    // by design: a void value cannot be sum-wrapped -- the void specialization has no
+    // sum_value member and the free fn::sum_value is constrained some_expected_non_void
+    // (include/fn/expected.hpp:1020); sum_error, by contrast, serves void (asserted above)
+    constexpr auto can_member_sum_value = [](auto &&e) { return requires { e.sum_value(); }; };
+    constexpr auto can_free_sum_value = [](auto &&e) { return requires { fn::sum_value(e); }; };
+    static_assert(not can_member_sum_value(fn::expected<void, Error>{}));
+    static_assert(not can_free_sum_value(fn::expected<void, Error>{}));
+    static_assert(can_member_sum_value(fn::expected<int, Error>{1}));
+    static_assert(can_free_sum_value(fn::expected<int, Error>{1}));
+    SUCCEED();
   }
 
   WHEN("and_then")
@@ -717,6 +768,25 @@ TEST_CASE("expected pack support", "[expected][pack][and_then][transform][operat
 {
   WHEN("and_then")
   {
+    using S = fn::expected<fn::pack<int, std::string_view>, Error>;
+
+    // noexcept (extension, expected.hpp:77-81): a multi-argument visitor is not invocable on
+    // the whole pack, so the borrowed std trait is conservatively false (GH #254); a generic
+    // same-error-type callback IS, and reports true
+    constexpr auto nothrow_two = [](int &, std::string_view &) noexcept -> fn::expected<bool, Error> { return {true}; };
+    static_assert(not noexcept(std::declval<S &>().and_then(nothrow_two)));
+    constexpr auto nothrow_generic = [](auto &&...) noexcept -> fn::expected<bool, Error> { return {true}; };
+    static_assert(noexcept(std::declval<S &>().and_then(nothrow_generic)));
+
+    // constraints (extension, :82-83): pack-apply invocability tracking the pack's value
+    // category; wrong arity or a non-callable SFINAE-drops
+    constexpr auto can_and_then_lval = [](auto &&f) { return requires { std::declval<S &>().and_then(f); }; };
+    constexpr auto can_and_then_rval = [](auto &&f) { return requires { std::declval<S &&>().and_then(f); }; };
+    static_assert(can_and_then_lval(nothrow_two));
+    static_assert(not can_and_then_rval(nothrow_two));                                         // lvalue-only visitor
+    static_assert(not can_and_then_lval([](int &) -> fn::expected<bool, Error> { throw 0; })); // wrong arity
+    static_assert(not can_and_then_lval(42));
+
     WHEN("value")
     {
       fn::expected<fn::pack<int, std::string_view>, Error> s{
@@ -778,6 +848,21 @@ TEST_CASE("expected pack support", "[expected][pack][and_then][transform][operat
 
   WHEN("transform")
   {
+    using S = fn::expected<fn::pack<int, std::string_view>, Error>;
+
+    // noexcept and constraints mirror and_then above (expected.hpp:216-220): the non-sum
+    // _transform is constrained on pack-apply invocability AND the untouched error's copy --
+    // contrast the sum case (see "expected sum support transform")
+    constexpr auto nothrow_two = [](int &, std::string_view &) noexcept -> bool { return true; };
+    static_assert(not noexcept(std::declval<S &>().transform(nothrow_two)));
+    constexpr auto nothrow_generic = [](auto &&...) noexcept -> bool { return true; };
+    static_assert(noexcept(std::declval<S &>().transform(nothrow_generic)));
+
+    constexpr auto can_transform = [](auto &&f) { return requires { std::declval<S &>().transform(f); }; };
+    static_assert(can_transform(nothrow_two));
+    static_assert(not can_transform([](int &) -> bool { throw 0; })); // wrong arity
+    static_assert(not can_transform(42));
+
     WHEN("value")
     {
       fn::expected<fn::pack<int, std::string_view>, Error> s{
@@ -857,6 +942,25 @@ TEST_CASE("expected pack support", "[expected][pack][and_then][transform][operat
 
   WHEN("operator &")
   {
+    // noexcept: all eight operator& overloads are declared unconditionally noexcept
+    // (expected.hpp:1032-1183) though joining copies/moves the operands' values into the
+    // result -- for a throwing-copy value type this is a promise the join cannot keep. GAP:
+    // asserts current behaviour; flip to `not noexcept` when fixed.
+    struct throwing_copy {
+      // defined, not just declared: the instantiated join references it (-Wundefined-internal)
+      throwing_copy(throwing_copy const &) noexcept(false) {}
+    };
+    static_assert(noexcept(std::declval<fn::expected<int, Error> &>() & std::declval<fn::expected<void, Error> &>()));
+    static_assert(
+        noexcept(std::declval<fn::expected<throwing_copy, Error> &>() & std::declval<fn::expected<int, Error> &>()));
+
+    // constraints: both operands are expected, and their error types must match or be graded
+    constexpr auto can_amp = [](auto &&rh) { return requires { std::declval<fn::expected<int, Error> &>() & rh; }; };
+    static_assert(can_amp(fn::expected<void, Error>{}));
+    static_assert(not can_amp(42));
+    enum class other_error {};
+    static_assert(not can_amp(fn::expected<int, other_error>{1})); // mismatched non-graded error
+
     WHEN("same error type")
     {
       WHEN("value & void yield value")
@@ -2200,6 +2304,18 @@ TEST_CASE("expected pack support", "[expected][pack][and_then][transform][operat
         CHECK((Rh{5} & VoidUnit{}).value() == 5);
         CHECK((Rh{::fn::unexpect, FileNotFound} & VoidUnit{}).error() == fn::sum{FileNotFound});
       }
+    }
+
+    WHEN("constexpr")
+    {
+      // the graded/unit shapes have constant-evaluation asserts above; these cover the plain
+      // same-error shapes, which had none
+      static_assert((fn::expected<double, Error>{0.5} & fn::expected<int, Error>{12})
+                        .transform([](double d, int i) constexpr -> bool { return d == 0.5 && i == 12; })
+                        .value());
+      static_assert((fn::expected<double, Error>{::fn::unexpect, FileNotFound} & fn::expected<int, Error>{12}).error()
+                    == FileNotFound);
+      SUCCEED();
     }
   }
 }

--- a/tests/fn/fail.cpp
+++ b/tests/fn/fail.cpp
@@ -322,6 +322,23 @@ TEST_CASE("fail", "[fail][optional][pack]")
   }
 }
 
+TEST_CASE("fail noexcept", "[fail][noexcept]")
+{
+  using namespace fn;
+
+  constexpr auto fnThrows = [](int) noexcept(false) -> Error { return {}; };
+  constexpr auto fnThrows0 = []() noexcept(false) -> Error { return {}; };
+  constexpr auto fnThrowsOpt = [](int) noexcept(false) -> void {};
+
+  // GAP #285: as with recover, the apply invokes the callback and constructs the failed result from
+  // what comes back, both under an unconditional noexcept, with no member spec behind it.
+  static_assert(noexcept(fail_t::apply{}(std::declval<fn::expected<int, Error> &>(), fnThrows)));
+  static_assert(noexcept(fail_t::apply{}(std::declval<fn::expected<void, Error> &>(), fnThrows0)));
+  static_assert(noexcept(fail_t::apply{}(std::declval<fn::optional<int> &>(), fnThrowsOpt)));
+
+  SUCCEED();
+}
+
 TEST_CASE("constexpr fail expected", "[fail][constexpr][expected]")
 {
   enum class Error { ThresholdExceeded, SomethingElse };

--- a/tests/fn/fail.cpp
+++ b/tests/fn/fail.cpp
@@ -66,16 +66,16 @@ TEST_CASE("fail", "[fail][expected][expected_value][pack]")
   static_assert(is::not_invocable_with_any([]() -> Error { throw 0; }));            // bad arity
   static_assert(is::not_invocable_with_any([](int, int) -> Error { throw 0; }));    // bad arity
 
-  WHEN("operand is lvalue")
+  SECTION("lvalue")
   {
-    WHEN("operand is value")
+    SECTION("value")
     {
       operand_t a{std::in_place, 12};
       using T = decltype(a | fail(fnValue));
       static_assert(std::is_same_v<T, operand_t>);
       REQUIRE((a | fail(fnValue)).error().what == "Got 12");
     }
-    WHEN("operand is error")
+    SECTION("error")
     {
       operand_t a{::fn::unexpect, Error{"Not good"}};
       using T = decltype(a | fail(wrong));
@@ -86,7 +86,7 @@ TEST_CASE("fail", "[fail][expected][expected_value][pack]")
                   .what
               == "Not good");
     }
-    WHEN("calling member function")
+    SECTION("member function")
     {
       using operand_t = fn::expected<Value, Error>;
       operand_t a{std::in_place, Value{12}};
@@ -96,10 +96,10 @@ TEST_CASE("fail", "[fail][expected][expected_value][pack]")
     }
   }
 
-  WHEN("operand is pack")
+  SECTION("pack")
   {
     using operand_t = fn::expected<fn::pack<int, double>, Error>;
-    WHEN("operand is value")
+    SECTION("value")
     {
       operand_t a{std::in_place, fn::pack{84, 0.5}};
       constexpr auto fnPack = [](int i, double d) constexpr -> Error {
@@ -110,22 +110,22 @@ TEST_CASE("fail", "[fail][expected][expected_value][pack]")
       REQUIRE((a | fail(fnPack)).error().what == "Got 84 and 0.500000");
     }
 
-    WHEN("operand is error")
+    SECTION("error")
     {
       constexpr auto wrong = [](auto...) -> Error { throw 0; };
       REQUIRE((operand_t{::fn::unexpect, Error{"Not good"}} | fail(wrong)).error().what == "Not good");
     }
   }
 
-  WHEN("operand is rvalue")
+  SECTION("rvalue")
   {
-    WHEN("operand is value")
+    SECTION("value")
     {
       using T = decltype(operand_t{std::in_place, 12} | fail(fnValue));
       static_assert(std::is_same_v<T, operand_t>);
       REQUIRE((operand_t{std::in_place, 12} | fail(fnValue)).error().what == "Got 12");
     }
-    WHEN("operand is error")
+    SECTION("error")
     {
       using T = decltype(operand_t{::fn::unexpect, Error{"Not good"}} | fail(wrong));
       static_assert(std::is_same_v<T, operand_t>);
@@ -135,12 +135,47 @@ TEST_CASE("fail", "[fail][expected][expected_value][pack]")
                   .what
               == "Not good");
     }
-    WHEN("calling member function")
+    SECTION("member function")
     {
       using operand_t = fn::expected<Value, Error>;
       using T = decltype(operand_t{std::in_place, Value{12}} | fail(&Value::fn));
       static_assert(std::is_same_v<T, operand_t>);
       REQUIRE((operand_t{std::in_place, Value{12}} | fail(&Value::fn)).error().what == "Was 12");
+    }
+  }
+
+  SECTION("constexpr")
+  {
+    enum class Error { ThresholdExceeded, SomethingElse };
+    using T = fn::expected<int, Error>;
+    constexpr auto fn = [](int i) constexpr noexcept -> Error {
+      if (i < 3)
+        return Error::SomethingElse;
+      return Error::ThresholdExceeded;
+    };
+    constexpr auto r1 = T{0} | fn::fail(fn);
+    static_assert(r1.error() == Error::SomethingElse);
+    constexpr auto r2 = T{3} | fn::fail(fn);
+    static_assert(r2.error() == Error::ThresholdExceeded);
+
+    SUCCEED();
+
+    SECTION("sum")
+    {
+      enum class Error { ThresholdExceeded, SomethingElse, Reserved };
+      using T = fn::expected<fn::sum_for<Value, int>, Error>;
+      constexpr auto fn = fn::overload{[](int) constexpr noexcept -> Error { return Error::ThresholdExceeded; },
+                                       [](Value const &) { return Error::SomethingElse; }};
+      constexpr auto r1 = T{0} | fn::fail(fn);
+      static_assert(r1.error() == Error::ThresholdExceeded);
+      constexpr auto r2 = T{Value{13}} | fn::fail(fn);
+      static_assert(r2.error() == Error::SomethingElse);
+      constexpr auto r3 = T{3} | fn::fail(fn);
+      static_assert(r3.error() == Error::ThresholdExceeded);
+      constexpr auto r4 = T{::fn::unexpect, Error::Reserved} | fn::fail(fn);
+      static_assert(r4.error() == Error::Reserved);
+
+      SUCCEED();
     }
   }
 }
@@ -170,16 +205,16 @@ TEST_CASE("fail", "[fail][expected][expected_void]")
   static_assert(is::not_invocable_with_any([](int) -> Error { throw 0; }));           // bad arity
   static_assert(is::not_invocable_with_any([](int, int) -> Error { throw 0; }));      // bad arity
 
-  WHEN("operand is lvalue")
+  SECTION("lvalue")
   {
-    WHEN("operand is value")
+    SECTION("value")
     {
       operand_t a{std::in_place};
       using T = decltype(a | fail(fnValue));
       static_assert(std::is_same_v<T, operand_t>);
       REQUIRE((a | fail(fnValue)).error().what == "Got 1");
     }
-    WHEN("operand is error")
+    SECTION("error")
     {
       operand_t a{::fn::unexpect, Error{"Not good"}};
       using T = decltype(a | fail(wrong));
@@ -192,15 +227,15 @@ TEST_CASE("fail", "[fail][expected][expected_void]")
     }
   }
 
-  WHEN("operand is rvalue")
+  SECTION("rvalue")
   {
-    WHEN("operand is value")
+    SECTION("value")
     {
       using T = decltype(operand_t{std::in_place} | fail(fnValue));
       static_assert(std::is_same_v<T, operand_t>);
       REQUIRE((operand_t{std::in_place} | fail(fnValue)).error().what == "Got 1");
     }
-    WHEN("operand is error")
+    SECTION("error")
     {
       using T = decltype(operand_t{::fn::unexpect, Error{"Not good"}} | fail(wrong));
       static_assert(std::is_same_v<T, operand_t>);
@@ -240,9 +275,9 @@ TEST_CASE("fail", "[fail][optional][pack]")
   static_assert(is::not_invocable_with_any([]() { throw 0; }));                                // bad arity
   static_assert(is::not_invocable_with_any([](int, int) { throw 0; }));                        // bad arity
 
-  WHEN("operand is lvalue")
+  SECTION("lvalue")
   {
-    WHEN("operand is value")
+    SECTION("value")
     {
       operand_t a{12};
       using T = decltype(a | fail(fnValue));
@@ -250,7 +285,7 @@ TEST_CASE("fail", "[fail][optional][pack]")
       REQUIRE(not(a | fail(fnValue)).has_value());
       CHECK(count == 1);
     }
-    WHEN("operand is error")
+    SECTION("error")
     {
       operand_t a{std::nullopt};
       using T = decltype(a | fail(wrong));
@@ -258,7 +293,7 @@ TEST_CASE("fail", "[fail][optional][pack]")
       REQUIRE(not(a | fail(wrong)).has_value());
       CHECK(count == 0);
     }
-    WHEN("calling member function")
+    SECTION("member function")
     {
       using operand_t = fn::optional<Value>;
       operand_t a{std::in_place, Value{12}};
@@ -270,10 +305,10 @@ TEST_CASE("fail", "[fail][optional][pack]")
     }
   }
 
-  WHEN("operand is pack")
+  SECTION("pack")
   {
     using operand_t = fn::optional<fn::pack<int, double>>;
-    WHEN("operand is value")
+    SECTION("value")
     {
       operand_t a{std::in_place, fn::pack{84, 0.5}};
       std::string what;
@@ -285,23 +320,23 @@ TEST_CASE("fail", "[fail][optional][pack]")
       CHECK(what == "Got 84 and 0.500000");
     }
 
-    WHEN("operand is error")
+    SECTION("error")
     {
       constexpr auto wrong = [](auto...) -> void { throw 0; };
       REQUIRE(not(operand_t{std::nullopt} | fail(wrong)).has_value());
     }
   }
 
-  WHEN("operand is rvalue")
+  SECTION("rvalue")
   {
-    WHEN("operand is value")
+    SECTION("value")
     {
       using T = decltype(operand_t{std::in_place, 12} | fail(fnValue));
       static_assert(std::is_same_v<T, operand_t>);
       REQUIRE(not(operand_t{std::in_place, 12} | fail(fnValue)).has_value());
       CHECK(count == 1);
     }
-    WHEN("operand is error")
+    SECTION("error")
     {
       using T = decltype(operand_t{std::nullopt} | fail(wrong));
       static_assert(std::is_same_v<T, operand_t>);
@@ -310,7 +345,7 @@ TEST_CASE("fail", "[fail][optional][pack]")
                      .has_value());
       CHECK(count == 0);
     }
-    WHEN("calling member function")
+    SECTION("member function")
     {
       using operand_t = fn::optional<Value>;
       using T = decltype(operand_t{std::in_place, Value{12}} | fail(&Value::finalize));
@@ -318,6 +353,29 @@ TEST_CASE("fail", "[fail][optional][pack]")
       auto const before = Value::count;
       REQUIRE(not(operand_t{std::in_place, Value{12}} | fail(&Value::finalize)).has_value());
       CHECK(Value::count == before + 12);
+    }
+  }
+
+  SECTION("constexpr")
+  {
+    using T = fn::optional<int>;
+    constexpr auto fn = [](int) constexpr noexcept -> void {};
+    constexpr auto r1 = T{0} | fn::fail(fn);
+    static_assert(not r1.has_value());
+
+    SUCCEED();
+
+    SECTION("sum")
+    {
+      using T = fn::optional<fn::sum_for<Value, int>>;
+      constexpr auto fn
+          = fn::overload{[](int) constexpr noexcept -> void {}, [](Value const &) constexpr noexcept -> void {}};
+      constexpr auto r1 = T{0} | fn::fail(fn);
+      static_assert(not r1.has_value());
+      constexpr auto r2 = T{Value{12}} | fn::fail(fn);
+      static_assert(not r2.has_value());
+
+      SUCCEED();
     }
   }
 }
@@ -335,64 +393,6 @@ TEST_CASE("fail noexcept", "[fail][noexcept]")
   static_assert(noexcept(fail_t::apply{}(std::declval<fn::expected<int, Error> &>(), fnThrows)));
   static_assert(noexcept(fail_t::apply{}(std::declval<fn::expected<void, Error> &>(), fnThrows0)));
   static_assert(noexcept(fail_t::apply{}(std::declval<fn::optional<int> &>(), fnThrowsOpt)));
-
-  SUCCEED();
-}
-
-TEST_CASE("constexpr fail expected", "[fail][constexpr][expected]")
-{
-  enum class Error { ThresholdExceeded, SomethingElse };
-  using T = fn::expected<int, Error>;
-  constexpr auto fn = [](int i) constexpr noexcept -> Error {
-    if (i < 3)
-      return Error::SomethingElse;
-    return Error::ThresholdExceeded;
-  };
-  constexpr auto r1 = T{0} | fn::fail(fn);
-  static_assert(r1.error() == Error::SomethingElse);
-  constexpr auto r2 = T{3} | fn::fail(fn);
-  static_assert(r2.error() == Error::ThresholdExceeded);
-
-  SUCCEED();
-}
-
-TEST_CASE("constexpr fail expected with sum", "[fail][constexpr][expected][sum]")
-{
-  enum class Error { ThresholdExceeded, SomethingElse, Reserved };
-  using T = fn::expected<fn::sum_for<Value, int>, Error>;
-  constexpr auto fn = fn::overload{[](int) constexpr noexcept -> Error { return Error::ThresholdExceeded; },
-                                   [](Value const &) { return Error::SomethingElse; }};
-  constexpr auto r1 = T{0} | fn::fail(fn);
-  static_assert(r1.error() == Error::ThresholdExceeded);
-  constexpr auto r2 = T{Value{13}} | fn::fail(fn);
-  static_assert(r2.error() == Error::SomethingElse);
-  constexpr auto r3 = T{3} | fn::fail(fn);
-  static_assert(r3.error() == Error::ThresholdExceeded);
-  constexpr auto r4 = T{::fn::unexpect, Error::Reserved} | fn::fail(fn);
-  static_assert(r4.error() == Error::Reserved);
-
-  SUCCEED();
-}
-
-TEST_CASE("constexpr fail optional", "[fail][constexpr][optional]")
-{
-  using T = fn::optional<int>;
-  constexpr auto fn = [](int) constexpr noexcept -> void {};
-  constexpr auto r1 = T{0} | fn::fail(fn);
-  static_assert(not r1.has_value());
-
-  SUCCEED();
-}
-
-TEST_CASE("constexpr fail optional with sum", "[fail][constexpr][optional][sum]")
-{
-  using T = fn::optional<fn::sum_for<Value, int>>;
-  constexpr auto fn
-      = fn::overload{[](int) constexpr noexcept -> void {}, [](Value const &) constexpr noexcept -> void {}};
-  constexpr auto r1 = T{0} | fn::fail(fn);
-  static_assert(not r1.has_value());
-  constexpr auto r2 = T{Value{12}} | fn::fail(fn);
-  static_assert(not r2.has_value());
 
   SUCCEED();
 }

--- a/tests/fn/filter.cpp
+++ b/tests/fn/filter.cpp
@@ -589,6 +589,24 @@ TEST_CASE("filter member function", "[filter][optional]")
   }
 }
 
+TEST_CASE("filter noexcept", "[filter][noexcept]")
+{
+  using namespace fn;
+
+  constexpr auto predThrows = [](int) noexcept(false) -> bool { return true; };
+  constexpr auto onErrThrows = [](int) noexcept(false) -> Error { return {}; };
+  constexpr auto predThrows0 = []() noexcept(false) -> bool { return true; };
+  constexpr auto onErrThrows0 = []() noexcept(false) -> Error { return {}; };
+
+  // GAP #285: filter's apply is the implementation, and it has three ways to throw that it promises
+  // nothing about - the predicate, the on-error callback, and constructing the result - all under an
+  // unconditional noexcept. It is the widest instance of the defect among the verbs.
+  static_assert(noexcept(filter_t::apply{}(std::declval<fn::expected<int, Error> &>(), predThrows, onErrThrows)));
+  static_assert(noexcept(filter_t::apply{}(std::declval<fn::expected<void, Error> &>(), predThrows0, onErrThrows0)));
+
+  SUCCEED();
+}
+
 TEST_CASE("constexpr filter expected", "[filter][constexpr][expected]")
 {
   enum class Error { ThresholdExceeded, SomethingElse };

--- a/tests/fn/filter.cpp
+++ b/tests/fn/filter.cpp
@@ -673,3 +673,33 @@ TEST_CASE("filter noexcept", "[filter][noexcept]")
 
   SUCCEED();
 }
+
+namespace fn {
+namespace {
+struct Error {};
+struct Value final {};
+
+constexpr auto pred_int = [](int) -> bool { throw 0; };
+constexpr auto pred_int_lvalue = [](int &) -> bool { throw 0; };
+constexpr auto pred_nullary = []() -> bool { throw 0; };
+constexpr auto pred_opaque = [](int) -> Value { throw 0; }; // not convertible to bool
+template <typename T> constexpr auto err_int = [](int) -> T { throw 0; };
+template <typename T> constexpr auto err_nullary = []() -> T { throw 0; };
+} // namespace
+
+// clang-format off
+static_assert(invocable_filter<decltype(pred_int), decltype(err_int<Error>), expected<int, Error>>);
+static_assert(not invocable_filter<decltype(pred_opaque), decltype(err_int<Error>), expected<int, Error>>);   // predicate must convert to bool
+static_assert(not invocable_filter<decltype(pred_int), decltype(err_int<Value>), expected<int, Error>>);      // no conversion to error
+static_assert(not invocable_filter<decltype(pred_nullary), decltype(err_int<Error>), expected<int, Error>>);  // bad arity
+// The predicate sees the value as const, whatever the operand's category.
+static_assert(not invocable_filter<decltype(pred_int_lvalue), decltype(err_int<Error>), expected<int, Error> &>);
+static_assert(invocable_filter<decltype(pred_nullary), decltype(err_nullary<Error>), expected<void, Error>>);
+static_assert(not invocable_filter<decltype(pred_int), decltype(err_int<Error>), expected<void, Error>>);     // void: nullary only
+// filter over optional takes NO error callback: the Err parameter is void, and only void.
+static_assert(invocable_filter<decltype(pred_int), void, optional<int>>);
+static_assert(not invocable_filter<decltype(pred_int), decltype(err_int<Error>), optional<int>>);
+static_assert(not invocable_filter<decltype(pred_int), void, optional<Value>>);                               // wrong parameter type
+static_assert(not invocable_filter<decltype(pred_int), void, choice<int>>);                                   // no choice disjunct
+// clang-format on
+} // namespace fn

--- a/tests/fn/filter.cpp
+++ b/tests/fn/filter.cpp
@@ -20,6 +20,15 @@ struct Error {
 };
 struct DerivedError : Error {};
 struct IncompatibleError {};
+
+struct Value final {
+  int v;
+
+  constexpr bool ok() const noexcept { return v < 2; }
+  constexpr bool operator==(Value const &) const = default;
+  Error error() const { return {"Got " + std::to_string(v)}; }
+  Error error_() { return {"Got " + std::to_string(v)}; }
+};
 } // namespace
 
 TEST_CASE("filter", "[filter][expected][expected_value]")
@@ -61,11 +70,11 @@ TEST_CASE("filter", "[filter][expected][expected_value]")
   static_assert(e_is::not_invocable_with_any([]() -> Error { throw 0; }));                                // bad arity
   static_assert(e_is::not_invocable_with_any([](int, int) -> Error { throw 0; }));                        // bad arity
 
-  WHEN("operand is lvalue")
+  SECTION("lvalue")
   {
-    WHEN("operand is value")
+    SECTION("value")
     {
-      WHEN("predicate returns true")
+      SECTION("predicate true")
       {
         operand_t a{std::in_place, 42};
         using T = decltype(a | filter(truePred, onError));
@@ -74,7 +83,7 @@ TEST_CASE("filter", "[filter][expected][expected_value]")
         REQUIRE((a | filter(truePred, onError)).value() == 42);
       }
 
-      WHEN("predicate returns false")
+      SECTION("predicate false")
       {
         operand_t a{std::in_place, 42};
         using T = decltype(a | filter(falsePred, onError));
@@ -84,7 +93,7 @@ TEST_CASE("filter", "[filter][expected][expected_value]")
       }
     }
 
-    WHEN("operand is error")
+    SECTION("error")
     {
       operand_t a{::fn::unexpect, Error{"Not good"}};
       using T = decltype(a | filter(truePred, wrong));
@@ -98,11 +107,11 @@ TEST_CASE("filter", "[filter][expected][expected_value]")
     }
   }
 
-  WHEN("operand is rvalue")
+  SECTION("rvalue")
   {
-    WHEN("operand is value")
+    SECTION("value")
     {
-      WHEN("predicate returns true")
+      SECTION("predicate true")
       {
         using T = decltype(operand_t{std::in_place, 42} | filter(truePred, onError));
         static_assert(std::is_same_v<T, operand_t>);
@@ -110,7 +119,7 @@ TEST_CASE("filter", "[filter][expected][expected_value]")
         REQUIRE((operand_t{std::in_place, 42} | filter(truePred, onError)).value() == 42);
       }
 
-      WHEN("predicate returns false")
+      SECTION("predicate false")
       {
         using T = decltype(operand_t{std::in_place, 42} | filter(falsePred, onError));
         static_assert(std::is_same_v<T, operand_t>);
@@ -119,7 +128,7 @@ TEST_CASE("filter", "[filter][expected][expected_value]")
       }
     }
 
-    WHEN("operand is error")
+    SECTION("error")
     {
       using T = decltype(operand_t{::fn::unexpect, Error{"Not good"}} | filter(truePred, wrong));
       static_assert(std::is_same_v<T, operand_t>);
@@ -131,18 +140,43 @@ TEST_CASE("filter", "[filter][expected][expected_value]")
               == "Not good");
     }
   }
+
+  SECTION("constexpr")
+  {
+    enum class Error { ThresholdExceeded, SomethingElse };
+    using T = fn::expected<int, Error>;
+
+    constexpr auto fn = [](int i) constexpr noexcept -> bool { return i < 3; };
+    constexpr auto error = [](int) -> Error { return Error::ThresholdExceeded; };
+    constexpr auto r1 = T{0} | fn::filter(fn, error);
+    static_assert(r1.value() == 0);
+    constexpr auto r2 = T{3} | fn::filter(fn, error);
+    static_assert(r2.error() == Error::ThresholdExceeded);
+
+    SUCCEED();
+
+    SECTION("sum")
+    {
+      using T = fn::expected<fn::sum_for<Value, int>, Error>;
+
+      constexpr auto fn = fn::overload{[](int i) constexpr noexcept -> bool { return i < 3; },
+                                       [](Value const &v) constexpr noexcept -> bool { return v.v >= 5; }};
+      constexpr auto error = [](auto &&) -> Error { return Error::ThresholdExceeded; };
+      constexpr auto r1 = T{0} | fn::filter(fn, error);
+      static_assert(r1.value() == fn::sum{0});
+      constexpr auto r2 = T{3} | fn::filter(fn, error);
+      static_assert(r2.error() == Error::ThresholdExceeded);
+      constexpr auto r3 = T{Value{0}} | fn::filter(fn, error);
+      static_assert(r3.error() == Error::ThresholdExceeded);
+      constexpr auto r4 = T{Value{5}} | fn::filter(fn, error);
+      static_assert(r4.value() == fn::sum{Value{5}});
+      constexpr auto r5 = T{3} | fn::filter(fn, error);
+      static_assert(r5.error() == Error::ThresholdExceeded);
+
+      SUCCEED();
+    }
+  }
 }
-
-namespace {
-struct Value final {
-  int v;
-
-  constexpr bool ok() const noexcept { return v < 2; }
-  constexpr bool operator==(Value const &) const = default;
-  Error error() const { return {"Got " + std::to_string(v)}; }
-  Error error_() { return {"Got " + std::to_string(v)}; }
-};
-} // namespace
 
 TEST_CASE("filter member function", "[filter][expected][expected_value][member_functions][pack]")
 {
@@ -180,11 +214,11 @@ TEST_CASE("filter member function", "[filter][expected][expected_value][member_f
   static_assert(e_is::not_invocable_with_any([]() -> Error { throw 0; }));                                  // bad arity
   static_assert(e_is::not_invocable_with_any([](Value, int) -> Error { throw 0; }));                        // bad arity
 
-  WHEN("operand is lvalue")
+  SECTION("lvalue")
   {
-    WHEN("operand is value")
+    SECTION("value")
     {
-      WHEN("predicate returns true")
+      SECTION("predicate true")
       {
         operand_t a{std::in_place, Value{1}};
         using T = decltype(a | filter(predicate, onError));
@@ -194,7 +228,7 @@ TEST_CASE("filter member function", "[filter][expected][expected_value][member_f
         REQUIRE((a | filter(predicate, &Value::error_)).value().v == 1);
       }
 
-      WHEN("predicate returns false")
+      SECTION("predicate false")
       {
         operand_t a{std::in_place, Value{42}};
         using T = decltype(a | filter(predicate, onError));
@@ -205,7 +239,7 @@ TEST_CASE("filter member function", "[filter][expected][expected_value][member_f
       }
     }
 
-    WHEN("operand is pack")
+    SECTION("pack")
     {
       using operand_t = fn::expected<fn::pack<int, double>, Error>;
       constexpr operand_t a{std::in_place, fn::pack{84, 0.5}};
@@ -214,11 +248,11 @@ TEST_CASE("filter member function", "[filter][expected][expected_value][member_f
       using T = decltype(a | filter(predPack, errPack));
       static_assert(std::is_same_v<T, operand_t>);
 
-      WHEN("operand is value")
+      SECTION("value")
       {
         REQUIRE((a | filter(predPack, errPack)).has_value());
 
-        WHEN("fail")
+        SECTION("fail")
         {
           constexpr auto fnFail = [](int, double) constexpr -> bool { return false; };
           using T = decltype(a | filter(fnFail, errPack));
@@ -228,13 +262,13 @@ TEST_CASE("filter member function", "[filter][expected][expected_value][member_f
         }
       }
 
-      WHEN("operand is error")
+      SECTION("error")
       {
         REQUIRE((operand_t{::fn::unexpect, Error{"Not good"}} | filter(predPack, errPack)).error().what == "Not good");
       }
     }
 
-    WHEN("operand is error")
+    SECTION("error")
     {
       operand_t a{::fn::unexpect, Error{"Not good"}};
       using T = decltype(a | filter(predicate, wrong));
@@ -248,11 +282,11 @@ TEST_CASE("filter member function", "[filter][expected][expected_value][member_f
     }
   }
 
-  WHEN("operand is rvalue")
+  SECTION("rvalue")
   {
-    WHEN("operand is value")
+    SECTION("value")
     {
-      WHEN("predicate returns true")
+      SECTION("predicate true")
       {
         using T = decltype(operand_t{std::in_place, Value{1}} | filter(predicate, onError));
         static_assert(std::is_same_v<T, operand_t>);
@@ -261,7 +295,7 @@ TEST_CASE("filter member function", "[filter][expected][expected_value][member_f
         REQUIRE((operand_t{std::in_place, Value{1}} | filter(predicate, &Value::error_)).value().v == 1);
       }
 
-      WHEN("predicate returns false")
+      SECTION("predicate false")
       {
         using T = decltype(operand_t{std::in_place, Value{42}} | filter(predicate, onError));
         static_assert(std::is_same_v<T, operand_t>);
@@ -271,7 +305,7 @@ TEST_CASE("filter member function", "[filter][expected][expected_value][member_f
       }
     }
 
-    WHEN("operand is error")
+    SECTION("error")
     {
       using T = decltype(operand_t{::fn::unexpect, Error{"Not good"}} | filter(predicate, wrong));
       static_assert(std::is_same_v<T, operand_t>);
@@ -308,11 +342,11 @@ TEST_CASE("filter", "[filter][expected][expected_void]")
   static_assert(e_is::not_invocable_with_any([](int) -> Error { throw 0; }));      // bad arity
   static_assert(e_is::not_invocable_with_any([](int, int) -> Error { throw 0; })); // bad arity
 
-  WHEN("operand is lvalue")
+  SECTION("lvalue")
   {
-    WHEN("operand is value")
+    SECTION("value")
     {
-      WHEN("predicate returns true")
+      SECTION("predicate true")
       {
         operand_t a{std::in_place};
         using T = decltype(a | filter(truePred, onError));
@@ -321,7 +355,7 @@ TEST_CASE("filter", "[filter][expected][expected_void]")
         REQUIRE((a | filter(truePred, onError)).has_value());
       }
 
-      WHEN("predicate returns false")
+      SECTION("predicate false")
       {
         operand_t a{std::in_place};
         using T = decltype(a | filter(falsePred, onError));
@@ -331,7 +365,7 @@ TEST_CASE("filter", "[filter][expected][expected_void]")
       }
     }
 
-    WHEN("operand is error")
+    SECTION("error")
     {
       operand_t a{::fn::unexpect, Error{"Not good"}};
       using T = decltype(a | filter(truePred, wrong));
@@ -345,11 +379,11 @@ TEST_CASE("filter", "[filter][expected][expected_void]")
     }
   }
 
-  WHEN("operand is rvalue")
+  SECTION("rvalue")
   {
-    WHEN("operand is value")
+    SECTION("value")
     {
-      WHEN("predicate returns true")
+      SECTION("predicate true")
       {
         using T = decltype(operand_t{std::in_place} | filter(truePred, onError));
         static_assert(std::is_same_v<T, operand_t>);
@@ -357,7 +391,7 @@ TEST_CASE("filter", "[filter][expected][expected_void]")
         REQUIRE((operand_t{std::in_place} | filter(truePred, onError)).has_value());
       }
 
-      WHEN("predicate returns false")
+      SECTION("predicate false")
       {
         using T = decltype(operand_t{std::in_place} | filter(falsePred, onError));
         static_assert(std::is_same_v<T, operand_t>);
@@ -366,7 +400,7 @@ TEST_CASE("filter", "[filter][expected][expected_void]")
       }
     }
 
-    WHEN("operand is error")
+    SECTION("error")
     {
       using T = decltype(operand_t{::fn::unexpect, Error{"Not good"}} | filter(truePred, wrong));
       static_assert(std::is_same_v<T, operand_t>);
@@ -415,11 +449,11 @@ TEST_CASE("filter", "[filter][optional]")
   static_assert(is::not_invocable_with_any([]() -> bool { throw 0; }));            // bad arity
   static_assert(is::not_invocable_with_any([](int, int) -> bool { throw 0; }));    // bad arity
 
-  WHEN("operand is lvalue")
+  SECTION("lvalue")
   {
-    WHEN("operand is value")
+    SECTION("value")
     {
-      WHEN("predicate returns true")
+      SECTION("predicate true")
       {
         operand_t a{42};
         using T = decltype(a | filter(truePred));
@@ -428,7 +462,7 @@ TEST_CASE("filter", "[filter][optional]")
         REQUIRE((a | filter(truePred)).has_value());
       }
 
-      WHEN("predicate returns false")
+      SECTION("predicate false")
       {
         operand_t a{42};
         using T = decltype(a | filter(falsePred));
@@ -438,7 +472,7 @@ TEST_CASE("filter", "[filter][optional]")
       }
     }
 
-    WHEN("operand is nullopt")
+    SECTION("nullopt")
     {
       operand_t a{std::nullopt};
       using T = decltype(a | filter(truePred));
@@ -448,7 +482,7 @@ TEST_CASE("filter", "[filter][optional]")
     }
   }
 
-  WHEN("operand is pack")
+  SECTION("pack")
   {
     using operand_t = fn::optional<fn::pack<int, double>>;
     constexpr operand_t a{std::in_place, fn::pack{84, 0.5}};
@@ -456,11 +490,11 @@ TEST_CASE("filter", "[filter][optional]")
     using T = decltype(a | filter(predPack));
     static_assert(std::is_same_v<T, operand_t>);
 
-    WHEN("operand is value")
+    SECTION("value")
     {
       REQUIRE((a | filter(predPack)).has_value());
 
-      WHEN("fail")
+      SECTION("fail")
       {
         constexpr auto fnFail = [](int, double) constexpr -> bool { return false; };
         using T = decltype(a | filter(fnFail));
@@ -470,14 +504,14 @@ TEST_CASE("filter", "[filter][optional]")
       }
     }
 
-    WHEN("operand is nullopt") { REQUIRE(not(operand_t{std::nullopt} | filter(predPack)).has_value()); }
+    SECTION("nullopt") { REQUIRE(not(operand_t{std::nullopt} | filter(predPack)).has_value()); }
   }
 
-  WHEN("operand is rvalue")
+  SECTION("rvalue")
   {
-    WHEN("operand is value")
+    SECTION("value")
     {
-      WHEN("predicate returns true")
+      SECTION("predicate true")
       {
         using T = decltype(operand_t{42} | filter(truePred));
         static_assert(std::is_same_v<T, operand_t>);
@@ -485,7 +519,7 @@ TEST_CASE("filter", "[filter][optional]")
         REQUIRE((operand_t{42} | filter(truePred)).has_value());
       }
 
-      WHEN("predicate returns false")
+      SECTION("predicate false")
       {
         using T = decltype(operand_t{42} | filter(falsePred));
         static_assert(std::is_same_v<T, operand_t>);
@@ -494,7 +528,7 @@ TEST_CASE("filter", "[filter][optional]")
       }
     }
 
-    WHEN("operand is nullopt")
+    SECTION("nullopt")
     {
       using T = decltype(operand_t{std::nullopt} | filter(truePred));
       static_assert(std::is_same_v<T, operand_t>);
@@ -502,6 +536,39 @@ TEST_CASE("filter", "[filter][optional]")
       REQUIRE(not(operand_t{std::nullopt} //
                   | filter(truePred))
                      .has_value());
+    }
+  }
+
+  SECTION("constexpr")
+  {
+    using T = fn::optional<int>;
+
+    constexpr auto fn = [](int i) constexpr noexcept -> bool { return i < 3; };
+    constexpr auto r1 = T{0} | fn::filter(fn);
+    static_assert(r1.value() == 0);
+    constexpr auto r2 = T{3} | fn::filter(fn);
+    static_assert(not r2.has_value());
+
+    SUCCEED();
+
+    SECTION("sum")
+    {
+      using T = fn::optional<fn::sum_for<Value, int>>;
+
+      constexpr auto fn = fn::overload{[](int i) constexpr noexcept -> bool { return i < 3; },
+                                       [](Value const &v) constexpr noexcept -> bool { return v.v >= 5; }};
+      constexpr auto r1 = T{0} | fn::filter(fn);
+      static_assert(r1.value() == fn::sum{0});
+      constexpr auto r2 = T{3} | fn::filter(fn);
+      static_assert(not r2.has_value());
+      constexpr auto r3 = T{Value{0}} | fn::filter(fn);
+      static_assert(not r3.has_value());
+      constexpr auto r4 = T{Value{5}} | fn::filter(fn);
+      static_assert(r4.value() == fn::sum{Value{5}});
+      constexpr auto r5 = T{3} | fn::filter(fn);
+      static_assert(not r5.has_value());
+
+      SUCCEED();
     }
   }
 }
@@ -525,11 +592,11 @@ TEST_CASE("filter member function", "[filter][optional]")
   static_assert(is::not_invocable_with_any([]() -> bool { throw 0; }));            // bad arity
   static_assert(is::not_invocable_with_any([](Value, int) -> bool { throw 0; }));  // bad arity
 
-  WHEN("operand is lvalue")
+  SECTION("lvalue")
   {
-    WHEN("operand is value")
+    SECTION("value")
     {
-      WHEN("predicate returns true")
+      SECTION("predicate true")
       {
         operand_t a{Value{1}};
         using T = decltype(a | filter(predicate));
@@ -537,7 +604,7 @@ TEST_CASE("filter member function", "[filter][optional]")
 
         REQUIRE((a | filter(predicate)).value().v == 1);
       }
-      WHEN("predicate returns false")
+      SECTION("predicate false")
       {
         operand_t a{Value{42}};
         using T = decltype(a | filter(predicate));
@@ -546,7 +613,7 @@ TEST_CASE("filter member function", "[filter][optional]")
         REQUIRE(not(a | filter(predicate)).has_value());
       }
     }
-    WHEN("operand is nullopt")
+    SECTION("nullopt")
     {
       operand_t a{std::nullopt};
       using T = decltype(a | filter(predicate));
@@ -556,11 +623,11 @@ TEST_CASE("filter member function", "[filter][optional]")
     }
   }
 
-  WHEN("operand is rvalue")
+  SECTION("rvalue")
   {
-    WHEN("operand is value")
+    SECTION("value")
     {
-      WHEN("predicate returns true")
+      SECTION("predicate true")
       {
         using T = decltype(operand_t{Value{1}} | filter(predicate));
         static_assert(std::is_same_v<T, operand_t>);
@@ -568,7 +635,7 @@ TEST_CASE("filter member function", "[filter][optional]")
         REQUIRE((operand_t{Value{1}} | filter(predicate)).value().v == 1);
       }
 
-      WHEN("predicate returns false")
+      SECTION("predicate false")
       {
         using T = decltype(operand_t{Value{42}} | filter(predicate));
         static_assert(std::is_same_v<T, operand_t>);
@@ -577,7 +644,7 @@ TEST_CASE("filter member function", "[filter][optional]")
       }
     }
 
-    WHEN("operand is nullopt")
+    SECTION("nullopt")
     {
       using T = decltype(operand_t{std::nullopt} | filter(predicate));
       static_assert(std::is_same_v<T, operand_t>);
@@ -603,76 +670,6 @@ TEST_CASE("filter noexcept", "[filter][noexcept]")
   // unconditional noexcept. It is the widest instance of the defect among the verbs.
   static_assert(noexcept(filter_t::apply{}(std::declval<fn::expected<int, Error> &>(), predThrows, onErrThrows)));
   static_assert(noexcept(filter_t::apply{}(std::declval<fn::expected<void, Error> &>(), predThrows0, onErrThrows0)));
-
-  SUCCEED();
-}
-
-TEST_CASE("constexpr filter expected", "[filter][constexpr][expected]")
-{
-  enum class Error { ThresholdExceeded, SomethingElse };
-  using T = fn::expected<int, Error>;
-
-  constexpr auto fn = [](int i) constexpr noexcept -> bool { return i < 3; };
-  constexpr auto error = [](int) -> Error { return Error::ThresholdExceeded; };
-  constexpr auto r1 = T{0} | fn::filter(fn, error);
-  static_assert(r1.value() == 0);
-  constexpr auto r2 = T{3} | fn::filter(fn, error);
-  static_assert(r2.error() == Error::ThresholdExceeded);
-
-  SUCCEED();
-}
-
-TEST_CASE("constexpr filter expected with sum", "[filter][constexpr][expected][sum]")
-{
-  enum class Error { ThresholdExceeded, SomethingElse };
-  using T = fn::expected<fn::sum_for<Value, int>, Error>;
-
-  constexpr auto fn = fn::overload{[](int i) constexpr noexcept -> bool { return i < 3; },
-                                   [](Value const &v) constexpr noexcept -> bool { return v.v >= 5; }};
-  constexpr auto error = [](auto &&) -> Error { return Error::ThresholdExceeded; };
-  constexpr auto r1 = T{0} | fn::filter(fn, error);
-  static_assert(r1.value() == fn::sum{0});
-  constexpr auto r2 = T{3} | fn::filter(fn, error);
-  static_assert(r2.error() == Error::ThresholdExceeded);
-  constexpr auto r3 = T{Value{0}} | fn::filter(fn, error);
-  static_assert(r3.error() == Error::ThresholdExceeded);
-  constexpr auto r4 = T{Value{5}} | fn::filter(fn, error);
-  static_assert(r4.value() == fn::sum{Value{5}});
-  constexpr auto r5 = T{3} | fn::filter(fn, error);
-  static_assert(r5.error() == Error::ThresholdExceeded);
-
-  SUCCEED();
-}
-
-TEST_CASE("constexpr filter optional", "[filter][constexpr][optional]")
-{
-  using T = fn::optional<int>;
-
-  constexpr auto fn = [](int i) constexpr noexcept -> bool { return i < 3; };
-  constexpr auto r1 = T{0} | fn::filter(fn);
-  static_assert(r1.value() == 0);
-  constexpr auto r2 = T{3} | fn::filter(fn);
-  static_assert(not r2.has_value());
-
-  SUCCEED();
-}
-
-TEST_CASE("constexpr filter optional with sum", "[filter][constexpr][optional][sum]")
-{
-  using T = fn::optional<fn::sum_for<Value, int>>;
-
-  constexpr auto fn = fn::overload{[](int i) constexpr noexcept -> bool { return i < 3; },
-                                   [](Value const &v) constexpr noexcept -> bool { return v.v >= 5; }};
-  constexpr auto r1 = T{0} | fn::filter(fn);
-  static_assert(r1.value() == fn::sum{0});
-  constexpr auto r2 = T{3} | fn::filter(fn);
-  static_assert(not r2.has_value());
-  constexpr auto r3 = T{Value{0}} | fn::filter(fn);
-  static_assert(not r3.has_value());
-  constexpr auto r4 = T{Value{5}} | fn::filter(fn);
-  static_assert(r4.value() == fn::sum{Value{5}});
-  constexpr auto r5 = T{3} | fn::filter(fn);
-  static_assert(not r5.has_value());
 
   SUCCEED();
 }

--- a/tests/fn/functional.cpp
+++ b/tests/fn/functional.cpp
@@ -214,3 +214,35 @@ TEST_CASE("invoke_r sum", "[invoke_r][sum]")
   CHECK(invoke_r<int>(fn, std::move(std::as_const(p))) == 1415);
   CHECK(invoke_r<int>(fn, std::move(p)) == 1415);
 }
+
+TEST_CASE("is_nothrow_invocable", "[is_nothrow_invocable][is_nothrow_invocable_r][invoke][noexcept]")
+{
+  constexpr auto fnNothrow = [](int i) noexcept -> int { return i; };
+  constexpr auto fnThrows = [](int i) noexcept(false) -> int { return i; };
+
+  // GAP #45: these two traits are exported alongside their std counterparts, but their value is
+  // stubbed false - so they answer false for a callable that plainly cannot throw, where std answers
+  // true. They are the only nothrow-invocability oracle fn has, and everything keyed on them inherits
+  // the wrong answer.
+  static_assert(std::is_nothrow_invocable_v<decltype(fnNothrow), int>);
+  static_assert(not fn::is_nothrow_invocable_v<decltype(fnNothrow), int>);
+  static_assert(not fn::is_nothrow_invocable_v<decltype(fnThrows), int>);
+
+  static_assert(std::is_nothrow_invocable_r_v<long, decltype(fnNothrow), int>);
+  static_assert(not fn::is_nothrow_invocable_r_v<long, decltype(fnNothrow), int>);
+
+  // The pack and sum dispatch paths have no std counterpart to fall back on, which is why the traits
+  // exist at all - and there the stub is the whole answer.
+  static_assert(not fn::is_nothrow_invocable_v<decltype(fnNothrow), fn::pack<int>>);
+  static_assert(not fn::is_nothrow_invocable_v<decltype(fnNothrow), fn::sum<int>>);
+
+  // So fn::invoke reports potentially-throwing whatever it is handed. This is the conservative
+  // direction, unlike the verbs, which promise noexcept and terminate (#285) - and it is why the
+  // self-implementing half of those cannot compute an honest spec until #45 lands.
+  static_assert(fn::is_invocable_v<decltype(fnNothrow), int>);
+  static_assert(not noexcept(fn::invoke(fnNothrow, 1)));
+  static_assert(not noexcept(fn::invoke_r<long>(fnNothrow, 1)));
+
+  CHECK(fn::invoke(fnNothrow, 1) == 1);
+  CHECK(fn::invoke_r<long>(fnNothrow, 1) == 1L);
+}

--- a/tests/fn/functor.cpp
+++ b/tests/fn/functor.cpp
@@ -69,7 +69,7 @@ TEST_CASE("user-defined monadic operation", "[functor]")
   CHECK((fn::expected<int, std::runtime_error>{12} | throwing_dummy(fn1)).value() == 13);
   CHECK((fn::optional{42} | throwing_dummy(fn1)).value() == 43);
 
-  WHEN("noexcept")
+  SECTION("noexcept")
   {
     using O = fn::optional<int>;
 

--- a/tests/fn/functor.cpp
+++ b/tests/fn/functor.cpp
@@ -9,6 +9,9 @@
 
 #include <catch2/catch_all.hpp>
 
+#include <type_traits>
+#include <utility>
+
 using namespace util;
 
 namespace {
@@ -23,6 +26,20 @@ constexpr inline struct dummy_t final {
     }
   };
 } dummy = {};
+
+// The same verb, but honestly potentially-throwing. Piping it isolates the machinery's own promise
+// from the verb's: whatever operator| says about this one, the verb did not say it.
+constexpr inline struct throwing_dummy_t final {
+  auto operator()(auto &&fn) const noexcept -> fn::functor<throwing_dummy_t, decltype(fn)> { return {FWD(fn)}; }
+
+  struct apply final {
+    auto operator()(fn::some_monadic_type auto &&v, auto &&fn) const noexcept(false) -> decltype(auto)
+      requires requires { fn(v.value()); }
+    {
+      return FWD(v).transform([&fn](auto &&v) { return FWD(fn)(FWD(v)); });
+    }
+  };
+} throwing_dummy = {};
 
 constexpr auto fn1 = [](int i) constexpr -> int { return i + 1; };
 constexpr auto fn2 = []() constexpr -> int { return 1; };
@@ -48,4 +65,36 @@ TEST_CASE("user-defined monadic operation", "[functor]")
 {
   CHECK((fn::expected<int, std::runtime_error>{12} | dummy(fn1)).value() == 13);
   CHECK((fn::optional{42} | dummy(fn1)).value() == 43);
+
+  CHECK((fn::expected<int, std::runtime_error>{12} | throwing_dummy(fn1)).value() == 13);
+  CHECK((fn::optional{42} | throwing_dummy(fn1)).value() == 43);
+
+  WHEN("noexcept")
+  {
+    using O = fn::optional<int>;
+
+    // GAP #285: the pipeline is unconditionally noexcept at every step - functor::operator| and the
+    // pack's _swap_invoke it dispatches through - and imposes that on whatever verb is piped into
+    // it. throwing_dummy's apply says plainly that it may throw, and operator| overrides it: an
+    // exception escaping the verb would cross the noexcept boundary and terminate. This is the
+    // machinery's promise, not any one verb's, which is why it is asserted here rather than in each
+    // verb's own tests.
+    static_assert(not noexcept(throwing_dummy_t::apply{}(std::declval<O &>(), fn1)));
+    static_assert(noexcept(std::declval<O &>() | throwing_dummy(fn1)));
+    static_assert(noexcept(std::declval<O &&>() | throwing_dummy(fn1)));
+
+    // Building the functor copies the callable into its pack, and that copy can throw as well -
+    // yet the nielbloid's operator() is noexcept too.
+    struct ThrowingCopy final {
+      ThrowingCopy() = default;
+      ThrowingCopy(ThrowingCopy const &) noexcept(false) {}
+      ThrowingCopy(ThrowingCopy &&) noexcept(false) {}
+      auto operator()(int i) const noexcept -> int { return i + 1; }
+    };
+    static_assert(not std::is_nothrow_copy_constructible_v<ThrowingCopy>);
+    static_assert(noexcept(dummy(std::declval<ThrowingCopy const &>())));
+    static_assert(noexcept(std::declval<O &>() | dummy(std::declval<ThrowingCopy const &>())));
+
+    SUCCEED();
+  }
 }

--- a/tests/fn/inspect.cpp
+++ b/tests/fn/inspect.cpp
@@ -376,6 +376,29 @@ TEST_CASE("inspect choice", "[inspect][choice]")
   CHECK(value == 12);
 }
 
+TEST_CASE("inspect noexcept", "[inspect][noexcept]")
+{
+  using namespace fn;
+
+  constexpr auto fnThrows = [](int) noexcept(false) -> void {};
+  constexpr auto fnThrows0 = []() noexcept(false) -> void {};
+  static_assert(not noexcept(fnThrows(1)));
+
+  // GAP #285, and the worse half of it. inspect has no monadic member to delegate to - its apply IS
+  // the implementation, invoking the callback itself (inspect.hpp:61-69). So unlike and_then, there
+  // is no honest spec anywhere for the verb to discard: the operation is simply declared noexcept
+  // while calling code that may throw. Fixing this group means COMPUTING the spec rather than
+  // propagating one, which needs the nothrow-invocable traits stubbed false by #45.
+  //
+  // One test case for every monad, not one each: nothing here differs between them, because no
+  // member is consulted.
+  static_assert(noexcept(inspect_t::apply{}(std::declval<fn::expected<int, Error> &>(), fnThrows)));
+  static_assert(noexcept(inspect_t::apply{}(std::declval<fn::expected<void, Error> &>(), fnThrows0)));
+  static_assert(noexcept(inspect_t::apply{}(std::declval<fn::optional<int> &>(), fnThrows)));
+
+  SUCCEED();
+}
+
 TEST_CASE("constexpr inspect expected", "[inspect][constexpr][expected]")
 {
   enum class Error { ThresholdExceeded, SomethingElse };

--- a/tests/fn/inspect.cpp
+++ b/tests/fn/inspect.cpp
@@ -58,9 +58,9 @@ TEST_CASE("inspect expected", "[inspect][expected][expected_value][pack]")
   static_assert(is::not_invocable_with_any([]() -> void { throw 0; }));            // bad arity
   static_assert(is::not_invocable_with_any([](int, int) -> void { throw 0; }));    // bad arity
 
-  WHEN("operand is lvalue")
+  SECTION("lvalue")
   {
-    WHEN("operand is value")
+    SECTION("value")
     {
       operand_t a{std::in_place, 12};
       using T = decltype(a | inspect(fnValue));
@@ -68,7 +68,7 @@ TEST_CASE("inspect expected", "[inspect][expected][expected_value][pack]")
       REQUIRE((a | inspect(fnValue)).value() == 12);
       CHECK(value == 12);
     }
-    WHEN("operand is error")
+    SECTION("error")
     {
       operand_t a{::fn::unexpect, Error{"Not good"}};
       using T = decltype(a | inspect(wrong));
@@ -79,7 +79,7 @@ TEST_CASE("inspect expected", "[inspect][expected][expected_value][pack]")
                   .what
               == "Not good");
     }
-    WHEN("calling member function")
+    SECTION("member function")
     {
       using operand_t = fn::expected<Value, Error>;
       operand_t a{std::in_place, Value{12}};
@@ -91,9 +91,9 @@ TEST_CASE("inspect expected", "[inspect][expected][expected_value][pack]")
     }
   }
 
-  WHEN("operand is pack")
+  SECTION("pack")
   {
-    WHEN("operand is value")
+    SECTION("value")
     {
       using operand_t = fn::expected<fn::pack<int, double>, Error>;
       operand_t a{std::in_place, fn::pack{84, 0.5}};
@@ -105,7 +105,7 @@ TEST_CASE("inspect expected", "[inspect][expected][expected_value][pack]")
       CHECK(value == 42);
     }
 
-    WHEN("operand is error")
+    SECTION("error")
     {
       using operand_t = fn::expected<fn::pack<int, double>, Error>;
       operand_t a{::fn::unexpect, Error{"Not good"}};
@@ -120,16 +120,16 @@ TEST_CASE("inspect expected", "[inspect][expected][expected_value][pack]")
     }
   }
 
-  WHEN("operand is rvalue")
+  SECTION("rvalue")
   {
-    WHEN("operand is value")
+    SECTION("value")
     {
       using T = decltype(operand_t{std::in_place, 12} | inspect(fnValue));
       static_assert(std::is_same_v<T, operand_t &&>);
       REQUIRE((operand_t{std::in_place, 12} | inspect(fnValue)).value() == 12);
       CHECK(value == 12);
     }
-    WHEN("operand is error")
+    SECTION("error")
     {
       using T = decltype(operand_t{::fn::unexpect, Error{"Not good"}} | inspect(wrong));
       static_assert(std::is_same_v<T, operand_t &&>);
@@ -139,7 +139,7 @@ TEST_CASE("inspect expected", "[inspect][expected][expected_value][pack]")
                   .what
               == "Not good");
     }
-    WHEN("calling member function")
+    SECTION("member function")
     {
       using operand_t = fn::expected<Value, Error>;
       using T = decltype(operand_t{std::in_place, Value{12}} | inspect(&Value::fn));
@@ -147,6 +147,36 @@ TEST_CASE("inspect expected", "[inspect][expected][expected_value][pack]")
       auto const before = Value::count;
       REQUIRE((operand_t{std::in_place, Value{12}} | inspect(&Value::fn)).value().value == 12);
       CHECK(Value::count == before + 12);
+    }
+  }
+
+  SECTION("constexpr")
+  {
+    enum class Error { ThresholdExceeded, SomethingElse };
+    using T = fn::expected<int, Error>;
+    constexpr auto fn = [](int) constexpr noexcept -> void {};
+    constexpr auto r1 = T{0} | fn::inspect(fn);
+    static_assert(r1.value() == 0);
+    constexpr auto r2 = T{::fn::unexpect, Error::SomethingElse} | fn::inspect(fn);
+    static_assert(r2.error() == Error::SomethingElse);
+
+    SUCCEED();
+
+    SECTION("sum")
+    {
+      using T = fn::expected<fn::sum<bool, int>, Error>;
+      constexpr auto fn1 = [](int) constexpr noexcept -> void {};
+      constexpr auto r11 = T{0} | fn::inspect(fn1);
+      static_assert(r11.value() == fn::sum{0});
+      constexpr auto fn2 = [](auto const &v) {
+        static_assert(std::is_same_v<decltype(v), int const &> || std::is_same_v<decltype(v), bool const &>);
+      };
+      constexpr auto r12 = T{0} | fn::inspect(fn2);
+      static_assert(r12.value() == fn::sum{0});
+      constexpr auto r2 = T{::fn::unexpect, Error::SomethingElse} | fn::inspect(fn1);
+      static_assert(r2.error() == Error::SomethingElse);
+
+      SUCCEED();
     }
   }
 }
@@ -168,9 +198,9 @@ TEST_CASE("inspect void expected", "[inspect][expected][expected_void]")
   static_assert(is::not_invocable_with_any([](int) -> void { throw 0; }));      // bad arity
   static_assert(is::not_invocable_with_any([](int, int) -> void { throw 0; })); // bad arity
 
-  WHEN("operand is lvalue")
+  SECTION("lvalue")
   {
-    WHEN("operand is value")
+    SECTION("value")
     {
       operand_t a{std::in_place};
       using T = decltype(a | inspect(fnValue));
@@ -178,7 +208,7 @@ TEST_CASE("inspect void expected", "[inspect][expected][expected_void]")
       (a | inspect(fnValue)).value();
       CHECK(count == 1);
     }
-    WHEN("operand is error")
+    SECTION("error")
     {
       operand_t a{::fn::unexpect, Error{"Not good"}};
       using T = decltype(a | inspect(wrong));
@@ -191,16 +221,16 @@ TEST_CASE("inspect void expected", "[inspect][expected][expected_void]")
     }
   }
 
-  WHEN("operand is rvalue")
+  SECTION("rvalue")
   {
-    WHEN("operand is value")
+    SECTION("value")
     {
       using T = decltype(operand_t{std::in_place} | inspect(fnValue));
       static_assert(std::is_same_v<T, operand_t &&>);
       (operand_t{std::in_place} | inspect(fnValue)).value();
       CHECK(count == 1);
     }
-    WHEN("operand is error")
+    SECTION("error")
     {
       using T = decltype(operand_t{::fn::unexpect, Error{"Not good"}} | inspect(wrong));
       static_assert(std::is_same_v<T, operand_t &&>);
@@ -236,9 +266,9 @@ TEST_CASE("inspect optional", "[inspect][optional][pack]")
   static_assert(is::not_invocable_with_any([](int, int) -> void { throw 0; }));    // bad arity
   static_assert(is::not_invocable_with_any([](int) -> int { return 0; }));         // bad return type
 
-  WHEN("operand is lvalue")
+  SECTION("lvalue")
   {
-    WHEN("operand is value")
+    SECTION("value")
     {
       operand_t a{12};
       using T = decltype(a | inspect(fnValue));
@@ -246,14 +276,14 @@ TEST_CASE("inspect optional", "[inspect][optional][pack]")
       REQUIRE((a | inspect(fnValue)).value() == 12);
       CHECK(value == 12);
     }
-    WHEN("operand is error")
+    SECTION("error")
     {
       operand_t a{std::nullopt};
       using T = decltype(a | inspect(wrong));
       static_assert(std::is_same_v<T, operand_t &>);
       REQUIRE(not(a | inspect(wrong)).has_value());
     }
-    WHEN("calling member function")
+    SECTION("member function")
     {
       using operand_t = fn::optional<Value>;
       operand_t a{std::in_place, Value{12}};
@@ -265,9 +295,9 @@ TEST_CASE("inspect optional", "[inspect][optional][pack]")
     }
   }
 
-  WHEN("operand is pack")
+  SECTION("pack")
   {
-    WHEN("operand is value")
+    SECTION("value")
     {
       using operand_t = fn::optional<fn::pack<int, double>>;
       operand_t a{std::in_place, fn::pack{84, 0.5}};
@@ -279,7 +309,7 @@ TEST_CASE("inspect optional", "[inspect][optional][pack]")
       CHECK(value == 42);
     }
 
-    WHEN("operand is error")
+    SECTION("error")
     {
       using operand_t = fn::optional<fn::pack<int, double>>;
       operand_t a{std::nullopt};
@@ -290,16 +320,16 @@ TEST_CASE("inspect optional", "[inspect][optional][pack]")
     }
   }
 
-  WHEN("operand is rvalue")
+  SECTION("rvalue")
   {
-    WHEN("operand is value")
+    SECTION("value")
     {
       using T = decltype(operand_t{12} | inspect(fnValue));
       static_assert(std::is_same_v<T, operand_t &&>);
       REQUIRE((operand_t{12} | inspect(fnValue)).value() == 12);
       CHECK(value == 12);
     }
-    WHEN("operand is error")
+    SECTION("error")
     {
       using T = decltype(operand_t{std::nullopt} | inspect(wrong));
       static_assert(std::is_same_v<T, operand_t &&>);
@@ -307,7 +337,7 @@ TEST_CASE("inspect optional", "[inspect][optional][pack]")
                   | inspect(wrong))
                      .has_value());
     }
-    WHEN("calling member function")
+    SECTION("member function")
     {
       using operand_t = fn::optional<Value>;
       using T = decltype(operand_t{std::in_place, Value{12}} | inspect(&Value::fn));
@@ -317,13 +347,42 @@ TEST_CASE("inspect optional", "[inspect][optional][pack]")
       CHECK(Value::count == before + 12);
     }
   }
+
+  SECTION("constexpr")
+  {
+    using T = fn::optional<int>;
+    constexpr auto fn = [](int) constexpr noexcept -> void {};
+    constexpr auto r1 = T{0} | fn::inspect(fn);
+    static_assert(r1.value() == 0);
+    constexpr auto r2 = T{} | fn::inspect(fn);
+    static_assert(not r2.has_value());
+
+    SUCCEED();
+
+    SECTION("sum")
+    {
+      using T = fn::optional<fn::sum<bool, int>>;
+      constexpr auto fn1 = [](int) constexpr noexcept -> void {};
+      constexpr auto r11 = T{0} | fn::inspect(fn1);
+      static_assert(r11.value() == fn::sum{0});
+      constexpr auto fn2 = [](auto const &v) {
+        static_assert(std::is_same_v<decltype(v), int const &> || std::is_same_v<decltype(v), bool const &>);
+      };
+      constexpr auto r12 = T{0} | fn::inspect(fn2);
+      static_assert(r12.value() == fn::sum{0});
+      constexpr auto r2 = T{} | fn::inspect(fn1);
+      static_assert(not r2.has_value());
+
+      SUCCEED();
+    }
+  }
 }
 
 TEST_CASE("inspect choice", "[inspect][choice]")
 {
   using namespace fn;
 
-  WHEN("convertible to int")
+  SECTION("convertible to int")
   {
     using operand_t = fn::choice<bool, int>;
     using is = monadic_static_check<inspect_t, operand_t>;
@@ -395,66 +454,6 @@ TEST_CASE("inspect noexcept", "[inspect][noexcept]")
   static_assert(noexcept(inspect_t::apply{}(std::declval<fn::expected<int, Error> &>(), fnThrows)));
   static_assert(noexcept(inspect_t::apply{}(std::declval<fn::expected<void, Error> &>(), fnThrows0)));
   static_assert(noexcept(inspect_t::apply{}(std::declval<fn::optional<int> &>(), fnThrows)));
-
-  SUCCEED();
-}
-
-TEST_CASE("constexpr inspect expected", "[inspect][constexpr][expected]")
-{
-  enum class Error { ThresholdExceeded, SomethingElse };
-  using T = fn::expected<int, Error>;
-  constexpr auto fn = [](int) constexpr noexcept -> void {};
-  constexpr auto r1 = T{0} | fn::inspect(fn);
-  static_assert(r1.value() == 0);
-  constexpr auto r2 = T{::fn::unexpect, Error::SomethingElse} | fn::inspect(fn);
-  static_assert(r2.error() == Error::SomethingElse);
-
-  SUCCEED();
-}
-
-TEST_CASE("constexpr inspect expected with sum", "[inspect][constexpr][expected][sum]")
-{
-  enum class Error { ThresholdExceeded, SomethingElse };
-  using T = fn::expected<fn::sum<bool, int>, Error>;
-  constexpr auto fn1 = [](int) constexpr noexcept -> void {};
-  constexpr auto r11 = T{0} | fn::inspect(fn1);
-  static_assert(r11.value() == fn::sum{0});
-  constexpr auto fn2 = [](auto const &v) {
-    static_assert(std::is_same_v<decltype(v), int const &> || std::is_same_v<decltype(v), bool const &>);
-  };
-  constexpr auto r12 = T{0} | fn::inspect(fn2);
-  static_assert(r12.value() == fn::sum{0});
-  constexpr auto r2 = T{::fn::unexpect, Error::SomethingElse} | fn::inspect(fn1);
-  static_assert(r2.error() == Error::SomethingElse);
-
-  SUCCEED();
-}
-
-TEST_CASE("constexpr inspect optional", "[inspect][constexpr][optional]")
-{
-  using T = fn::optional<int>;
-  constexpr auto fn = [](int) constexpr noexcept -> void {};
-  constexpr auto r1 = T{0} | fn::inspect(fn);
-  static_assert(r1.value() == 0);
-  constexpr auto r2 = T{} | fn::inspect(fn);
-  static_assert(not r2.has_value());
-
-  SUCCEED();
-}
-
-TEST_CASE("constexpr inspect optional with sum", "[inspect][constexpr][optional][sum]")
-{
-  using T = fn::optional<fn::sum<bool, int>>;
-  constexpr auto fn1 = [](int) constexpr noexcept -> void {};
-  constexpr auto r11 = T{0} | fn::inspect(fn1);
-  static_assert(r11.value() == fn::sum{0});
-  constexpr auto fn2 = [](auto const &v) {
-    static_assert(std::is_same_v<decltype(v), int const &> || std::is_same_v<decltype(v), bool const &>);
-  };
-  constexpr auto r12 = T{0} | fn::inspect(fn2);
-  static_assert(r12.value() == fn::sum{0});
-  constexpr auto r2 = T{} | fn::inspect(fn1);
-  static_assert(not r2.has_value());
 
   SUCCEED();
 }

--- a/tests/fn/inspect_error.cpp
+++ b/tests/fn/inspect_error.cpp
@@ -51,16 +51,16 @@ TEST_CASE("inspect_error expected", "[inspect_error][expected]")
   static_assert(is::not_invocable_with_any([]() -> void { throw 0; }));                // bad arity
   static_assert(is::not_invocable_with_any([](Error, int) -> void { throw 0; }));      // bad arity
 
-  WHEN("operand is lvalue")
+  SECTION("lvalue")
   {
-    WHEN("operand is value")
+    SECTION("value")
     {
       operand_t a{std::in_place, 12};
       using T = decltype(a | inspect_error(wrong));
       static_assert(std::is_same_v<T, operand_t &>);
       REQUIRE((a | inspect_error(wrong)).value() == 12);
     }
-    WHEN("operand is error")
+    SECTION("error")
     {
       operand_t a{::fn::unexpect, Error{"Not good"}};
       using T = decltype(a | inspect_error(fnError));
@@ -72,7 +72,7 @@ TEST_CASE("inspect_error expected", "[inspect_error][expected]")
               == "Not good");
       CHECK(error == "Not good");
     }
-    WHEN("calling member function")
+    SECTION("member function")
     {
       operand_t a{::fn::unexpect, Error{"Not good"}};
       using T = decltype(a | inspect_error(&Error::finalize));
@@ -87,15 +87,15 @@ TEST_CASE("inspect_error expected", "[inspect_error][expected]")
     }
   }
 
-  WHEN("operand is rvalue")
+  SECTION("rvalue")
   {
-    WHEN("operand is value")
+    SECTION("value")
     {
       using T = decltype(operand_t{std::in_place, 12} | inspect_error(wrong));
       static_assert(std::is_same_v<T, operand_t &&>);
       REQUIRE((operand_t{std::in_place, 12} | inspect_error(wrong)).value() == 12);
     }
-    WHEN("operand is error")
+    SECTION("error")
     {
       using T = decltype(operand_t{::fn::unexpect, Error{"Not good"}} | inspect_error(fnError));
       static_assert(std::is_same_v<T, operand_t &&>);
@@ -106,7 +106,7 @@ TEST_CASE("inspect_error expected", "[inspect_error][expected]")
               == "Not good");
       CHECK(error == "Not good");
     }
-    WHEN("calling member function")
+    SECTION("member function")
     {
       using T = decltype(operand_t{::fn::unexpect, Error{"Not good"}} | inspect_error(&Error::finalize));
       static_assert(std::is_same_v<T, operand_t &&>);
@@ -117,6 +117,34 @@ TEST_CASE("inspect_error expected", "[inspect_error][expected]")
                   .what
               == "Not good");
       CHECK(Error::count == before + 8);
+    }
+  }
+
+  SECTION("constexpr")
+  {
+    enum class Error { ThresholdExceeded, SomethingElse };
+    using T = fn::expected<int, Error>;
+    constexpr auto fn = [](Error) constexpr noexcept -> void {};
+    constexpr auto r1 = T{0} | fn::inspect_error(fn);
+    static_assert(r1.value() == 0);
+    constexpr auto r2 = T{::fn::unexpect, Error::SomethingElse} | fn::inspect_error(fn);
+    static_assert(r2.error() == Error::SomethingElse);
+
+    SUCCEED();
+
+    SECTION("sum")
+    {
+      using TS = fn::expected<int, fn::sum_for<Error, bool>>;
+      constexpr auto fnSum
+          = fn::overload{[](Error) constexpr noexcept -> void {}, [](bool) constexpr noexcept -> void {}};
+      constexpr auto s1 = TS{0} | fn::inspect_error(fnSum);
+      static_assert(s1.value() == 0);
+      constexpr auto s2 = TS{::fn::unexpect, fn::sum{Error::SomethingElse}} | fn::inspect_error(fnSum);
+      static_assert(s2.error() == fn::sum{Error::SomethingElse});
+      constexpr auto s3 = TS{::fn::unexpect, fn::sum{false}} | fn::inspect_error(fnSum);
+      static_assert(s3.error() == fn::sum{false});
+
+      SUCCEED();
     }
   }
 }
@@ -137,16 +165,16 @@ TEST_CASE("inspect_error optional", "[inspect_error][optional]")
   static_assert(is::not_invocable_with_any([](auto) -> void { throw 0; }));       // bad arity
   static_assert(is::not_invocable_with_any([](auto, auto) -> void { throw 0; })); // bad arity
 
-  WHEN("operand is lvalue")
+  SECTION("lvalue")
   {
-    WHEN("operand is value")
+    SECTION("value")
     {
       operand_t a{12};
       using T = decltype(a | inspect_error(wrong));
       static_assert(std::is_same_v<T, operand_t &>);
       REQUIRE((a | inspect_error(wrong)).value() == 12);
     }
-    WHEN("operand is error")
+    SECTION("error")
     {
       operand_t a{std::nullopt};
       using T = decltype(a | inspect_error(fnError));
@@ -156,15 +184,15 @@ TEST_CASE("inspect_error optional", "[inspect_error][optional]")
     }
   }
 
-  WHEN("operand is rvalue")
+  SECTION("rvalue")
   {
-    WHEN("operand is value")
+    SECTION("value")
     {
       using T = decltype(operand_t{12} | inspect_error(wrong));
       static_assert(std::is_same_v<T, operand_t &&>);
       REQUIRE((operand_t{12} | inspect_error(wrong)).value() == 12);
     }
-    WHEN("operand is error")
+    SECTION("error")
     {
       using T = decltype(operand_t{std::nullopt} | inspect_error(fnError));
       static_assert(std::is_same_v<T, operand_t &&>);
@@ -173,6 +201,18 @@ TEST_CASE("inspect_error optional", "[inspect_error][optional]")
                      .has_value());
       CHECK(error == 1);
     }
+  }
+
+  SECTION("constexpr")
+  {
+    using T = fn::optional<int>;
+    constexpr auto fn = []() constexpr noexcept -> void {};
+    constexpr auto r1 = T{0} | fn::inspect_error(fn);
+    static_assert(r1.value() == 0);
+    constexpr auto r2 = T{} | fn::inspect_error(fn);
+    static_assert(not r2.has_value());
+
+    SUCCEED();
   }
 }
 
@@ -187,46 +227,6 @@ TEST_CASE("inspect_error noexcept", "[inspect_error][noexcept]")
   // there is no member spec for it to discard - the operation has no honest noexcept anywhere.
   static_assert(noexcept(inspect_error_t::apply{}(std::declval<fn::expected<int, Error> &>(), fnThrows)));
   static_assert(noexcept(inspect_error_t::apply{}(std::declval<fn::optional<int> &>(), fnThrows0)));
-
-  SUCCEED();
-}
-
-TEST_CASE("constexpr inspect_error expected", "[inspect_error][constexpr][expected]")
-{
-  enum class Error { ThresholdExceeded, SomethingElse };
-  using T = fn::expected<int, Error>;
-  constexpr auto fn = [](Error) constexpr noexcept -> void {};
-  constexpr auto r1 = T{0} | fn::inspect_error(fn);
-  static_assert(r1.value() == 0);
-  constexpr auto r2 = T{::fn::unexpect, Error::SomethingElse} | fn::inspect_error(fn);
-  static_assert(r2.error() == Error::SomethingElse);
-
-  SUCCEED();
-}
-
-TEST_CASE("constexpr inspect_error expected with sum", "[inspect_error][constexpr][expected][sum]")
-{
-  enum class Error { ThresholdExceeded, SomethingElse };
-  using T = fn::expected<int, fn::sum_for<Error, bool>>;
-  constexpr auto fn = fn::overload{[](Error) constexpr noexcept -> void {}, [](bool) constexpr noexcept -> void {}};
-  constexpr auto r1 = T{0} | fn::inspect_error(fn);
-  static_assert(r1.value() == 0);
-  constexpr auto r2 = T{::fn::unexpect, fn::sum{Error::SomethingElse}} | fn::inspect_error(fn);
-  static_assert(r2.error() == fn::sum{Error::SomethingElse});
-  constexpr auto r3 = T{::fn::unexpect, fn::sum{false}} | fn::inspect_error(fn);
-  static_assert(r3.error() == fn::sum{false});
-
-  SUCCEED();
-}
-
-TEST_CASE("constexpr inspect_error optional", "[inspect_error][constexpr][optional]")
-{
-  using T = fn::optional<int>;
-  constexpr auto fn = []() constexpr noexcept -> void {};
-  constexpr auto r1 = T{0} | fn::inspect_error(fn);
-  static_assert(r1.value() == 0);
-  constexpr auto r2 = T{} | fn::inspect_error(fn);
-  static_assert(not r2.has_value());
 
   SUCCEED();
 }

--- a/tests/fn/inspect_error.cpp
+++ b/tests/fn/inspect_error.cpp
@@ -176,6 +176,21 @@ TEST_CASE("inspect_error optional", "[inspect_error][optional]")
   }
 }
 
+TEST_CASE("inspect_error noexcept", "[inspect_error][noexcept]")
+{
+  using namespace fn;
+
+  constexpr auto fnThrows = [](Error const &) noexcept(false) -> void {};
+  constexpr auto fnThrows0 = []() noexcept(false) -> void {};
+
+  // GAP #285: as with inspect, the apply is the implementation and invokes the callback itself, so
+  // there is no member spec for it to discard - the operation has no honest noexcept anywhere.
+  static_assert(noexcept(inspect_error_t::apply{}(std::declval<fn::expected<int, Error> &>(), fnThrows)));
+  static_assert(noexcept(inspect_error_t::apply{}(std::declval<fn::optional<int> &>(), fnThrows0)));
+
+  SUCCEED();
+}
+
 TEST_CASE("constexpr inspect_error expected", "[inspect_error][constexpr][expected]")
 {
   enum class Error { ThresholdExceeded, SomethingElse };

--- a/tests/fn/optional.cpp
+++ b/tests/fn/optional.cpp
@@ -167,6 +167,27 @@ TEST_CASE("optional pack support", "[optional][pack][and_then][transform][operat
 {
   WHEN("and_then")
   {
+    using P = fn::optional<fn::pack<int, std::string_view>>;
+
+    // noexcept (extension): the spec is std::is_nothrow_invocable_v on the whole pack
+    // (optional.hpp:146), never satisfied by a multi-argument visitor -- conservatively
+    // noexcept(false) even with nothrow handlers; fn-native noexcept for sum/pack dispatch is
+    // GH #254. A generic callback IS invocable on the whole pack, so the borrowed trait then
+    // reports true from a call shape the pack-apply dispatch never makes.
+    constexpr auto nothrow_two = [](int &, std::string_view &) noexcept -> fn::optional<bool> { return {true}; };
+    static_assert(not noexcept(std::declval<P &>().and_then(nothrow_two)));
+    constexpr auto nothrow_generic = [](auto &&...) noexcept -> fn::optional<bool> { return {true}; };
+    static_assert(noexcept(std::declval<P &>().and_then(nothrow_generic)));
+
+    // constraints (extension): pack-apply invocability is a constraint (optional.hpp:147);
+    // wrong arity or a non-callable SFINAE-drops, and the pack's value category is tracked
+    constexpr auto can_and_then_lval = [](auto &&f) { return requires { std::declval<P &>().and_then(f); }; };
+    constexpr auto can_and_then_rval = [](auto &&f) { return requires { std::declval<P &&>().and_then(f); }; };
+    static_assert(can_and_then_lval(nothrow_two));
+    static_assert(not can_and_then_rval(nothrow_two));                                        // lvalue-only visitor
+    static_assert(not can_and_then_lval([](int &) -> fn::optional<bool> { return {true}; })); // wrong arity
+    static_assert(not can_and_then_lval(42));
+
     WHEN("value")
     {
       fn::optional<fn::pack<int, std::string_view>> s{
@@ -223,10 +244,35 @@ TEST_CASE("optional pack support", "[optional][pack][and_then][transform][operat
                                      [](int const &&, auto &&...) -> fn::optional<bool> { throw 0; }}) //
                     .has_value());
     }
+
+    WHEN("constexpr")
+    {
+      constexpr P a{fn::pack<int>{12}.append(std::in_place_type<std::string_view>, "bar")};
+      static_assert(a.and_then([](int const &i, std::string_view const &s) -> fn::optional<bool> {
+                       return {i == 12 && s == "bar"};
+                     }).value());
+      static_assert(not P{std::nullopt}.and_then([](auto &&...) -> fn::optional<bool> { return {true}; }).has_value());
+      SUCCEED();
+    }
   }
 
   WHEN("transform")
   {
+    using P = fn::optional<fn::pack<int, std::string_view>>;
+
+    // noexcept and constraints mirror and_then above (optional.hpp:219-220): the non-sum
+    // _transform is constrained on pack-apply invocability -- contrast the sum case, whose
+    // callback is checked only in its deduced-return body (see "optional transform sum")
+    constexpr auto nothrow_two = [](int &, std::string_view &) noexcept -> bool { return true; };
+    static_assert(not noexcept(std::declval<P &>().transform(nothrow_two)));
+    constexpr auto nothrow_generic = [](auto &&...) noexcept -> bool { return true; };
+    static_assert(noexcept(std::declval<P &>().transform(nothrow_generic)));
+
+    constexpr auto can_transform = [](auto &&f) { return requires { std::declval<P &>().transform(f); }; };
+    static_assert(can_transform(nothrow_two));
+    static_assert(not can_transform([](int &) -> bool { return true; })); // wrong arity
+    static_assert(not can_transform(42));
+
     WHEN("value")
     {
       fn::optional<fn::pack<int, std::string_view>> s{
@@ -269,10 +315,35 @@ TEST_CASE("optional pack support", "[optional][pack][and_then][transform][operat
       CHECK(not std::move(std::as_const(s)).transform([](auto...) -> bool { throw 0; }).has_value());
       CHECK(not std::move(s).transform([](auto...) -> bool { throw 0; }).has_value());
     }
+
+    WHEN("constexpr")
+    {
+      constexpr P a{fn::pack<int>{12}.append(std::in_place_type<std::string_view>, "bar")};
+      static_assert(
+          a.transform([](int const &i, std::string_view const &s) -> bool { return i == 12 && s == "bar"; }).value());
+      static_assert(not P{std::nullopt}.transform([](auto &&...) -> bool { return true; }).has_value());
+      SUCCEED();
+    }
   }
 
   WHEN("operator &")
   {
+    // noexcept: operator& is declared unconditionally noexcept (optional.hpp:881) though
+    // joining copies/moves the operands' values into the result pack -- for a throwing-copy
+    // value type this is a promise the join cannot keep (make_optional, by contrast, spells
+    // conditional noexcept). GAP: asserts current behaviour; flip to `not noexcept` when fixed.
+    struct throwing_copy {
+      // defined, not just declared: the instantiated join references it (-Wundefined-internal)
+      throwing_copy(throwing_copy const &) noexcept(false) {}
+    };
+    static_assert(noexcept(std::declval<fn::optional<double> &>() & std::declval<fn::optional<int> &>()));
+    static_assert(noexcept(std::declval<fn::optional<throwing_copy> &>() & std::declval<fn::optional<int> &>()));
+
+    // constraints: both operands must be optionals
+    constexpr auto can_amp = [](auto &&rh) { return requires { std::declval<fn::optional<int> &>() & rh; }; };
+    static_assert(can_amp(fn::optional<double>{0.5}));
+    static_assert(not can_amp(42));
+
     WHEN("value & value yield pack")
     {
       static_assert(std::same_as<decltype(std::declval<fn::optional<int>>() & std::declval<fn::optional<double>>()),
@@ -469,11 +540,51 @@ TEST_CASE("optional pack support", "[optional][pack][and_then][transform][operat
         CHECK(not(Lh{std::nullopt} & Rh{std::nullopt}).has_value());
       }
     }
+
+    WHEN("constexpr")
+    {
+      static_assert((fn::optional<double>{0.5} & fn::optional<int>{12})
+                        .transform([](double d, int i) constexpr -> bool { return d == 0.5 && i == 12; })
+                        .value());
+      static_assert(not(fn::optional<double>{std::nullopt} & fn::optional<int>{12}).has_value());
+      using Lh = fn::optional<fn::sum<double, int>>;
+      using Rh = fn::optional<fn::sum<bool, int>>;
+      static_assert((Lh{fn::sum{0.5}} & Rh{fn::sum{12}})
+                        .transform([](auto i, auto j) constexpr -> bool {
+                          return 0.5 == static_cast<double>(i) && 12 == static_cast<int>(j);
+                        })
+                        .value()
+                    == fn::sum{true});
+      SUCCEED();
+    }
   }
 }
 
 TEST_CASE("optional and_then sum", "[optional][sum][and_then]")
 {
+  using S = fn::optional<fn::sum_for<Xint, int>>;
+
+  // noexcept (extension): the spec is std::is_nothrow_invocable_v on the whole sum
+  // (optional.hpp:146); a visitor set is not invocable on the sum itself, so and_then over a
+  // sum is conservatively noexcept(false) even with nothrow handlers -- fn-native noexcept for
+  // sum dispatch is GH #254. A generic callback IS invocable on the whole sum, so the borrowed
+  // trait then reports true from a call shape the per-alternative dispatch never makes.
+  constexpr auto nothrow_lval = fn::overload{[](int &) noexcept -> fn::optional<bool> { return {true}; },
+                                             [](Xint &) noexcept -> fn::optional<bool> { return {false}; }};
+  static_assert(not noexcept(std::declval<S &>().and_then(nothrow_lval)));
+  constexpr auto nothrow_generic = [](auto &&) noexcept -> fn::optional<bool> { return {true}; };
+  static_assert(noexcept(std::declval<S &>().and_then(nothrow_generic)));
+
+  // constraints (extension): exhaustive invocability over the sum's alternatives is a
+  // constraint (optional.hpp:147) -- a partial or non-invocable visitor SFINAE-drops, and the
+  // alternatives' value category is tracked
+  constexpr auto can_and_then_lval = [](auto &&f) { return requires { std::declval<S &>().and_then(f); }; };
+  constexpr auto can_and_then_rval = [](auto &&f) { return requires { std::declval<S &&>().and_then(f); }; };
+  static_assert(can_and_then_lval(nothrow_lval));
+  static_assert(not can_and_then_rval(nothrow_lval)); // no rvalue handlers
+  static_assert(not can_and_then_lval(fn::overload{[](int &) -> fn::optional<bool> { return {true}; }})); // partial
+  static_assert(not can_and_then_lval(42));
+
   WHEN("value")
   {
     fn::optional<fn::sum_for<Xint, int>> s{12};
@@ -574,6 +685,27 @@ TEST_CASE("optional and_then sum", "[optional][sum][and_then]")
 
 TEST_CASE("optional transform sum", "[optional][sum][transform]")
 {
+  using S = fn::optional<fn::sum_for<Xint, int>>;
+
+  // noexcept: the sum-case _transform (optional.hpp:233) carries no noexcept spec at all, so
+  // transform over a sum is noexcept(false) even for a whole-sum-invocable nothrow callback
+  // that and_then reports noexcept(true) for -- fn-native noexcept for sum dispatch is GH #254
+  constexpr auto nothrow_visitor = fn::overload{[](int const &) noexcept -> bool { return true; },
+                                                [](Xint const &) noexcept -> bool { return false; }};
+  static_assert(not noexcept(std::declval<S &>().transform(nothrow_visitor)));
+  constexpr auto nothrow_generic = [](auto &&) noexcept -> bool { return true; };
+  static_assert(not noexcept(std::declval<S &>().transform(nothrow_generic)));
+
+  // GAP: unlike and_then (optional.hpp:147) and the non-sum transform (:220), the sum-case
+  // _transform (:233) has no callback-invocability constraint; validity surfaces in its
+  // deduced-return body (:236) during candidate-signature formation, outside the immediate
+  // context. A bad callback is a hard error instead of SFINAE-dropping (so no negative probe
+  // here), and a category-partial visitor poisons overload resolution outright: on a non-const
+  // lvalue even the losing const& candidate must instantiate, which is why the visitors above
+  // take const& (serving every candidate) where and_then's can take int&/Xint&.
+  constexpr auto can_transform = [](auto &&f) { return requires { std::declval<S &>().transform(f); }; };
+  static_assert(can_transform(nothrow_visitor));
+
   WHEN("value")
   {
     fn::optional<fn::sum_for<Xint, int>> s{12};

--- a/tests/fn/optional.cpp
+++ b/tests/fn/optional.cpp
@@ -331,7 +331,8 @@ TEST_CASE("optional pack support", "[optional][pack][and_then][transform][operat
     // noexcept: operator& is declared unconditionally noexcept (optional.hpp:881) though
     // joining copies/moves the operands' values into the result pack -- for a throwing-copy
     // value type this is a promise the join cannot keep (make_optional, by contrast, spells
-    // conditional noexcept). GAP: asserts current behaviour; flip to `not noexcept` when fixed.
+    // conditional noexcept). GAP: asserts current behaviour; flip to `not noexcept` when
+    // fixed (issue #279).
     struct throwing_copy {
       // defined, not just declared: the instantiated join references it (-Wundefined-internal)
       throwing_copy(throwing_copy const &) noexcept(false) {}
@@ -702,7 +703,7 @@ TEST_CASE("optional transform sum", "[optional][sum][transform]")
   // context. A bad callback is a hard error instead of SFINAE-dropping (so no negative probe
   // here), and a category-partial visitor poisons overload resolution outright: on a non-const
   // lvalue even the losing const& candidate must instantiate, which is why the visitors above
-  // take const& (serving every candidate) where and_then's can take int&/Xint&.
+  // take const& (serving every candidate) where and_then's can take int&/Xint& (issue #277).
   constexpr auto can_transform = [](auto &&f) { return requires { std::declval<S &>().transform(f); }; };
   static_assert(can_transform(nothrow_visitor));
 

--- a/tests/fn/optional.cpp
+++ b/tests/fn/optional.cpp
@@ -27,7 +27,7 @@ struct Xint {
 
 TEST_CASE("optional graded monad", "[optional][sum][graded][or_else][sum_value]")
 {
-  WHEN("sum_value from sum")
+  SECTION("sum_value from sum")
   {
     using T = fn::optional<fn::sum<int>>;
     T s{12};
@@ -41,14 +41,14 @@ TEST_CASE("optional graded monad", "[optional][sum][graded][or_else][sum_value]"
     static_assert(not noexcept(std::as_const(s).sum_value()));
     static_assert(not noexcept(std::move(std::as_const(s)).sum_value()));
     static_assert(not noexcept(std::move(s).sum_value()));
-    WHEN("value")
+    SECTION("value")
     {
       CHECK(s.sum_value().value() == fn::sum{12});
       CHECK(std::as_const(s).sum_value().value() == fn::sum{12});
       CHECK(std::move(std::as_const(s)).sum_value().value() == fn::sum{12});
       CHECK(std::move(s).sum_value().value() == fn::sum{12});
     }
-    WHEN("error")
+    SECTION("error")
     {
       T s{std::nullopt};
       CHECK(not s.sum_value().has_value());
@@ -60,7 +60,7 @@ TEST_CASE("optional graded monad", "[optional][sum][graded][or_else][sum_value]"
     static_assert(std::is_same_v<decltype(fn::sum_value(s)), T &>);
   }
 
-  WHEN("sum_value from non-sum")
+  SECTION("sum_value from non-sum")
   {
     using T = fn::optional<int>;
     T s{12};
@@ -74,14 +74,14 @@ TEST_CASE("optional graded monad", "[optional][sum][graded][or_else][sum_value]"
     static_assert(not noexcept(std::as_const(s).sum_value()));
     static_assert(not noexcept(std::move(std::as_const(s)).sum_value()));
     static_assert(not noexcept(std::move(s).sum_value()));
-    WHEN("value")
+    SECTION("value")
     {
       CHECK(s.sum_value().value() == fn::sum{12});
       CHECK(std::as_const(s).sum_value().value() == fn::sum{12});
       CHECK(std::move(std::as_const(s)).sum_value().value() == fn::sum{12});
       CHECK(std::move(s).sum_value().value() == fn::sum{12});
     }
-    WHEN("error")
+    SECTION("error")
     {
       T s{std::nullopt};
       CHECK(not s.sum_value().has_value());
@@ -93,7 +93,7 @@ TEST_CASE("optional graded monad", "[optional][sum][graded][or_else][sum_value]"
     static_assert(std::is_same_v<decltype(fn::sum_value(s)), fn::optional<fn::sum<int>>>);
   }
 
-  WHEN("or_else")
+  SECTION("or_else")
   {
     fn::optional<fn::sum<int>> s{std::nullopt};
 
@@ -130,7 +130,7 @@ TEST_CASE("optional graded monad", "[optional][sum][graded][or_else][sum_value]"
     static_assert(can_or_else(nothrow_same));
     static_assert(not can_or_else(42));
 
-    WHEN("error to value")
+    SECTION("error to value")
     {
       constexpr auto fn = []() -> fn::optional<Xint> { return {Xint{12}}; };
       static_assert(std::is_same_v<decltype(s.or_else(fn)), fn::optional<fn::sum_for<Xint, int>>>);
@@ -140,7 +140,7 @@ TEST_CASE("optional graded monad", "[optional][sum][graded][or_else][sum_value]"
       CHECK(std::move(s).or_else(fn).value() == fn::sum{Xint{12}});
     }
 
-    WHEN("error to error")
+    SECTION("error to error")
     {
       constexpr auto fn = []() -> fn::optional<Xint> { return {std::nullopt}; };
       static_assert(std::is_same_v<decltype(s.or_else(fn)), fn::optional<fn::sum_for<Xint, int>>>);
@@ -150,7 +150,7 @@ TEST_CASE("optional graded monad", "[optional][sum][graded][or_else][sum_value]"
       CHECK(not std::move(s).or_else(fn).has_value());
     }
 
-    WHEN("value")
+    SECTION("value")
     {
       fn::optional<fn::sum<int>> s{fn::sum{12}};
       constexpr auto fn = []() -> fn::optional<Xint> { throw 0; };
@@ -165,7 +165,7 @@ TEST_CASE("optional graded monad", "[optional][sum][graded][or_else][sum_value]"
 
 TEST_CASE("optional pack support", "[optional][pack][and_then][transform][operator_and]")
 {
-  WHEN("and_then")
+  SECTION("and_then")
   {
     using P = fn::optional<fn::pack<int, std::string_view>>;
 
@@ -188,7 +188,7 @@ TEST_CASE("optional pack support", "[optional][pack][and_then][transform][operat
     static_assert(not can_and_then_lval([](int &) -> fn::optional<bool> { return {true}; })); // wrong arity
     static_assert(not can_and_then_lval(42));
 
-    WHEN("value")
+    SECTION("value")
     {
       fn::optional<fn::pack<int, std::string_view>> s{
           fn::pack<int>{12}.append(std::in_place_type<std::string_view>, "bar")};
@@ -222,7 +222,7 @@ TEST_CASE("optional pack support", "[optional][pack][and_then][transform][operat
                 .value());
     }
 
-    WHEN("error")
+    SECTION("error")
     {
       fn::optional<fn::pack<int, std::string_view>> s{std::nullopt};
       CHECK(not s.and_then( //
@@ -245,7 +245,7 @@ TEST_CASE("optional pack support", "[optional][pack][and_then][transform][operat
                     .has_value());
     }
 
-    WHEN("constexpr")
+    SECTION("constexpr")
     {
       constexpr P a{fn::pack<int>{12}.append(std::in_place_type<std::string_view>, "bar")};
       static_assert(a.and_then([](int const &i, std::string_view const &s) -> fn::optional<bool> {
@@ -256,7 +256,7 @@ TEST_CASE("optional pack support", "[optional][pack][and_then][transform][operat
     }
   }
 
-  WHEN("transform")
+  SECTION("transform")
   {
     using P = fn::optional<fn::pack<int, std::string_view>>;
 
@@ -273,7 +273,7 @@ TEST_CASE("optional pack support", "[optional][pack][and_then][transform][operat
     static_assert(not can_transform([](int &) -> bool { return true; })); // wrong arity
     static_assert(not can_transform(42));
 
-    WHEN("value")
+    SECTION("value")
     {
       fn::optional<fn::pack<int, std::string_view>> s{
           fn::pack<int>{12}.append(std::in_place_type<std::string_view>, "bar")};
@@ -307,7 +307,7 @@ TEST_CASE("optional pack support", "[optional][pack][and_then][transform][operat
                 .value());
     }
 
-    WHEN("error")
+    SECTION("error")
     {
       fn::optional<fn::pack<int, std::string_view>> s{std::nullopt};
       CHECK(not s.transform([](auto...) -> bool { throw 0; }).has_value());
@@ -316,7 +316,7 @@ TEST_CASE("optional pack support", "[optional][pack][and_then][transform][operat
       CHECK(not std::move(s).transform([](auto...) -> bool { throw 0; }).has_value());
     }
 
-    WHEN("constexpr")
+    SECTION("constexpr")
     {
       constexpr P a{fn::pack<int>{12}.append(std::in_place_type<std::string_view>, "bar")};
       static_assert(
@@ -326,7 +326,7 @@ TEST_CASE("optional pack support", "[optional][pack][and_then][transform][operat
     }
   }
 
-  WHEN("operator &")
+  SECTION("operator &")
   {
     // noexcept: operator& is declared unconditionally noexcept (optional.hpp:881) though
     // joining copies/moves the operands' values into the result pack -- for a throwing-copy
@@ -345,7 +345,7 @@ TEST_CASE("optional pack support", "[optional][pack][and_then][transform][operat
     static_assert(can_amp(fn::optional<double>{0.5}));
     static_assert(not can_amp(42));
 
-    WHEN("value & value yield pack")
+    SECTION("value & value yield pack")
     {
       static_assert(std::same_as<decltype(std::declval<fn::optional<int>>() & std::declval<fn::optional<double>>()),
                                  fn::optional<fn::pack<int, double>>>);
@@ -365,7 +365,7 @@ TEST_CASE("optional pack support", "[optional][pack][and_then][transform][operat
                    .has_value());
     }
 
-    WHEN("value & pack yield pack")
+    SECTION("value & pack yield pack")
     {
       static_assert(std::same_as<decltype(std::declval<fn::optional<int>>()
                                           & std::declval<fn::optional<fn::pack<double, bool>>>()),
@@ -386,7 +386,7 @@ TEST_CASE("optional pack support", "[optional][pack][and_then][transform][operat
                    .has_value());
     }
 
-    WHEN("pack & value yield pack")
+    SECTION("pack & value yield pack")
     {
       static_assert(std::same_as<decltype(std::declval<fn::optional<fn::pack<double, bool>>>()
                                           & std::declval<fn::optional<int>>()),
@@ -407,7 +407,7 @@ TEST_CASE("optional pack support", "[optional][pack][and_then][transform][operat
                    .has_value());
     }
 
-    WHEN("pack & pack yield pack")
+    SECTION("pack & pack yield pack")
     {
       static_assert(std::same_as<decltype(std::declval<fn::optional<fn::pack<double, bool>>>()
                                           & std::declval<fn::optional<fn::pack<bool, int>>>()),
@@ -429,7 +429,7 @@ TEST_CASE("optional pack support", "[optional][pack][and_then][transform][operat
                    .has_value());
     }
 
-    WHEN("sum on both sides")
+    SECTION("sum on both sides")
     {
       using Lh = fn::optional<fn::sum<double, int>>;
       using Rh = fn::optional<fn::sum<bool, int>>;
@@ -448,7 +448,7 @@ TEST_CASE("optional pack support", "[optional][pack][and_then][transform][operat
       CHECK(not(Lh{fn::sum{0.5}} & Rh{std::nullopt}).has_value());
       CHECK(not(Lh{std::nullopt} & Rh{std::nullopt}).has_value());
 
-      WHEN("sum of packs on left")
+      SECTION("sum of packs on left")
       {
         using Lh = fn::optional<fn::sum_for<fn::pack<double, bool>, fn::pack<double, int>>>;
         static_assert(std::same_as<decltype(std::declval<Lh>() & std::declval<Rh>()),
@@ -468,7 +468,7 @@ TEST_CASE("optional pack support", "[optional][pack][and_then][transform][operat
       }
     }
 
-    WHEN("sum on left side only")
+    SECTION("sum on left side only")
     {
       using Lh = fn::optional<fn::sum<double, int>>;
       using Rh = fn::optional<int>;
@@ -486,7 +486,7 @@ TEST_CASE("optional pack support", "[optional][pack][and_then][transform][operat
       CHECK(not(Lh{fn::sum{0.5}} & Rh{std::nullopt}).has_value());
       CHECK(not(Lh{std::nullopt} & Rh{std::nullopt}).has_value());
 
-      WHEN("sum of packs on left")
+      SECTION("sum of packs on left")
       {
         using Lh = fn::optional<fn::sum_for<fn::pack<double, bool>, fn::pack<double, int>>>;
         static_assert(std::same_as<decltype(std::declval<Lh>() & std::declval<Rh>()),
@@ -505,7 +505,7 @@ TEST_CASE("optional pack support", "[optional][pack][and_then][transform][operat
       }
     }
 
-    WHEN("sum on right side only")
+    SECTION("sum on right side only")
     {
       using Lh = fn::optional<double>;
       using Rh = fn::optional<fn::sum<bool, int>>;
@@ -523,7 +523,7 @@ TEST_CASE("optional pack support", "[optional][pack][and_then][transform][operat
       CHECK(not(Lh{0.5} & Rh{std::nullopt}).has_value());
       CHECK(not(Lh{std::nullopt} & Rh{std::nullopt}).has_value());
 
-      WHEN("pack on left")
+      SECTION("pack on left")
       {
         using Lh = fn::optional<fn::pack<double, int>>;
         static_assert(std::same_as<decltype(std::declval<Lh>() & std::declval<Rh>()),
@@ -542,7 +542,7 @@ TEST_CASE("optional pack support", "[optional][pack][and_then][transform][operat
       }
     }
 
-    WHEN("constexpr")
+    SECTION("constexpr")
     {
       static_assert((fn::optional<double>{0.5} & fn::optional<int>{12})
                         .transform([](double d, int i) constexpr -> bool { return d == 0.5 && i == 12; })
@@ -586,7 +586,7 @@ TEST_CASE("optional and_then sum", "[optional][sum][and_then]")
   static_assert(not can_and_then_lval(fn::overload{[](int &) -> fn::optional<bool> { return {true}; }})); // partial
   static_assert(not can_and_then_lval(42));
 
-  WHEN("value")
+  SECTION("value")
   {
     fn::optional<fn::sum_for<Xint, int>> s{12};
     CHECK(s.and_then( //
@@ -634,7 +634,7 @@ TEST_CASE("optional and_then sum", "[optional][sum][and_then]")
             .value());
   }
 
-  WHEN("error")
+  SECTION("error")
   {
     fn::optional<fn::sum_for<Xint, int>> s{};
     CHECK(not s.and_then( //
@@ -653,7 +653,7 @@ TEST_CASE("optional and_then sum", "[optional][sum][and_then]")
                       [](auto) -> fn::optional<bool> { throw 0; })
                   .has_value());
 
-    WHEN("immovable result type")
+    SECTION("immovable result type")
     {
       // the disengaged path must compile even though the result cannot be moved (the
       // clang<=18 miscompile workaround must not force a move)
@@ -668,7 +668,7 @@ TEST_CASE("optional and_then sum", "[optional][sum][and_then]")
     }
   }
 
-  WHEN("constexpr")
+  SECTION("constexpr")
   {
     constexpr auto fn = fn::overload{[](int &) -> fn::optional<bool> { throw 0; },
                                      [](int const &i) -> fn::optional<bool> { return i == 42; },
@@ -707,7 +707,7 @@ TEST_CASE("optional transform sum", "[optional][sum][transform]")
   constexpr auto can_transform = [](auto &&f) { return requires { std::declval<S &>().transform(f); }; };
   static_assert(can_transform(nothrow_visitor));
 
-  WHEN("value")
+  SECTION("value")
   {
     fn::optional<fn::sum_for<Xint, int>> s{12};
     CHECK(s.transform( //
@@ -746,7 +746,7 @@ TEST_CASE("optional transform sum", "[optional][sum][transform]")
           == fn::sum{true});
   }
 
-  WHEN("error")
+  SECTION("error")
   {
     fn::optional<fn::sum_for<Xint, int>> s{};
     CHECK(not s.transform( //
@@ -766,7 +766,7 @@ TEST_CASE("optional transform sum", "[optional][sum][transform]")
                   .has_value());
   }
 
-  WHEN("constexpr")
+  SECTION("constexpr")
   {
     constexpr auto fn = fn::overload{[](int &) -> bool { throw 0; },
                                      [](int const &i) -> bool { return i == 42; },

--- a/tests/fn/optional.cpp
+++ b/tests/fn/optional.cpp
@@ -35,6 +35,12 @@ TEST_CASE("optional graded monad", "[optional][sum][graded][or_else][sum_value]"
     static_assert(std::is_same_v<decltype(std::as_const(s).sum_value()), T const &>);
     static_assert(std::is_same_v<decltype(std::move(std::as_const(s)).sum_value()), T const &&>);
     static_assert(std::is_same_v<decltype(std::move(s).sum_value()), T &&>);
+    // GAP: these overloads return *this by reference but are not declared noexcept
+    // (include/fn/optional.hpp:495-510, issue #276); asserts current behaviour until fixed.
+    static_assert(not noexcept(s.sum_value()));
+    static_assert(not noexcept(std::as_const(s).sum_value()));
+    static_assert(not noexcept(std::move(std::as_const(s)).sum_value()));
+    static_assert(not noexcept(std::move(s).sum_value()));
     WHEN("value")
     {
       CHECK(s.sum_value().value() == fn::sum{12});
@@ -62,6 +68,12 @@ TEST_CASE("optional graded monad", "[optional][sum][graded][or_else][sum_value]"
     static_assert(std::is_same_v<decltype(std::as_const(s).sum_value()), fn::optional<fn::sum<int>>>);
     static_assert(std::is_same_v<decltype(std::move(std::as_const(s)).sum_value()), fn::optional<fn::sum<int>>>);
     static_assert(std::is_same_v<decltype(std::move(s).sum_value()), fn::optional<fn::sum<int>>>);
+    // GAP: sum_value() here wraps the value in a fresh optional<sum<int>> and is likewise not
+    // declared noexcept (include/fn/optional.hpp:477/486, issue #276), even for a nothrow value type.
+    static_assert(not noexcept(s.sum_value()));
+    static_assert(not noexcept(std::as_const(s).sum_value()));
+    static_assert(not noexcept(std::move(std::as_const(s)).sum_value()));
+    static_assert(not noexcept(std::move(s).sum_value()));
     WHEN("value")
     {
       CHECK(s.sum_value().value() == fn::sum{12});

--- a/tests/fn/optional.cpp
+++ b/tests/fn/optional.cpp
@@ -114,6 +114,22 @@ TEST_CASE("optional graded monad", "[optional][sum][graded][or_else][sum_value]"
     constexpr auto fn8 = []() -> fn::optional<fn::sum_for<Xint, int, long>> { throw 0; };
     static_assert(std::is_same_v<decltype(s.or_else(fn8)), fn::optional<fn::sum_for<Xint, int, long>>>);
 
+    // noexcept (extension): true only when the callback is nothrow-invocable, returns exactly
+    // optional<sum<int>> (no widening), and *this is nothrow-constructible from itself.
+    constexpr auto nothrow_same = []() noexcept -> fn::optional<fn::sum<int>> { return {std::nullopt}; };
+    static_assert(noexcept(s.or_else(nothrow_same)));
+    static_assert(noexcept(std::move(s).or_else(nothrow_same)));
+    static_assert(not noexcept(s.or_else(fn3))); // fn3 throws
+    constexpr auto nothrow_widen = []() noexcept -> fn::optional<Xint> { return {std::nullopt}; };
+    static_assert(not noexcept(s.or_else(nothrow_widen))); // nothrow but widens to sum_for<Xint, int>
+
+    // constraints (extension): a non-invocable argument drops or_else from the overload set via
+    // SFINAE (the return-type-is-optional requirement is instead a Mandates static_assert inside).
+    constexpr auto can_or_else
+        = [](auto &&f) { return requires { std::declval<fn::optional<fn::sum<int>>>().or_else(f); }; };
+    static_assert(can_or_else(nothrow_same));
+    static_assert(not can_or_else(42));
+
     WHEN("error to value")
     {
       constexpr auto fn = []() -> fn::optional<Xint> { return {Xint{12}}; };

--- a/tests/fn/or_else.cpp
+++ b/tests/fn/or_else.cpp
@@ -68,48 +68,48 @@ TEST_CASE("or_else", "[or_else][expected][expected_value]")
   static_assert(is::not_invocable_with_any([]() -> operand_t { throw 0; }));                        // bad arity
   static_assert(is::not_invocable_with_any([](Error, int) -> operand_t { throw 0; }));              // bad arity
 
-  WHEN("operand is lvalue")
+  SECTION("lvalue")
   {
-    WHEN("operand is value")
+    SECTION("value")
     {
       operand_t a{std::in_place, 12};
 
-      WHEN("keep type")
+      SECTION("keep type")
       {
         using T = decltype(a | or_else(wrong));
         static_assert(std::is_same_v<T, operand_t>);
         REQUIRE((a | or_else(wrong)).value() == 12);
       }
 
-      WHEN("change type")
+      SECTION("change type")
       {
         using T = decltype(a | or_else(fnXerror));
         static_assert(std::is_same_v<T, fn::expected<int, Xerror>>);
         REQUIRE((a | or_else(wrong)).value() == 12);
       }
     }
-    WHEN("operand is error")
+    SECTION("error")
     {
       operand_t a{::fn::unexpect, Error{"Not good"}};
       using T = decltype(a | or_else(fnError));
       static_assert(std::is_same_v<T, operand_t>);
       REQUIRE((a | or_else(fnError)).value() == 8);
 
-      WHEN("fail")
+      SECTION("fail")
       {
         using T = decltype(a | or_else(fnFail));
         static_assert(std::is_same_v<T, operand_t>);
         REQUIRE((a | or_else(fnFail)).error().what == "Got: Not good");
       }
 
-      WHEN("change error type")
+      SECTION("change error type")
       {
         using T = decltype(a | or_else(fnXerror));
         static_assert(std::is_same_v<T, fn::expected<int, Xerror>>);
         REQUIRE((a | or_else(fnXerror)).error().what == "Was: Not good");
       }
     }
-    WHEN("calling member function")
+    SECTION("member function")
     {
       operand_t a{::fn::unexpect, Error{"Not good"}};
       using T = decltype(a | or_else(&Error::fn<operand_t>));
@@ -118,21 +118,21 @@ TEST_CASE("or_else", "[or_else][expected][expected_value]")
     }
   }
 
-  WHEN("operand is rvalue")
+  SECTION("rvalue")
   {
-    WHEN("operand is value")
+    SECTION("value")
     {
       using T = decltype(operand_t{std::in_place, 12} | or_else(wrong));
       static_assert(std::is_same_v<T, operand_t>);
       REQUIRE((operand_t{std::in_place, 12} | or_else(wrong)).value() == 12);
     }
-    WHEN("operand is error")
+    SECTION("error")
     {
       using T = decltype(operand_t{::fn::unexpect, Error{"Not good"}} | or_else(fnError));
       static_assert(std::is_same_v<T, operand_t>);
       REQUIRE((operand_t{::fn::unexpect, Error{"Not good"}} | or_else(fnError)).value() == 8);
 
-      WHEN("fail")
+      SECTION("fail")
       {
         using T = decltype(operand_t{::fn::unexpect, Error{"Not good"}} | or_else(fnFail));
         static_assert(std::is_same_v<T, operand_t>);
@@ -143,11 +143,120 @@ TEST_CASE("or_else", "[or_else][expected][expected_value]")
                 == "Got: Not good");
       }
     }
-    WHEN("calling member function")
+    SECTION("member function")
     {
       using T = decltype(operand_t{::fn::unexpect, Error{"Not good"}} | or_else(&Error::fn<operand_t>));
       static_assert(std::is_same_v<T, operand_t>);
       REQUIRE((operand_t{::fn::unexpect, Error{"Not good"}} | or_else(&Error::fn<operand_t>)).value() == 8);
+    }
+  }
+
+  SECTION("constexpr")
+  {
+    enum class Error { ThresholdExceeded, SomethingElse };
+    using T = fn::expected<int, Error>;
+
+    SECTION("same error type")
+    {
+      constexpr auto fn = [](Error e) constexpr noexcept -> T {
+        if (e == Error::SomethingElse)
+          return {0};
+        return ::fn::unexpected<Error>{e};
+      };
+      constexpr auto r1 = T{0} | fn::or_else(fn);
+      static_assert(r1.value() == 0);
+      constexpr auto r2 = T{::fn::unexpect, Error::SomethingElse} | fn::or_else(fn);
+      static_assert(r2.value() == 0);
+      constexpr auto r3 = T{::fn::unexpect, Error::ThresholdExceeded} | fn::or_else(fn);
+      static_assert(r3.error() == Error::ThresholdExceeded);
+
+      SUCCEED();
+    }
+
+    SECTION("different error type")
+    {
+      struct UnrecoverableError final {
+        constexpr UnrecoverableError() {}
+        constexpr bool operator==(UnrecoverableError const &) const noexcept = default;
+      };
+      using T1 = fn::expected<int, UnrecoverableError>;
+      constexpr auto fn = [](Error e) constexpr noexcept -> T1 {
+        if (e == Error::SomethingElse)
+          return {true};
+        return T1{::fn::unexpect};
+      };
+      constexpr auto r1 = T{::fn::unexpect, Error::SomethingElse} | fn::or_else(fn);
+      static_assert(std::is_same_v<decltype(r1), fn::expected<int, UnrecoverableError> const>);
+      static_assert(r1.value() == true);
+      constexpr auto r2 = T{::fn::unexpect, Error::ThresholdExceeded} | fn::or_else(fn);
+      static_assert(r2.error() == UnrecoverableError{});
+
+      SUCCEED();
+    }
+
+    SECTION("sum")
+    {
+      enum class Error { ThresholdExceeded, SomethingElse, UnexpectedType };
+      using T = fn::expected<int, fn::sum_for<Error, int>>;
+
+      SECTION("same error type")
+      {
+        constexpr auto fn = fn::overload{[](int i) constexpr noexcept -> T {
+                                           if (i < 3)
+                                             return {i + 1};
+                                           return ::fn::unexpected<fn::sum_for<Error, int>>{Error::ThresholdExceeded};
+                                         },
+                                         [](Error v) constexpr noexcept -> T { return {static_cast<int>(v)}; }};
+        constexpr auto r1 = T{::fn::unexpect, 0} | fn::or_else(fn);
+        static_assert(r1.value() == 1);
+        constexpr auto r2 = T{::fn::unexpect, 3} | fn::or_else(fn);
+        static_assert(r2.error() == fn::sum{Error::ThresholdExceeded});
+
+        SUCCEED();
+      }
+
+      SECTION("different error type")
+      {
+        using T1 = fn::expected<int, Error>;
+        constexpr auto fn = fn::overload{
+            [](int i) constexpr noexcept -> T1 {
+              if (i < 2)
+                return {i + 1};
+              return ::fn::unexpected<Error>{Error::SomethingElse};
+            },
+            [](Error) constexpr noexcept -> T1 { return ::fn::unexpected<Error>{Error::UnexpectedType}; }};
+        constexpr auto r1 = T{::fn::unexpect, 1} | fn::or_else(fn);
+        static_assert(std::is_same_v<decltype(r1), fn::expected<int, Error> const>);
+        static_assert(r1.value() == 2);
+        constexpr auto r2 = T{::fn::unexpect, 2} | fn::or_else(fn);
+        static_assert(r2.error() == Error::SomethingElse);
+        constexpr auto r3 = T{::fn::unexpect, Error::ThresholdExceeded} | fn::or_else(fn);
+        static_assert(r3.error() == Error::UnexpectedType);
+
+        SUCCEED();
+      }
+    }
+
+    SECTION("graded")
+    {
+      enum class Error : int { Unknown, InvalidValue };
+      using T = fn::expected<fn::sum<int>, Error>;
+
+      constexpr auto fn1 = [](Error i) -> fn::expected<int, int> {
+        if (i == Error::Unknown)
+          return {0};
+        return ::fn::unexpected<int>{(int)i};
+      };
+
+      constexpr auto r1 = T{14} | fn::or_else(fn1);
+      static_assert(std::is_same_v<decltype(r1), fn::expected<fn::sum<int>, int> const>);
+      static_assert(r1.value() == fn::sum{14});
+      constexpr auto r2 = T{::fn::unexpect, Error::InvalidValue} | fn::or_else(fn1);
+      static_assert(r2.error() == 1);
+      constexpr auto r3 = T{::fn::unexpect, Error::Unknown} | fn::or_else(fn1);
+      static_assert(r3.value() == fn::sum{0});
+
+      SUCCEED();
     }
   }
 }
@@ -220,9 +329,9 @@ TEST_CASE("or_else", "[or_else][expected][expected_void]")
   static_assert(is::not_invocable_with_any([]() -> operand_t { throw 0; }));                        // bad arity
   static_assert(is::not_invocable_with_any([](Error, int) -> operand_t { throw 0; }));              // bad arity
 
-  WHEN("operand is lvalue")
+  SECTION("lvalue")
   {
-    WHEN("operand is value")
+    SECTION("value")
     {
       operand_t a{std::in_place};
       using T = decltype(a | or_else(wrong));
@@ -230,7 +339,7 @@ TEST_CASE("or_else", "[or_else][expected][expected_void]")
       (a | or_else(wrong)).value();
       CHECK(count == 0);
     }
-    WHEN("operand is error")
+    SECTION("error")
     {
       operand_t a{::fn::unexpect, Error{"Not good"}};
       using T = decltype(a | or_else(fnError));
@@ -238,7 +347,7 @@ TEST_CASE("or_else", "[or_else][expected][expected_void]")
       (a | or_else(fnError)).value();
       CHECK(count == 1);
 
-      WHEN("fail")
+      SECTION("fail")
       {
         using T = decltype(a | or_else(fnFail));
         static_assert(std::is_same_v<T, operand_t>);
@@ -246,14 +355,14 @@ TEST_CASE("or_else", "[or_else][expected][expected_void]")
         CHECK(count == 1);
       }
 
-      WHEN("change error type")
+      SECTION("change error type")
       {
         using T = decltype(a | or_else(fnXerror));
         static_assert(std::is_same_v<T, fn::expected<void, Xerror>>);
         REQUIRE((a | or_else(fnXerror)).error().what == "Was: Not good");
       }
     }
-    WHEN("calling member function")
+    SECTION("member function")
     {
       operand_t a{::fn::unexpect, Error{"Not good"}};
       using T = decltype(a | or_else(&Error::finalize<operand_t>));
@@ -264,22 +373,22 @@ TEST_CASE("or_else", "[or_else][expected][expected_void]")
     }
   }
 
-  WHEN("operand is rvalue")
+  SECTION("rvalue")
   {
-    WHEN("operand is value")
+    SECTION("value")
     {
       using T = decltype(operand_t{std::in_place} | or_else(wrong));
       static_assert(std::is_same_v<T, operand_t>);
       (operand_t{std::in_place} | or_else(wrong)).value();
       CHECK(count == 0);
     }
-    WHEN("operand is error")
+    SECTION("error")
     {
       using T = decltype(operand_t{::fn::unexpect, Error{"Not good"}} | or_else(fnError));
       static_assert(std::is_same_v<T, operand_t>);
       (operand_t{::fn::unexpect, Error{"Not good"}} | or_else(fnError)).value();
 
-      WHEN("fail")
+      SECTION("fail")
       {
         using T = decltype(operand_t{::fn::unexpect, Error{"Not good"}} | or_else(fnFail));
         static_assert(std::is_same_v<T, operand_t>);
@@ -290,7 +399,7 @@ TEST_CASE("or_else", "[or_else][expected][expected_void]")
                 == "Got: Not good");
       }
     }
-    WHEN("calling member function")
+    SECTION("member function")
     {
       using T = decltype(operand_t{::fn::unexpect, Error{"Not good"}} | or_else(&Error::finalize<operand_t>));
       static_assert(std::is_same_v<T, operand_t>);
@@ -342,23 +451,23 @@ TEST_CASE("or_else", "[or_else][optional]")
   static_assert(is::not_invocable_with_any([](int) -> operand_t { throw 0; }));                     // bad arity
   static_assert(is::not_invocable_with_any([](int, int) -> operand_t { throw 0; }));                // bad arity
 
-  WHEN("operand is lvalue")
+  SECTION("lvalue")
   {
-    WHEN("operand is value")
+    SECTION("value")
     {
       operand_t a{12};
       using T = decltype(a | or_else(wrong));
       static_assert(std::is_same_v<T, operand_t>);
       REQUIRE((a | or_else(wrong)).value() == 12);
     }
-    WHEN("operand is error")
+    SECTION("error")
     {
       operand_t a{std::nullopt};
       using T = decltype(a | or_else(fnError));
       static_assert(std::is_same_v<T, operand_t>);
       REQUIRE((a | or_else(fnError)).value() == 42);
 
-      WHEN("fail")
+      SECTION("fail")
       {
         using T = decltype(a | or_else(fnFail));
         static_assert(std::is_same_v<T, operand_t>);
@@ -367,26 +476,51 @@ TEST_CASE("or_else", "[or_else][optional]")
     }
   }
 
-  WHEN("operand is rvalue")
+  SECTION("rvalue")
   {
-    WHEN("operand is value")
+    SECTION("value")
     {
       using T = decltype(operand_t{12} | or_else(wrong));
       static_assert(std::is_same_v<T, operand_t>);
       REQUIRE((operand_t{12} | or_else(wrong)).value() == 12);
     }
-    WHEN("operand is error")
+    SECTION("error")
     {
       using T = decltype(operand_t{std::nullopt} | or_else(fnError));
       static_assert(std::is_same_v<T, operand_t>);
       REQUIRE((operand_t{std::nullopt} | or_else(fnError)).value() == 42);
 
-      WHEN("fail")
+      SECTION("fail")
       {
         using T = decltype(operand_t{std::nullopt} | or_else(fnFail));
         static_assert(std::is_same_v<T, operand_t>);
         REQUIRE(not(operand_t{std::nullopt} | or_else(fnFail)).has_value());
       }
+    }
+  }
+
+  SECTION("constexpr")
+  {
+    using T = fn::optional<int>;
+    constexpr auto fn = []() constexpr noexcept -> T { return {1}; };
+    constexpr auto r1 = T{0} | fn::or_else(fn);
+    static_assert(r1.value() == 0);
+    constexpr auto r2 = T{} | fn::or_else(fn);
+    static_assert(r2.value() == 1);
+
+    SUCCEED();
+
+    SECTION("sum")
+    {
+      using T = fn::optional<fn::sum<int>>;
+      constexpr auto fn = []() constexpr noexcept -> fn::optional<unsigned long> { return {1ul}; };
+      constexpr auto r1 = T{0} | fn::or_else(fn);
+      static_assert(std::is_same_v<decltype(r1), fn::optional<fn::sum<int, unsigned long>> const>);
+      static_assert(r1.value() == fn::sum{0});
+      constexpr auto r2 = T{} | fn::or_else(fn);
+      static_assert(r2.value() == fn::sum{1ul});
+
+      SUCCEED();
     }
   }
 }
@@ -404,139 +538,6 @@ TEST_CASE("or_else noexcept", "[or_else][optional][noexcept]")
   static_assert(not noexcept(std::declval<operand_t &>().or_else(fnThrows)));
 
   static_assert(noexcept(or_else_t::apply{}(std::declval<operand_t &>(), fnThrows))); // GAP #285
-
-  SUCCEED();
-}
-
-TEST_CASE("constexpr or_else expected", "[or_else][constexpr][expected]")
-{
-  enum class Error { ThresholdExceeded, SomethingElse };
-  using T = fn::expected<int, Error>;
-
-  WHEN("same error type")
-  {
-    constexpr auto fn = [](Error e) constexpr noexcept -> T {
-      if (e == Error::SomethingElse)
-        return {0};
-      return ::fn::unexpected<Error>{e};
-    };
-    constexpr auto r1 = T{0} | fn::or_else(fn);
-    static_assert(r1.value() == 0);
-    constexpr auto r2 = T{::fn::unexpect, Error::SomethingElse} | fn::or_else(fn);
-    static_assert(r2.value() == 0);
-    constexpr auto r3 = T{::fn::unexpect, Error::ThresholdExceeded} | fn::or_else(fn);
-    static_assert(r3.error() == Error::ThresholdExceeded);
-  }
-
-  WHEN("different error type")
-  {
-    struct UnrecoverableError final {
-      constexpr UnrecoverableError() {}
-      constexpr bool operator==(UnrecoverableError const &) const noexcept = default;
-    };
-    using T1 = fn::expected<int, UnrecoverableError>;
-    constexpr auto fn = [](Error e) constexpr noexcept -> T1 {
-      if (e == Error::SomethingElse)
-        return {true};
-      return T1{::fn::unexpect};
-    };
-    constexpr auto r1 = T{::fn::unexpect, Error::SomethingElse} | fn::or_else(fn);
-    static_assert(std::is_same_v<decltype(r1), fn::expected<int, UnrecoverableError> const>);
-    static_assert(r1.value() == true);
-    constexpr auto r2 = T{::fn::unexpect, Error::ThresholdExceeded} | fn::or_else(fn);
-    static_assert(r2.error() == UnrecoverableError{});
-  }
-
-  SUCCEED();
-}
-
-TEST_CASE("constexpr or_else expected with sum", "[or_else][constexpr][expected][sum]")
-{
-  enum class Error { ThresholdExceeded, SomethingElse, UnexpectedType };
-  using T = fn::expected<int, fn::sum_for<Error, int>>;
-
-  WHEN("same error type")
-  {
-    constexpr auto fn = fn::overload{[](int i) constexpr noexcept -> T {
-                                       if (i < 3)
-                                         return {i + 1};
-                                       return ::fn::unexpected<fn::sum_for<Error, int>>{Error::ThresholdExceeded};
-                                     },
-                                     [](Error v) constexpr noexcept -> T { return {static_cast<int>(v)}; }};
-    constexpr auto r1 = T{::fn::unexpect, 0} | fn::or_else(fn);
-    static_assert(r1.value() == 1);
-    constexpr auto r2 = T{::fn::unexpect, 3} | fn::or_else(fn);
-    static_assert(r2.error() == fn::sum{Error::ThresholdExceeded});
-  }
-
-  WHEN("different error type")
-  {
-    using T1 = fn::expected<int, Error>;
-    constexpr auto fn
-        = fn::overload{[](int i) constexpr noexcept -> T1 {
-                         if (i < 2)
-                           return {i + 1};
-                         return ::fn::unexpected<Error>{Error::SomethingElse};
-                       },
-                       [](Error) constexpr noexcept -> T1 { return ::fn::unexpected<Error>{Error::UnexpectedType}; }};
-    constexpr auto r1 = T{::fn::unexpect, 1} | fn::or_else(fn);
-    static_assert(std::is_same_v<decltype(r1), fn::expected<int, Error> const>);
-    static_assert(r1.value() == 2);
-    constexpr auto r2 = T{::fn::unexpect, 2} | fn::or_else(fn);
-    static_assert(r2.error() == Error::SomethingElse);
-    constexpr auto r3 = T{::fn::unexpect, Error::ThresholdExceeded} | fn::or_else(fn);
-    static_assert(r3.error() == Error::UnexpectedType);
-  }
-
-  SUCCEED();
-}
-
-TEST_CASE("constexpr or_else graded monad", "[or_else][constexpr][expected][graded]")
-{
-  enum class Error : int { Unknown, InvalidValue };
-  using T = fn::expected<fn::sum<int>, Error>;
-
-  WHEN("same error type")
-  {
-    constexpr auto fn1 = [](Error i) -> fn::expected<int, int> {
-      if (i == Error::Unknown)
-        return {0};
-      return ::fn::unexpected<int>{(int)i};
-    };
-
-    constexpr auto r1 = T{14} | fn::or_else(fn1);
-    static_assert(std::is_same_v<decltype(r1), fn::expected<fn::sum<int>, int> const>);
-    static_assert(r1.value() == fn::sum{14});
-    constexpr auto r2 = T{::fn::unexpect, Error::InvalidValue} | fn::or_else(fn1);
-    static_assert(r2.error() == 1);
-    constexpr auto r3 = T{::fn::unexpect, Error::Unknown} | fn::or_else(fn1);
-    static_assert(r3.value() == fn::sum{0});
-  }
-
-  SUCCEED();
-}
-
-TEST_CASE("constexpr or_else optional", "[or_else][constexpr][optional]")
-{
-  using T = fn::optional<int>;
-  constexpr auto fn = []() constexpr noexcept -> T { return {1}; };
-  constexpr auto r1 = T{0} | fn::or_else(fn);
-  static_assert(r1.value() == 0);
-  constexpr auto r2 = T{} | fn::or_else(fn);
-  static_assert(r2.value() == 1);
-
-  SUCCEED();
-}
-
-TEST_CASE("constexpr or_else optional with sum", "[or_else][constexpr][optional][sum]")
-{
-  using T = fn::optional<fn::sum<int>>;
-  constexpr auto fn = []() constexpr noexcept -> fn::optional<unsigned long> { return {1ul}; };
-  constexpr auto r1 = T{0} | fn::or_else(fn);
-  static_assert(std::is_same_v<decltype(r1), fn::optional<fn::sum<int, unsigned long>> const>);
-  static_assert(r1.value() == fn::sum{0});
-  constexpr auto r2 = T{} | fn::or_else(fn);
-  static_assert(r2.value() == fn::sum{1ul});
 
   SUCCEED();
 }

--- a/tests/fn/or_else.cpp
+++ b/tests/fn/or_else.cpp
@@ -152,6 +152,37 @@ TEST_CASE("or_else", "[or_else][expected][expected_value]")
   }
 }
 
+TEST_CASE("or_else noexcept", "[or_else][expected][expected_value][noexcept]")
+{
+  using namespace fn;
+
+  using operand_t = fn::expected<int, Error>;
+
+  // Taken by const reference: a by-value Error would copy its std::string on the way in, which is
+  // itself a throwing operation and would mask what the callback promises.
+  constexpr auto fnNothrow = [](Error const &) noexcept -> operand_t { return {0}; };
+  constexpr auto fnThrows = [](Error const &) noexcept(false) -> operand_t { return {0}; };
+
+  // The member's spec is precise: here the untouched value is an int, whose copy cannot throw, so
+  // the callback alone decides.
+  static_assert(noexcept(std::declval<operand_t &>().or_else(fnNothrow)));
+  static_assert(not noexcept(std::declval<operand_t &>().or_else(fnThrows)));
+
+  // It weighs the copy of the untouched VALUE as well - the mirror of what and_then does with the
+  // untouched error. Give it a value whose copy can throw and even a noexcept callback leaves the
+  // member potentially-throwing.
+  using throwing_value_t = fn::expected<std::string, Error>;
+  constexpr auto fnNothrow2 = [](Error const &) noexcept -> throwing_value_t { return {""}; };
+  static_assert(not std::is_nothrow_copy_constructible_v<std::string>);
+  static_assert(not noexcept(std::declval<throwing_value_t &>().or_else(fnNothrow2)));
+
+  // GAP #285: or_else_t::apply then discards all of that, being unconditionally noexcept - as is the
+  // rest of the pipeline it is reached through (pinned in tests/fn/functor.cpp).
+  static_assert(noexcept(or_else_t::apply{}(std::declval<operand_t &>(), fnThrows)));
+
+  SUCCEED();
+}
+
 TEST_CASE("or_else", "[or_else][expected][expected_void]")
 {
   using namespace fn;
@@ -270,6 +301,24 @@ TEST_CASE("or_else", "[or_else][expected][expected_void]")
   }
 }
 
+TEST_CASE("or_else noexcept", "[or_else][expected][expected_void][noexcept]")
+{
+  using namespace fn;
+
+  using operand_t = fn::expected<void, Error>;
+
+  constexpr auto fnNothrow = [](Error const &) noexcept -> operand_t { return {}; };
+  constexpr auto fnThrows = [](Error const &) noexcept(false) -> operand_t { return {}; };
+
+  // With a void value there is nothing on the untouched side to copy, so the callback alone decides.
+  static_assert(noexcept(std::declval<operand_t &>().or_else(fnNothrow)));
+  static_assert(not noexcept(std::declval<operand_t &>().or_else(fnThrows)));
+
+  static_assert(noexcept(or_else_t::apply{}(std::declval<operand_t &>(), fnThrows))); // GAP #285
+
+  SUCCEED();
+}
+
 TEST_CASE("or_else", "[or_else][optional]")
 {
   using namespace fn;
@@ -340,6 +389,23 @@ TEST_CASE("or_else", "[or_else][optional]")
       }
     }
   }
+}
+
+TEST_CASE("or_else noexcept", "[or_else][optional][noexcept]")
+{
+  using namespace fn;
+
+  using operand_t = fn::optional<int>;
+
+  constexpr auto fnNothrow = []() noexcept -> operand_t { return {42}; };
+  constexpr auto fnThrows = []() noexcept(false) -> operand_t { return {42}; };
+
+  static_assert(noexcept(std::declval<operand_t &>().or_else(fnNothrow)));
+  static_assert(not noexcept(std::declval<operand_t &>().or_else(fnThrows)));
+
+  static_assert(noexcept(or_else_t::apply{}(std::declval<operand_t &>(), fnThrows))); // GAP #285
+
+  SUCCEED();
 }
 
 TEST_CASE("constexpr or_else expected", "[or_else][constexpr][expected]")

--- a/tests/fn/pack.cpp
+++ b/tests/fn/pack.cpp
@@ -4,7 +4,6 @@
 // or copy at https://opensource.org/licenses/ISC
 
 #include "util/helper_types.hpp"
-#include "util/static_check.hpp"
 
 #include <fn/functional.hpp>
 #include <fn/optional.hpp>
@@ -328,7 +327,6 @@ TEST_CASE("append value categories", "[pack][append]")
 TEST_CASE("pack with immovable data", "[pack][immovable]")
 {
   using fn::pack;
-  using util::static_check;
 
   struct ImmovableType {
     int value = 0;
@@ -348,15 +346,14 @@ TEST_CASE("pack with immovable data", "[pack][immovable]")
   ImmovableType const val2{92};
   T v{ImmovableType{3}, ImmovableType{14}, val1, val2};
 
-  using is
-      = static_check::bind<decltype([](auto &&fn) constexpr { return requires { std::declval<T>().invoke(fn); }; })>;
+  constexpr auto can_invoke = [](auto &&fn) constexpr { return requires { std::declval<T>().invoke(fn); }; };
 
-  static_assert(is::invocable([](auto &&...) {})); // generic call
-  static_assert(is::invocable([](ImmovableType const &, ImmovableType const &, ImmovableType const &,
-                                 ImmovableType const &) {})); // pass everything by const reference
-  static_assert(is::invocable([](ImmovableType &&, ImmovableType const &&, ImmovableType &, ImmovableType const &) {
-  }));                                                                // bind rvalues and lvalues
-  static_assert(is::not_invocable([](ImmovableType, auto &&...) {})); // cannot pass immovable by value
+  static_assert(can_invoke([](auto &&...) {})); // generic call
+  static_assert(can_invoke([](ImmovableType const &, ImmovableType const &, ImmovableType const &,
+                              ImmovableType const &) {})); // pass everything by const reference
+  static_assert(can_invoke([](ImmovableType &&, ImmovableType const &&, ImmovableType &, ImmovableType const &) {
+  }));                                                             // bind rvalues and lvalues
+  static_assert(not can_invoke([](ImmovableType, auto &&...) {})); // cannot pass immovable by value
 
   CHECK(v.invoke([](auto &&...args) noexcept -> int { return (0 + ... + args.value); }) == 3 + 14 + 15 + 92);
 }

--- a/tests/fn/pack.cpp
+++ b/tests/fn/pack.cpp
@@ -3,6 +3,7 @@
 // Distributed under the ISC License. See accompanying file LICENSE.md
 // or copy at https://opensource.org/licenses/ISC
 
+#include "util/helper_types.hpp"
 #include "util/static_check.hpp"
 
 #include <fn/functional.hpp>
@@ -26,6 +27,16 @@ concept pack_check = requires(V v, Fn fn) { FWD(v).invoke(FWD(fn), A{}); };
 template <fn::pack<int, double> P> struct pack_nttp final {};
 template <fn::some_pack auto P> struct some_pack_nttp final {};
 template <fn::some_pack auto P> auto read_nttp() { return fn::get<0>(P); }
+
+template <typename V, typename R, typename Fn>
+concept can_invoke_r = requires(V v, Fn fn) { FWD(v).template invoke_r<R>(FWD(fn)); };
+
+template <typename V, typename T, typename... Args>
+concept can_append_in_place = requires(V v, Args... args) { FWD(v).append(std::in_place_type<T>, args...); };
+
+// A pack element whose copy and move can both throw, while the pack member relocating it promises
+// noexcept regardless. Witnesses the #280 tripwires below.
+using Throwing = helper_t<prop::throw_copy | prop::throw_move>;
 
 } // namespace
 
@@ -132,6 +143,38 @@ TEST_CASE("pack", "[pack]")
   static_assert(std::is_same_v<some_pack_nttp<s1>, some_pack_nttp<s2>>);
   static_assert(not std::is_same_v<some_pack_nttp<s1>, some_pack_nttp<s3>>);
   CHECK(read_nttp<s1>() == 3); // the template-parameter object is usable at runtime
+
+  WHEN("invoke_r return conversion")
+  {
+    struct NotFromInt final {
+      explicit NotFromInt(std::nullptr_t) {}
+    };
+    constexpr auto sum_fn = [](auto... args) noexcept -> int { return (0 + ... + args); };
+
+    static_assert(can_invoke_r<T &, long, decltype(sum_fn)>);
+    static_assert(not can_invoke_r<T &, NotFromInt, decltype(sum_fn)>); // int does not convert to it
+    SUCCEED();
+  }
+
+  WHEN("noexcept")
+  {
+    // GAP #280: invoke and invoke_r are unconditionally noexcept whatever the callback promises,
+    // so a throwing callback terminates instead of propagating.
+    constexpr auto throwing = [](auto &&...) noexcept(false) -> int { return 0; };
+    static_assert(not noexcept(throwing()));
+    static_assert(noexcept(v.invoke(throwing)));
+    static_assert(noexcept(std::as_const(v).invoke(throwing)));
+    static_assert(noexcept(std::move(v).invoke(throwing)));
+    static_assert(noexcept(std::move(std::as_const(v)).invoke(throwing)));
+    static_assert(noexcept(v.invoke_r<long>(throwing)));
+    static_assert(noexcept(std::move(v).invoke_r<long>(throwing)));
+
+    // GAP #280 (converse): the as_pack lifts carry no noexcept specifier, so they report
+    // noexcept(false) even where nothing can throw.
+    static_assert(not noexcept(fn::as_pack()));
+    static_assert(not noexcept(fn::as_pack(true, 12)));
+    SUCCEED();
+  }
 }
 
 TEST_CASE("append value categories", "[pack][append]")
@@ -237,6 +280,48 @@ TEST_CASE("append value categories", "[pack][append]")
     CHECK(c2.invoke([](bool i, int j, B const &b1, C const &c, B const &b2) {
       return i && j == 3 && b1.v == 14 && c.v == 30 && b2.v == 20;
     }));
+  }
+
+  WHEN("constraints")
+  {
+    static_assert(can_append_in_place<T &, B, int>);
+    static_assert(can_append_in_place<T &, B, int, int>);
+    static_assert(not can_append_in_place<T &, B, char const *>); // B is not constructible from it
+
+    // GAP #283: given no arguments and an element with no default constructor, the in_place overload
+    // drops out on its is_constructible_v conjunct and the deduced-Arg overload picks the call up
+    // instead - silently appending the TAG as an element rather than failing. So the call below is
+    // "viable" for entirely the wrong reason, and the element type says so.
+    static_assert(can_append_in_place<T &, B>);
+    static_assert(std::same_as<decltype(std::declval<T &>().append(std::in_place_type<B>)),
+                               T::append_type<std::in_place_type_t<B> const &>>);
+    // A default-constructible element takes the intended path - see WHEN("default constructor").
+    static_assert(std::same_as<decltype(std::declval<T &>().append(std::in_place_type<C>)), T::append_type<C>>);
+
+    // GAP #282: a pack never holds a sum, but merely ASKING whether one can be appended is a hard
+    // error on gcc (ambiguous partial specialization of _pack_append), so no negative probe is
+    // portable here until that is fixed.
+
+    SUCCEED();
+  }
+
+  WHEN("noexcept")
+  {
+    // GAP #280: every append overload is unconditionally noexcept, though _append both constructs
+    // the new element and relocates every existing one into the new pack.
+    using P = pack<Throwing>;
+    static_assert(not std::is_nothrow_copy_constructible_v<Throwing>);
+    static_assert(not std::is_nothrow_move_constructible_v<Throwing>);
+
+    // constructing the appended element by a throwing copy
+    static_assert(
+        noexcept(std::declval<pack<int> &>().append(std::in_place_type<Throwing>, std::declval<Throwing const &>())));
+    // ... and relocating an existing throwing element, even where the appended one cannot throw
+    static_assert(noexcept(std::declval<P &>().append(std::in_place_type<int>, 1)));
+    static_assert(noexcept(std::declval<P const &>().append(std::in_place_type<int>, 1)));
+    static_assert(noexcept(std::declval<P &&>().append(std::in_place_type<int>, 1)));
+    static_assert(noexcept(std::declval<P &>().append(1))); // deduced form
+    SUCCEED();
   }
 }
 
@@ -693,6 +778,16 @@ TEST_CASE("operator &", "[pack][sum][operator_and]")
                     fn::pack<int, int, double, double, bool, double, int>> const>);
   static_assert(r2.invoke([](auto &&...args) -> double { return (1 * ... * static_cast<double>(args)); })
                 == 12. * 3 * 2.5 * 0.5 * 1 * 1.5 * 12);
+
+  WHEN("noexcept")
+  {
+    // This operator& carries no noexcept specifier, so it never over-promises - in contrast with
+    // optional's and expected's, which are unconditionally noexcept although the join copies the
+    // operands' values into the result pack (#279).
+    static_assert(not noexcept(std::declval<fn::pack<int> &>() & 2));
+    static_assert(not noexcept(std::declval<fn::sum<int> &>() & 2));
+    SUCCEED();
+  }
 }
 
 namespace {
@@ -726,6 +821,11 @@ TEST_CASE("pack get and tuple protocol", "[pack][get][tuple]")
   CHECK(get<1>(p) == 4.0);
   get<0>(p) = 7;
   CHECK(get<0>(p) == 7);
+
+  // accurate, unlike the members that relocate elements: get only forms a reference
+  static_assert(noexcept(get<0>(p)));
+  static_assert(noexcept(get<0>(std::move(p))));
+  static_assert(noexcept(get<0>(std::declval<pack<Throwing> &>())));
 
   // out-of-range index is not viable (SFINAE-clean, not a hard error)
   static_assert(can_get<pack<int, double> &, 0>);

--- a/tests/fn/pack.cpp
+++ b/tests/fn/pack.cpp
@@ -143,7 +143,7 @@ TEST_CASE("pack", "[pack]")
   static_assert(not std::is_same_v<some_pack_nttp<s1>, some_pack_nttp<s3>>);
   CHECK(read_nttp<s1>() == 3); // the template-parameter object is usable at runtime
 
-  WHEN("invoke_r return conversion")
+  SECTION("invoke_r return conversion")
   {
     struct NotFromInt final {
       explicit NotFromInt(std::nullptr_t) {}
@@ -155,7 +155,7 @@ TEST_CASE("pack", "[pack]")
     SUCCEED();
   }
 
-  WHEN("noexcept")
+  SECTION("noexcept")
   {
     // GAP #280: invoke and invoke_r are unconditionally noexcept whatever the callback promises,
     // so a throwing callback terminates instead of propagating.
@@ -172,6 +172,14 @@ TEST_CASE("pack", "[pack]")
     // noexcept(false) even where nothing can throw.
     static_assert(not noexcept(fn::as_pack()));
     static_assert(not noexcept(fn::as_pack(true, 12)));
+    SUCCEED();
+  }
+
+  SECTION("constexpr")
+  {
+    constexpr fn::pack<int, int> v2{3, 14};
+    constexpr auto r2 = v2.invoke([](auto &&...args) constexpr noexcept -> int { return (0 + ... + args); });
+    static_assert(r2 == 3 + 14);
     SUCCEED();
   }
 }
@@ -199,7 +207,7 @@ TEST_CASE("append value categories", "[pack][append]")
     return i == 12 && s == std::string("bar") && a.v == 42 && b.v == 30;
   };
 
-  WHEN("explicit type selection")
+  SECTION("explicit type selection")
   {
     static_assert(std::same_as<decltype(s.append(std::in_place_type<B>, 5, 6)), T::append_type<B>>);
     static_assert(std::same_as<T::append_type<B>, pack<int, std::string_view, A, B>>);
@@ -213,7 +221,7 @@ TEST_CASE("append value categories", "[pack][append]")
     static_assert(std::same_as<decltype(s.append(std::in_place_type<B &>, c2)), T::append_type<B &>>);
     static_assert(std::same_as<T::append_type<B &>, pack<int, std::string_view, A, B &>>);
 
-    WHEN("constructor takes parameters")
+    SECTION("constructor takes parameters")
     {
       CHECK(s.append(std::in_place_type<B>, 5, 6).invoke(check));
       CHECK(std::as_const(s).append(std::in_place_type<B>, 5, 6).invoke(check));
@@ -221,7 +229,7 @@ TEST_CASE("append value categories", "[pack][append]")
       CHECK(std::move(s).append(std::in_place_type<B>, 5, 6).invoke(check));
     }
 
-    WHEN("constructor takes parameters invoke_r")
+    SECTION("constructor takes parameters invoke_r")
     {
       CHECK(s.append(std::in_place_type<B>, 5, 6).invoke_r<bool>(check));
       CHECK(std::as_const(s).append(std::in_place_type<B>, 5, 6).invoke_r<bool>(check));
@@ -229,7 +237,7 @@ TEST_CASE("append value categories", "[pack][append]")
       CHECK(std::move(s).append(std::in_place_type<B>, 5, 6).invoke_r<bool>(check));
     }
 
-    WHEN("default constructor")
+    SECTION("default constructor")
     {
       CHECK(s.append(std::in_place_type<C>).invoke(check));
       CHECK(std::as_const(s).append(std::in_place_type<C>).invoke(check));
@@ -237,7 +245,7 @@ TEST_CASE("append value categories", "[pack][append]")
       CHECK(std::move(s).append(std::in_place_type<C>).invoke(check));
     }
 
-    WHEN("default constructor invoke_r")
+    SECTION("default constructor invoke_r")
     {
       CHECK(s.append(std::in_place_type<C>).invoke_r<int>(check) == 1);
       CHECK(std::as_const(s).append(std::in_place_type<C>).invoke_r<int>(check) == 1);
@@ -246,7 +254,7 @@ TEST_CASE("append value categories", "[pack][append]")
     }
   }
 
-  WHEN("deduced type")
+  SECTION("deduced type")
   {
     static_assert(std::same_as<decltype(s.append(B{5, 6})), T::append_type<B>>);
 
@@ -264,7 +272,7 @@ TEST_CASE("append value categories", "[pack][append]")
     CHECK(std::move(s).append(B{30}).invoke(check));
   }
 
-  WHEN("pack on the right side, deduced")
+  SECTION("pack on the right side, deduced")
   {
     constexpr fn::pack<bool, int, B> a{true, 3, B{14}};
     constexpr fn::pack<C, B> b{C{}, B{3, 4}};
@@ -281,7 +289,7 @@ TEST_CASE("append value categories", "[pack][append]")
     }));
   }
 
-  WHEN("constraints")
+  SECTION("constraints")
   {
     static_assert(can_append_in_place<T &, B, int>);
     static_assert(can_append_in_place<T &, B, int, int>);
@@ -294,7 +302,7 @@ TEST_CASE("append value categories", "[pack][append]")
     static_assert(can_append_in_place<T &, B>);
     static_assert(std::same_as<decltype(std::declval<T &>().append(std::in_place_type<B>)),
                                T::append_type<std::in_place_type_t<B> const &>>);
-    // A default-constructible element takes the intended path - see WHEN("default constructor").
+    // A default-constructible element takes the intended path - see SECTION("default constructor").
     static_assert(std::same_as<decltype(std::declval<T &>().append(std::in_place_type<C>)), T::append_type<C>>);
 
     // GAP #282: a pack never holds a sum, but merely ASKING whether one can be appended is a hard
@@ -304,7 +312,7 @@ TEST_CASE("append value categories", "[pack][append]")
     SUCCEED();
   }
 
-  WHEN("noexcept")
+  SECTION("noexcept")
   {
     // GAP #280: every append overload is unconditionally noexcept, though _append both constructs
     // the new element and relocates every existing one into the new pack.
@@ -358,14 +366,6 @@ TEST_CASE("pack with immovable data", "[pack][immovable]")
   CHECK(v.invoke([](auto &&...args) noexcept -> int { return (0 + ... + args.value); }) == 3 + 14 + 15 + 92);
 }
 
-TEST_CASE("constexpr pack", "[pack][constexpr]")
-{
-  constexpr fn::pack<int, int> v2{3, 14};
-  constexpr auto r2 = v2.invoke([](auto &&...args) constexpr noexcept -> int { return (0 + ... + args); });
-  static_assert(r2 == 3 + 14);
-  SUCCEED();
-}
-
 namespace {
 struct Alef final {
   int value;
@@ -387,373 +387,152 @@ struct Zayn final {
 };
 } // namespace
 
-TEST_CASE("detail::_join on constexpr optional", "[detail][pack][sum][optional][constexpr]")
+namespace {
+constexpr auto join_witness = [](auto &&...v) -> int { return (0 + ... + v.value); };
+
+// One join algebra, two layers walking the same shape grid: the TEMPLATE_TEST_CASE below runs the
+// battery through each subject, in both constant and runtime evaluation.
+struct join_via_optional final { // fn::detail::_join over engaged optionals - the monads' layer
+  template <typename R, typename LH, typename RH> static constexpr auto join(LH const &lh, RH const &rh)
+  {
+    constexpr auto efn = [](auto &&...) { return std::nullopt; };
+    auto const r = fn::detail::_join<fn::optional>(fn::optional<LH>{lh}, fn::optional<RH>{rh}, efn);
+    static_assert(std::is_same_v<decltype(r), fn::optional<R> const>);
+    return r.value();
+  }
+};
+
+struct join_via_operator final { // the public operator& over bare sums, packs and values
+  template <typename R, typename LH, typename RH> static constexpr auto join(LH const &lh, RH const &rh)
+  {
+    auto const r = lh & rh;
+    static_assert(std::is_same_v<decltype(r), R const>);
+    return r;
+  }
+};
+
+template <typename S> constexpr bool join_battery()
 {
-  WHEN("sum of packs join sum of scalars")
-  {
-    constexpr fn::optional<fn::sum<fn::pack<Alef, Gimel>, fn::pack<Bet, Gimel>>> lh{fn::pack{Alef{3}, Gimel{14}}};
-    constexpr fn::optional<fn::sum<Heh, Vav, Zayn>> rh{Vav{15}};
-    static constexpr auto efn = [](auto &&...) { return std::nullopt; };
-    constexpr auto r = fn::detail::_join<fn::optional>(lh, rh, efn);
-    static_assert(
-        std::is_same_v<decltype(r),          //
-                       fn::optional<fn::sum< //
-                           fn::pack<Alef, Gimel, Heh>, fn::pack<Alef, Gimel, Vav>, fn::pack<Alef, Gimel, Zayn>,
-                           fn::pack<Bet, Gimel, Heh>, fn::pack<Bet, Gimel, Vav>, fn::pack<Bet, Gimel, Zayn>>> const>);
-    static_assert(r.has_value());
-    static_assert(r.value().has_value<fn::pack<Alef, Gimel, Vav>>());
-    static_assert(r.value().invoke([](auto &&...v) -> int { return (0 + ... + v.value); }) == 3 + 14 + 15);
-  }
+  using fn::pack;
+  using fn::sum;
 
-  WHEN("sum of packs join sum of packs")
-  {
-    constexpr fn::optional<fn::sum<fn::pack<Alef, Gimel>, fn::pack<Bet, Gimel>>> lh{fn::pack{Alef{3}, Gimel{14}}};
-    constexpr fn::optional<fn::sum<fn::pack<Heh, Zayn>, fn::pack<Vav>>> rh{fn::pack{Vav{15}}};
-    static constexpr auto efn = [](auto &&...) { return std::nullopt; };
-    constexpr auto r = fn::detail::_join<fn::optional>(lh, rh, efn);
-    static_assert(std::is_same_v<decltype(r),          //
-                                 fn::optional<fn::sum< //
-                                     fn::pack<Alef, Gimel, Heh, Zayn>, fn::pack<Alef, Gimel, Vav>,
-                                     fn::pack<Bet, Gimel, Heh, Zayn>, fn::pack<Bet, Gimel, Vav>>> const>);
-    static_assert(r.has_value());
-    static_assert(r.value().has_value<fn::pack<Alef, Gimel, Vav>>());
-    static_assert(r.value().invoke([](auto &&...v) -> int { return (0 + ... + v.value); }) == 3 + 14 + 15);
+  bool ok = true;
+  { // sum of packs join sum of scalars
+    using R = sum<pack<Alef, Gimel, Heh>, pack<Alef, Gimel, Vav>, pack<Alef, Gimel, Zayn>, //
+                  pack<Bet, Gimel, Heh>, pack<Bet, Gimel, Vav>, pack<Bet, Gimel, Zayn>>;
+    auto const r = S::template join<R>(sum<pack<Alef, Gimel>, pack<Bet, Gimel>>{pack{Alef{3}, Gimel{14}}},
+                                       sum<Heh, Vav, Zayn>{Vav{15}});
+    ok = ok && r.template has_value<pack<Alef, Gimel, Vav>>() && r.invoke(join_witness) == 3 + 14 + 15;
   }
+  {                                                                     // sum of packs join sum of packs
+    using R = sum<pack<Alef, Gimel, Heh, Zayn>, pack<Alef, Gimel, Vav>, //
+                  pack<Bet, Gimel, Heh, Zayn>, pack<Bet, Gimel, Vav>>;
+    auto const r = S::template join<R>(sum<pack<Alef, Gimel>, pack<Bet, Gimel>>{pack{Alef{3}, Gimel{14}}},
+                                       sum<pack<Heh, Zayn>, pack<Vav>>{pack{Vav{15}}});
+    ok = ok && r.template has_value<pack<Alef, Gimel, Vav>>() && r.invoke(join_witness) == 3 + 14 + 15;
+  }
+  { // sum of scalars join sum of scalars
+    using R = sum<pack<Alef, Heh>, pack<Alef, Vav>, pack<Alef, Zayn>, pack<Bet, Heh>, pack<Bet, Vav>, pack<Bet, Zayn>,
+                  pack<Gimel, Heh>, pack<Gimel, Vav>, pack<Gimel, Zayn>>;
+    auto const r = S::template join<R>(sum<Alef, Bet, Gimel>{Gimel{3}}, sum<Heh, Vav, Zayn>{Vav{14}});
+    ok = ok && r.template has_value<pack<Gimel, Vav>>() && r.invoke(join_witness) == 3 + 14;
+  }
+  {                                                                             // sum of scalars join sum of packs
+    using R = sum<pack<Alef, Heh, Zayn>, pack<Alef, Vav>, pack<Bet, Heh, Zayn>, //
+                  pack<Bet, Vav>, pack<Gimel, Heh, Zayn>, pack<Gimel, Vav>>;
+    auto const r = S::template join<R>(sum<Alef, Bet, Gimel>{Gimel{3}}, sum<pack<Heh, Zayn>, pack<Vav>>{pack{Vav{14}}});
+    ok = ok && r.template has_value<pack<Gimel, Vav>>() && r.invoke(join_witness) == 3 + 14;
+  }
+  { // sum of packs join scalar
+    using R = sum<pack<Alef, Gimel, Vav>, pack<Bet, Gimel, Vav>>;
+    auto const r = S::template join<R>(sum<pack<Alef, Gimel>, pack<Bet, Gimel>>{pack{Alef{3}, Gimel{14}}}, Vav{15});
+    ok = ok && r.template has_value<pack<Alef, Gimel, Vav>>() && r.invoke(join_witness) == 3 + 14 + 15;
+  }
+  { // sum of packs join pack
+    using R = sum<pack<Alef, Gimel, Vav>, pack<Bet, Gimel, Vav>>;
+    auto const r = S::template join<R>(sum<pack<Alef, Gimel>, pack<Bet, Gimel>>{pack{Alef{3}, Gimel{14}}},
+                                       pack<Vav>{pack{Vav{15}}});
+    ok = ok && r.template has_value<pack<Alef, Gimel, Vav>>() && r.invoke(join_witness) == 3 + 14 + 15;
+  }
+  { // sum of scalars join scalar
+    using R = sum<pack<Alef, Vav>, pack<Bet, Vav>, pack<Gimel, Vav>>;
+    auto const r = S::template join<R>(sum<Alef, Bet, Gimel>{Gimel{3}}, Vav{14});
+    ok = ok && r.template has_value<pack<Gimel, Vav>>() && r.invoke(join_witness) == 3 + 14;
+  }
+  { // sum of scalars join pack
+    using R = sum<pack<Alef, Vav>, pack<Bet, Vav>, pack<Gimel, Vav>>;
+    auto const r = S::template join<R>(sum<Alef, Bet, Gimel>{Gimel{3}}, pack<Vav>{pack{Vav{14}}});
+    ok = ok && r.template has_value<pack<Gimel, Vav>>() && r.invoke(join_witness) == 3 + 14;
+  }
+  { // pack join sum of scalars
+    using R = sum<pack<Alef, Gimel, Heh>, pack<Alef, Gimel, Vav>, pack<Alef, Gimel, Zayn>>;
+    auto const r = S::template join<R>(pack<Alef, Gimel>{pack{Alef{3}, Gimel{14}}}, sum<Heh, Vav, Zayn>{Vav{15}});
+    ok = ok && r.template has_value<pack<Alef, Gimel, Vav>>() && r.invoke(join_witness) == 3 + 14 + 15;
+  }
+  { // pack join sum of packs
+    using R = sum<pack<Alef, Gimel, Heh, Zayn>, pack<Alef, Gimel, Vav>>;
+    auto const r = S::template join<R>(pack<Alef, Gimel>{pack{Alef{3}, Gimel{14}}},
+                                       sum<pack<Heh, Zayn>, pack<Vav>>{pack{Vav{15}}});
+    ok = ok && r.template has_value<pack<Alef, Gimel, Vav>>() && r.invoke(join_witness) == 3 + 14 + 15;
+  }
+  { // pack join scalar
+    auto const r = S::template join<pack<Alef, Gimel, Vav>>(pack<Alef, Gimel>{pack{Alef{3}, Gimel{14}}}, Vav{15});
+    ok = ok && r.invoke(join_witness) == 3 + 14 + 15;
+  }
+  { // pack join pack
+    auto const r = S::template join<pack<Alef, Gimel, Vav>>(pack<Alef, Gimel>{pack{Alef{3}, Gimel{14}}},
+                                                            pack<Vav>{pack{Vav{15}}});
+    ok = ok && r.invoke(join_witness) == 3 + 14 + 15;
+  }
+  return ok;
+}
 
-  WHEN("sum of scalars join sum of scalars")
-  {
-    constexpr fn::optional<fn::sum<Alef, Bet, Gimel>> lh{Gimel{3}};
-    constexpr fn::optional<fn::sum<Heh, Vav, Zayn>> rh{Vav{14}};
-    static constexpr auto efn = [](auto &&...) { return std::nullopt; };
-    constexpr auto r = fn::detail::_join<fn::optional>(lh, rh, efn);
-    static_assert(
-        std::is_same_v<
-            decltype(r),          //
-            fn::optional<fn::sum< //
-                fn::pack<Alef, Heh>, fn::pack<Alef, Vav>, fn::pack<Alef, Zayn>, fn::pack<Bet, Heh>, fn::pack<Bet, Vav>,
-                fn::pack<Bet, Zayn>, fn::pack<Gimel, Heh>, fn::pack<Gimel, Vav>, fn::pack<Gimel, Zayn>>> const>);
-    static_assert(r.has_value());
-    static_assert(r.value().has_value<fn::pack<Gimel, Vav>>());
-    static_assert(r.value().invoke([](auto &&...v) -> int { return (0 + ... + v.value); }) == 3 + 14);
-  }
+// A bare value can sit on the LEFT of the monad-level join only - operator& has no overload for it,
+// so these four shapes belong to join_via_optional alone.
+constexpr bool join_value_lhs_battery()
+{
+  using fn::pack;
+  using fn::sum;
+  using S = join_via_optional;
 
-  WHEN("sum of scalars join sum of packs")
-  {
-    constexpr fn::optional<fn::sum<Alef, Bet, Gimel>> lh{Gimel{3}};
-    constexpr fn::optional<fn::sum<fn::pack<Heh, Zayn>, fn::pack<Vav>>> rh{fn::pack{Vav{14}}};
-    static constexpr auto efn = [](auto &&...) { return std::nullopt; };
-    constexpr auto r = fn::detail::_join<fn::optional>(lh, rh, efn);
-    static_assert(std::is_same_v<decltype(r),          //
-                                 fn::optional<fn::sum< //
-                                     fn::pack<Alef, Heh, Zayn>, fn::pack<Alef, Vav>, fn::pack<Bet, Heh, Zayn>,
-                                     fn::pack<Bet, Vav>, fn::pack<Gimel, Heh, Zayn>, fn::pack<Gimel, Vav>>> const>);
-    static_assert(r.has_value());
-    static_assert(r.value().has_value<fn::pack<Gimel, Vav>>());
-    static_assert(r.value().invoke([](auto &&...v) -> int { return (0 + ... + v.value); }) == 3 + 14);
+  bool ok = true;
+  { // scalar join sum of scalars
+    using R = sum<pack<Alef, Heh>, pack<Alef, Vav>, pack<Alef, Zayn>>;
+    auto const r = S::join<R>(Alef{3}, sum<Heh, Vav, Zayn>{Vav{14}});
+    ok = ok && r.template has_value<pack<Alef, Vav>>() && r.invoke(join_witness) == 3 + 14;
   }
+  { // scalar join sum of packs
+    using R = sum<pack<Alef, Heh, Zayn>, pack<Alef, Vav>>;
+    auto const r = S::join<R>(Alef{3}, sum<pack<Heh, Zayn>, pack<Vav>>{pack{Vav{14}}});
+    ok = ok && r.template has_value<pack<Alef, Vav>>() && r.invoke(join_witness) == 3 + 14;
+  }
+  { // scalar join scalar
+    auto const r = S::join<pack<Alef, Vav>>(Alef{3}, Vav{14});
+    ok = ok && r.invoke(join_witness) == 3 + 14;
+  }
+  { // scalar join pack
+    auto const r = S::join<pack<Alef, Vav>>(Alef{3}, pack<Vav>{pack{Vav{14}}});
+    ok = ok && r.invoke(join_witness) == 3 + 14;
+  }
+  return ok;
+}
+} // namespace
 
-  WHEN("sum of packs join scalar")
-  {
-    constexpr fn::optional<fn::sum<fn::pack<Alef, Gimel>, fn::pack<Bet, Gimel>>> lh{fn::pack{Alef{3}, Gimel{14}}};
-    constexpr fn::optional<Vav> rh{Vav{15}};
-    static constexpr auto efn = [](auto &&...) { return std::nullopt; };
-    constexpr auto r = fn::detail::_join<fn::optional>(lh, rh, efn);
-    static_assert(std::is_same_v<decltype(r),          //
-                                 fn::optional<fn::sum< //
-                                     fn::pack<Alef, Gimel, Vav>, fn::pack<Bet, Gimel, Vav>>> const>);
-    static_assert(r.has_value());
-    static_assert(r.value().has_value<fn::pack<Alef, Gimel, Vav>>());
-    static_assert(r.value().invoke([](auto &&...v) -> int { return (0 + ... + v.value); }) == 3 + 14 + 15);
-  }
+TEMPLATE_TEST_CASE("join of sums, packs and values", "[pack][sum][detail][optional][operator_and]", join_via_optional,
+                   join_via_operator)
+{
+  static_assert(join_battery<TestType>());
+  REQUIRE(join_battery<TestType>());
+}
 
-  WHEN("sum of packs join pack")
-  {
-    constexpr fn::optional<fn::sum<fn::pack<Alef, Gimel>, fn::pack<Bet, Gimel>>> lh{fn::pack{Alef{3}, Gimel{14}}};
-    constexpr fn::optional<fn::pack<Vav>> rh{fn::pack{Vav{15}}};
-    static constexpr auto efn = [](auto &&...) { return std::nullopt; };
-    constexpr auto r = fn::detail::_join<fn::optional>(lh, rh, efn);
-    static_assert(std::is_same_v<decltype(r),          //
-                                 fn::optional<fn::sum< //
-                                     fn::pack<Alef, Gimel, Vav>, fn::pack<Bet, Gimel, Vav>>> const>);
-    static_assert(r.has_value());
-    static_assert(r.value().has_value<fn::pack<Alef, Gimel, Vav>>());
-    static_assert(r.value().invoke([](auto &&...v) -> int { return (0 + ... + v.value); }) == 3 + 14 + 15);
-  }
-
-  WHEN("sum of scalars join scalar")
-  {
-    constexpr fn::optional<fn::sum<Alef, Bet, Gimel>> lh{Gimel{3}};
-    constexpr fn::optional<Vav> rh{Vav{14}};
-    static constexpr auto efn = [](auto &&...) { return std::nullopt; };
-    constexpr auto r = fn::detail::_join<fn::optional>(lh, rh, efn);
-    static_assert(std::is_same_v<decltype(r),          //
-                                 fn::optional<fn::sum< //
-                                     fn::pack<Alef, Vav>, fn::pack<Bet, Vav>, fn::pack<Gimel, Vav>>> const>);
-    static_assert(r.has_value());
-    static_assert(r.value().has_value<fn::pack<Gimel, Vav>>());
-    static_assert(r.value().invoke([](auto &&...v) -> int { return (0 + ... + v.value); }) == 3 + 14);
-  }
-
-  WHEN("sum of scalars join pack")
-  {
-    constexpr fn::optional<fn::sum<Alef, Bet, Gimel>> lh{Gimel{3}};
-    constexpr fn::optional<fn::pack<Vav>> rh{fn::pack{Vav{14}}};
-    static constexpr auto efn = [](auto &&...) { return std::nullopt; };
-    constexpr auto r = fn::detail::_join<fn::optional>(lh, rh, efn);
-    static_assert(std::is_same_v<decltype(r),          //
-                                 fn::optional<fn::sum< //
-                                     fn::pack<Alef, Vav>, fn::pack<Bet, Vav>, fn::pack<Gimel, Vav>>> const>);
-    static_assert(r.has_value());
-    static_assert(r.value().has_value<fn::pack<Gimel, Vav>>());
-    static_assert(r.value().invoke([](auto &&...v) -> int { return (0 + ... + v.value); }) == 3 + 14);
-  }
-
-  WHEN("pack join sum of scalars")
-  {
-    constexpr fn::optional<fn::pack<Alef, Gimel>> lh{fn::pack{Alef{3}, Gimel{14}}};
-    constexpr fn::optional<fn::sum<Heh, Vav, Zayn>> rh{Vav{15}};
-    static constexpr auto efn = [](auto &&...) { return std::nullopt; };
-    constexpr auto r = fn::detail::_join<fn::optional>(lh, rh, efn);
-    static_assert(std::is_same_v<
-                  decltype(r),          //
-                  fn::optional<fn::sum< //
-                      fn::pack<Alef, Gimel, Heh>, fn::pack<Alef, Gimel, Vav>, fn::pack<Alef, Gimel, Zayn>>> const>);
-    static_assert(r.has_value());
-    static_assert(r.value().has_value<fn::pack<Alef, Gimel, Vav>>());
-    static_assert(r.value().invoke([](auto &&...v) -> int { return (0 + ... + v.value); }) == 3 + 14 + 15);
-  }
-
-  WHEN("pack join sum of packs")
-  {
-    constexpr fn::optional<fn::pack<Alef, Gimel>> lh{fn::pack{Alef{3}, Gimel{14}}};
-    constexpr fn::optional<fn::sum<fn::pack<Heh, Zayn>, fn::pack<Vav>>> rh{fn::pack{Vav{15}}};
-    static constexpr auto efn = [](auto &&...) { return std::nullopt; };
-    constexpr auto r = fn::detail::_join<fn::optional>(lh, rh, efn);
-    static_assert(std::is_same_v<decltype(r),          //
-                                 fn::optional<fn::sum< //
-                                     fn::pack<Alef, Gimel, Heh, Zayn>, fn::pack<Alef, Gimel, Vav>>> const>);
-    static_assert(r.has_value());
-    static_assert(r.value().has_value<fn::pack<Alef, Gimel, Vav>>());
-    static_assert(r.value().invoke([](auto &&...v) -> int { return (0 + ... + v.value); }) == 3 + 14 + 15);
-  }
-
-  WHEN("scalar join sum of scalars")
-  {
-    constexpr fn::optional<Alef> lh{Alef{3}};
-    constexpr fn::optional<fn::sum<Heh, Vav, Zayn>> rh{Vav{14}};
-    static constexpr auto efn = [](auto &&...) { return std::nullopt; };
-    constexpr auto r = fn::detail::_join<fn::optional>(lh, rh, efn);
-    static_assert(std::is_same_v<decltype(r),          //
-                                 fn::optional<fn::sum< //
-                                     fn::pack<Alef, Heh>, fn::pack<Alef, Vav>, fn::pack<Alef, Zayn>>> const>);
-    static_assert(r.has_value());
-    static_assert(r.value().has_value<fn::pack<Alef, Vav>>());
-    static_assert(r.value().invoke([](auto &&...v) -> int { return (0 + ... + v.value); }) == 3 + 14);
-  }
-
-  WHEN("scalar join sum of packs")
-  {
-    constexpr fn::optional<Alef> lh{Alef{3}};
-    constexpr fn::optional<fn::sum<fn::pack<Heh, Zayn>, fn::pack<Vav>>> rh{fn::pack{Vav{14}}};
-    static constexpr auto efn = [](auto &&...) { return std::nullopt; };
-    constexpr auto r = fn::detail::_join<fn::optional>(lh, rh, efn);
-    static_assert(std::is_same_v<decltype(r),          //
-                                 fn::optional<fn::sum< //
-                                     fn::pack<Alef, Heh, Zayn>, fn::pack<Alef, Vav>>> const>);
-    static_assert(r.has_value());
-    static_assert(r.value().has_value<fn::pack<Alef, Vav>>());
-    static_assert(r.value().invoke([](auto &&...v) -> int { return (0 + ... + v.value); }) == 3 + 14);
-  }
-
-  WHEN("pack join scalar")
-  {
-    constexpr fn::optional<fn::pack<Alef, Gimel>> lh{fn::pack{Alef{3}, Gimel{14}}};
-    constexpr fn::optional<Vav> rh{Vav{15}};
-    static constexpr auto efn = [](auto &&...) { return std::nullopt; };
-    constexpr auto r = fn::detail::_join<fn::optional>(lh, rh, efn);
-    static_assert(std::is_same_v<decltype(r), //
-                                 fn::optional<fn::pack<Alef, Gimel, Vav>> const>);
-    static_assert(r.has_value());
-    static_assert(r.value().invoke([](auto &&...v) -> int { return (0 + ... + v.value); }) == 3 + 14 + 15);
-  }
-
-  WHEN("pack join pack")
-  {
-    constexpr fn::optional<fn::pack<Alef, Gimel>> lh{fn::pack{Alef{3}, Gimel{14}}};
-    constexpr fn::optional<fn::pack<Vav>> rh{fn::pack{Vav{15}}};
-    static constexpr auto efn = [](auto &&...) { return std::nullopt; };
-    constexpr auto r = fn::detail::_join<fn::optional>(lh, rh, efn);
-    static_assert(std::is_same_v<decltype(r), //
-                                 fn::optional<fn::pack<Alef, Gimel, Vav>> const>);
-    static_assert(r.has_value());
-    static_assert(r.value().invoke([](auto &&...v) -> int { return (0 + ... + v.value); }) == 3 + 14 + 15);
-  }
-
-  WHEN("scalar join scalar")
-  {
-    constexpr fn::optional<Alef> lh{Alef{3}};
-    constexpr fn::optional<Vav> rh{Vav{14}};
-    static constexpr auto efn = [](auto &&...) { return std::nullopt; };
-    constexpr auto r = fn::detail::_join<fn::optional>(lh, rh, efn);
-    static_assert(std::is_same_v<decltype(r), //
-                                 fn::optional<fn::pack<Alef, Vav>> const>);
-    static_assert(r.has_value());
-    static_assert(r.value().invoke([](auto &&...v) -> int { return (0 + ... + v.value); }) == 3 + 14);
-  }
-
-  WHEN("scalar join pack")
-  {
-    constexpr fn::optional<Alef> lh{Alef{3}};
-    constexpr fn::optional<fn::pack<Vav>> rh{fn::pack{Vav{14}}};
-    static constexpr auto efn = [](auto &&...) { return std::nullopt; };
-    constexpr auto r = fn::detail::_join<fn::optional>(lh, rh, efn);
-    static_assert(std::is_same_v<decltype(r), //
-                                 fn::optional<fn::pack<Alef, Vav>> const>);
-    static_assert(r.has_value());
-    static_assert(r.value().invoke([](auto &&...v) -> int { return (0 + ... + v.value); }) == 3 + 14);
-  }
+TEST_CASE("detail::_join with value operands", "[detail][pack][sum][optional]")
+{
+  static_assert(join_value_lhs_battery());
+  REQUIRE(join_value_lhs_battery());
 }
 
 TEST_CASE("operator &", "[pack][sum][operator_and]")
 {
-  WHEN("sum of packs join sum of scalars")
-  {
-    constexpr fn::sum<fn::pack<Alef, Gimel>, fn::pack<Bet, Gimel>> lh{fn::pack{Alef{3}, Gimel{14}}};
-    constexpr fn::sum<Heh, Vav, Zayn> rh{Vav{15}};
-    auto r = lh & rh;
-    static_assert(
-        std::is_same_v<decltype(r), //
-                       fn::sum<     //
-                           fn::pack<Alef, Gimel, Heh>, fn::pack<Alef, Gimel, Vav>, fn::pack<Alef, Gimel, Zayn>,
-                           fn::pack<Bet, Gimel, Heh>, fn::pack<Bet, Gimel, Vav>, fn::pack<Bet, Gimel, Zayn>>>);
-    CHECK(r.invoke([](auto &&...v) -> int { return (0 + ... + v.value); }) == 3 + 14 + 15);
-  }
-
-  WHEN("sum of packs join sum of packs")
-  {
-    constexpr fn::sum<fn::pack<Alef, Gimel>, fn::pack<Bet, Gimel>> lh{fn::pack{Alef{3}, Gimel{14}}};
-    constexpr fn::sum<fn::pack<Heh, Zayn>, fn::pack<Vav>> rh{fn::pack{Vav{15}}};
-    auto r = lh & rh;
-    static_assert(std::is_same_v<decltype(r), //
-                                 fn::sum<     //
-                                     fn::pack<Alef, Gimel, Heh, Zayn>, fn::pack<Alef, Gimel, Vav>,
-                                     fn::pack<Bet, Gimel, Heh, Zayn>, fn::pack<Bet, Gimel, Vav>>>);
-    CHECK(r.invoke([](auto &&...v) -> int { return (0 + ... + v.value); }) == 3 + 14 + 15);
-  }
-
-  WHEN("sum of scalars join sum of scalars")
-  {
-    constexpr fn::sum<Alef, Bet, Gimel> lh{Gimel{3}};
-    constexpr fn::sum<Heh, Vav, Zayn> rh{Vav{14}};
-    auto r = lh & rh;
-    static_assert(
-        std::is_same_v<
-            decltype(r), //
-            fn::sum<     //
-                fn::pack<Alef, Heh>, fn::pack<Alef, Vav>, fn::pack<Alef, Zayn>, fn::pack<Bet, Heh>, fn::pack<Bet, Vav>,
-                fn::pack<Bet, Zayn>, fn::pack<Gimel, Heh>, fn::pack<Gimel, Vav>, fn::pack<Gimel, Zayn>>>);
-    CHECK(r.invoke([](auto &&...v) -> int { return (0 + ... + v.value); }) == 3 + 14);
-  }
-
-  WHEN("sum of scalars join sum of packs")
-  {
-    constexpr fn::sum<Alef, Bet, Gimel> lh{Gimel{3}};
-    constexpr fn::sum<fn::pack<Heh, Zayn>, fn::pack<Vav>> rh{fn::pack{Vav{14}}};
-    auto r = lh & rh;
-    static_assert(std::is_same_v<decltype(r), //
-                                 fn::sum<     //
-                                     fn::pack<Alef, Heh, Zayn>, fn::pack<Alef, Vav>, fn::pack<Bet, Heh, Zayn>,
-                                     fn::pack<Bet, Vav>, fn::pack<Gimel, Heh, Zayn>, fn::pack<Gimel, Vav>>>);
-    CHECK(r.invoke([](auto &&...v) -> int { return (0 + ... + v.value); }) == 3 + 14);
-  }
-
-  WHEN("sum of packs join scalar")
-  {
-    constexpr fn::sum<fn::pack<Alef, Gimel>, fn::pack<Bet, Gimel>> lh{fn::pack{Alef{3}, Gimel{14}}};
-    constexpr Vav rh{Vav{15}};
-    auto r = lh & rh;
-    static_assert(std::is_same_v<decltype(r), //
-                                 fn::sum<     //
-                                     fn::pack<Alef, Gimel, Vav>, fn::pack<Bet, Gimel, Vav>>>);
-    CHECK(r.invoke([](auto &&...v) -> int { return (0 + ... + v.value); }) == 3 + 14 + 15);
-  }
-
-  WHEN("sum of packs join pack")
-  {
-    constexpr fn::sum<fn::pack<Alef, Gimel>, fn::pack<Bet, Gimel>> lh{fn::pack{Alef{3}, Gimel{14}}};
-    constexpr fn::pack<Vav> rh{fn::pack{Vav{15}}};
-    auto r = lh & rh;
-    static_assert(std::is_same_v<decltype(r), //
-                                 fn::sum<     //
-                                     fn::pack<Alef, Gimel, Vav>, fn::pack<Bet, Gimel, Vav>>>);
-    CHECK(r.invoke([](auto &&...v) -> int { return (0 + ... + v.value); }) == 3 + 14 + 15);
-  }
-
-  WHEN("sum of scalars join scalar")
-  {
-    constexpr fn::sum<Alef, Bet, Gimel> lh{Gimel{3}};
-    constexpr Vav rh{Vav{14}};
-    auto r = lh & rh;
-    static_assert(std::is_same_v<decltype(r), //
-                                 fn::sum<     //
-                                     fn::pack<Alef, Vav>, fn::pack<Bet, Vav>, fn::pack<Gimel, Vav>>>);
-    CHECK(r.invoke([](auto &&...v) -> int { return (0 + ... + v.value); }) == 3 + 14);
-  }
-
-  WHEN("sum of scalars join pack")
-  {
-    constexpr fn::sum<Alef, Bet, Gimel> lh{Gimel{3}};
-    constexpr fn::pack<Vav> rh{fn::pack{Vav{14}}};
-    auto r = lh & rh;
-    static_assert(std::is_same_v<decltype(r), //
-                                 fn::sum<     //
-                                     fn::pack<Alef, Vav>, fn::pack<Bet, Vav>, fn::pack<Gimel, Vav>>>);
-    CHECK(r.invoke([](auto &&...v) -> int { return (0 + ... + v.value); }) == 3 + 14);
-  }
-
-  WHEN("pack join sum of scalars")
-  {
-    constexpr fn::pack<Alef, Gimel> lh{fn::pack{Alef{3}, Gimel{14}}};
-    constexpr fn::sum<Heh, Vav, Zayn> rh{Vav{15}};
-    auto r = lh & rh;
-    static_assert(
-        std::is_same_v<decltype(r), //
-                       fn::sum<     //
-                           fn::pack<Alef, Gimel, Heh>, fn::pack<Alef, Gimel, Vav>, fn::pack<Alef, Gimel, Zayn>>>);
-    CHECK(r.invoke([](auto &&...v) -> int { return (0 + ... + v.value); }) == 3 + 14 + 15);
-  }
-
-  WHEN("pack join sum of packs")
-  {
-    constexpr fn::pack<Alef, Gimel> lh{fn::pack{Alef{3}, Gimel{14}}};
-    constexpr fn::sum<fn::pack<Heh, Zayn>, fn::pack<Vav>> rh{fn::pack{Vav{15}}};
-    auto r = lh & rh;
-    static_assert(std::is_same_v<decltype(r), //
-                                 fn::sum<     //
-                                     fn::pack<Alef, Gimel, Heh, Zayn>, fn::pack<Alef, Gimel, Vav>>>);
-    CHECK(r.invoke([](auto &&...v) -> int { return (0 + ... + v.value); }) == 3 + 14 + 15);
-  }
-
-  WHEN("pack join scalar")
-  {
-    constexpr fn::pack<Alef, Gimel> lh{fn::pack{Alef{3}, Gimel{14}}};
-    constexpr Vav rh{Vav{15}};
-    auto r = lh & rh;
-    static_assert(std::is_same_v<decltype(r), //
-                                 fn::pack<Alef, Gimel, Vav>>);
-    CHECK(r.invoke([](auto &&...v) -> int { return (0 + ... + v.value); }) == 3 + 14 + 15);
-  }
-
-  WHEN("pack join pack")
-  {
-    constexpr fn::pack<Alef, Gimel> lh{fn::pack{Alef{3}, Gimel{14}}};
-    constexpr fn::pack<Vav> rh{fn::pack{Vav{15}}};
-    auto r = lh & rh;
-    static_assert(std::is_same_v<decltype(r), //
-                                 fn::pack<Alef, Gimel, Vav>>);
-    CHECK(r.invoke([](auto &&...v) -> int { return (0 + ... + v.value); }) == 3 + 14 + 15);
-  }
-
   constexpr auto r1 = fn::as_sum(12) & 3 & 2.5 & fn::pack{0.5, true}
                       & fn::sum_for<bool, int, fn::pack<double, int>>(fn::pack{1.5, 12});
   static_assert(std::is_same_v<                                     //
@@ -776,7 +555,7 @@ TEST_CASE("operator &", "[pack][sum][operator_and]")
   static_assert(r2.invoke([](auto &&...args) -> double { return (1 * ... * static_cast<double>(args)); })
                 == 12. * 3 * 2.5 * 0.5 * 1 * 1.5 * 12);
 
-  WHEN("noexcept")
+  SECTION("noexcept")
   {
     // This operator& carries no noexcept specifier, so it never over-promises - in contrast with
     // optional's and expected's, which are unconditionally noexcept although the join copies the

--- a/tests/fn/recover.cpp
+++ b/tests/fn/recover.cpp
@@ -211,6 +211,24 @@ TEST_CASE("recover", "[recover][optional]")
   }
 }
 
+TEST_CASE("recover noexcept", "[recover][noexcept]")
+{
+  using namespace fn;
+
+  constexpr auto fnThrows = [](Error const &) noexcept(false) -> int { return 0; };
+  constexpr auto fnThrows0 = [](Error const &) noexcept(false) -> void {};
+  constexpr auto fnThrowsOpt = []() noexcept(false) -> int { return 0; };
+
+  // GAP #285: recover's apply is the implementation too - it invokes the callback AND constructs the
+  // recovered result from what comes back, both under an unconditional noexcept. So it has two ways
+  // to throw and promises neither, with no member spec anywhere to appeal to.
+  static_assert(noexcept(recover_t::apply{}(std::declval<fn::expected<int, Error> &>(), fnThrows)));
+  static_assert(noexcept(recover_t::apply{}(std::declval<fn::expected<void, Error> &>(), fnThrows0)));
+  static_assert(noexcept(recover_t::apply{}(std::declval<fn::optional<int> &>(), fnThrowsOpt)));
+
+  SUCCEED();
+}
+
 TEST_CASE("constexpr recover expected", "[recover][constexpr][expected]")
 {
   enum class Error { ThresholdExceeded, SomethingElse };

--- a/tests/fn/recover.cpp
+++ b/tests/fn/recover.cpp
@@ -55,16 +55,16 @@ TEST_CASE("recover", "[recover][expected][expected_value]")
   static_assert(is::not_invocable_with_any([]() -> int { throw 0; }));                                  // bad arity
   static_assert(is::not_invocable_with_any([](int, int) -> int { throw 0; }));                          // bad arity
 
-  WHEN("operand is lvalue")
+  SECTION("lvalue")
   {
-    WHEN("operand is value")
+    SECTION("value")
     {
       operand_t a{std::in_place, 12};
       using T = decltype(a | recover(wrong));
       static_assert(std::is_same_v<T, operand_t>);
       REQUIRE((a | recover(wrong)).value() == 12);
     }
-    WHEN("operand is error")
+    SECTION("error")
     {
       operand_t a{::fn::unexpect, Error{"Not good"}};
       using T = decltype(a | recover(fnError));
@@ -73,19 +73,61 @@ TEST_CASE("recover", "[recover][expected][expected_value]")
     }
   }
 
-  WHEN("operand is rvalue")
+  SECTION("rvalue")
   {
-    WHEN("operand is value")
+    SECTION("value")
     {
       using T = decltype(operand_t{std::in_place, 12} | recover(wrong));
       static_assert(std::is_same_v<T, operand_t>);
       REQUIRE((operand_t{std::in_place, 12} | recover(wrong)).value() == 12);
     }
-    WHEN("operand is error")
+    SECTION("error")
     {
       using T = decltype(operand_t{::fn::unexpect, Error{"Not good"}} | recover(fnError));
       static_assert(std::is_same_v<T, operand_t>);
       REQUIRE((operand_t{::fn::unexpect, Error{"Not good"}} | recover(fnError)).value() == 8);
+    }
+  }
+
+  SECTION("constexpr")
+  {
+    enum class Error { ThresholdExceeded, SomethingElse };
+    using T = fn::expected<int, Error>;
+
+    constexpr auto fn = [](Error e) constexpr noexcept -> int {
+      if (e == Error::SomethingElse)
+        return 0;
+      return 1;
+    };
+    constexpr auto r1 = T{2} | fn::recover(fn);
+    static_assert(r1.value() == 2);
+    constexpr auto r2 = T{::fn::unexpect, Error::SomethingElse} | fn::recover(fn);
+    static_assert(r2.value() == 0);
+    constexpr auto r3 = T{::fn::unexpect, Error::ThresholdExceeded} | fn::recover(fn);
+    static_assert(r3.value() == 1);
+
+    SUCCEED();
+
+    SECTION("sum")
+    {
+      using TS = fn::expected<int, fn::sum_for<Error, bool>>;
+
+      constexpr auto fnSum = fn::overload{[](Error e) constexpr noexcept -> int {
+                                            if (e == Error::SomethingElse)
+                                              return 0;
+                                            return 1;
+                                          },
+                                          [](bool e) constexpr noexcept -> int { return (int)e; }};
+      constexpr auto s1 = TS{2} | fn::recover(fnSum);
+      static_assert(s1.value() == 2);
+      constexpr auto s2 = TS{::fn::unexpect, fn::sum{Error::SomethingElse}} | fn::recover(fnSum);
+      static_assert(s2.value() == 0);
+      constexpr auto s3 = TS{::fn::unexpect, fn::sum{true}} | fn::recover(fnSum);
+      static_assert(s3.value() == 1);
+      constexpr auto s4 = TS{::fn::unexpect, fn::sum{Error::ThresholdExceeded}} | fn::recover(fnSum);
+      static_assert(s4.value() == 1);
+
+      SUCCEED();
     }
   }
 }
@@ -116,9 +158,9 @@ TEST_CASE("recover", "[recover][expected][expected_void]")
   static_assert(is::not_invocable_with_any([]() { throw 0; }));                                  // bad arity
   static_assert(is::not_invocable_with_any([](int, int) { throw 0; }));                          // bad arity
 
-  WHEN("operand is lvalue")
+  SECTION("lvalue")
   {
-    WHEN("operand is value")
+    SECTION("value")
     {
       operand_t a{std::in_place};
       using T = decltype(a | recover(wrong));
@@ -126,7 +168,7 @@ TEST_CASE("recover", "[recover][expected][expected_void]")
       (a | recover(wrong)).value();
       REQUIRE(count == 0);
     }
-    WHEN("operand is error")
+    SECTION("error")
     {
       operand_t a{::fn::unexpect, Error{"Not good"}};
       using T = decltype(a | recover(fnError));
@@ -136,16 +178,16 @@ TEST_CASE("recover", "[recover][expected][expected_void]")
     }
   }
 
-  WHEN("operand is rvalue")
+  SECTION("rvalue")
   {
-    WHEN("operand is value")
+    SECTION("value")
     {
       using T = decltype(operand_t{std::in_place} | recover(wrong));
       static_assert(std::is_same_v<T, operand_t>);
       (operand_t{std::in_place} | recover(wrong)).value();
       REQUIRE(count == 0);
     }
-    WHEN("operand is error")
+    SECTION("error")
     {
       using T = decltype(operand_t{::fn::unexpect, Error{"Not good"}} | recover(fnError));
       static_assert(std::is_same_v<T, operand_t>);
@@ -176,16 +218,16 @@ TEST_CASE("recover", "[recover][optional]")
   static_assert(is::not_invocable_with_any([](int) -> int { throw 0; }));      // bad arity
   static_assert(is::not_invocable_with_any([](int, int) -> int { throw 0; })); // bad arity
 
-  WHEN("operand is lvalue")
+  SECTION("lvalue")
   {
-    WHEN("operand is value")
+    SECTION("value")
     {
       operand_t a{12};
       using T = decltype(a | recover(wrong));
       static_assert(std::is_same_v<T, operand_t>);
       REQUIRE((a | recover(wrong)).value() == 12);
     }
-    WHEN("operand is error")
+    SECTION("error")
     {
       operand_t a{std::nullopt};
       using T = decltype(a | recover(fnError));
@@ -194,20 +236,32 @@ TEST_CASE("recover", "[recover][optional]")
     }
   }
 
-  WHEN("operand is rvalue")
+  SECTION("rvalue")
   {
-    WHEN("operand is value")
+    SECTION("value")
     {
       using T = decltype(operand_t{12} | recover(wrong));
       static_assert(std::is_same_v<T, operand_t>);
       REQUIRE((operand_t{12} | recover(wrong)).value() == 12);
     }
-    WHEN("operand is error")
+    SECTION("error")
     {
       using T = decltype(operand_t{std::nullopt} | recover(fnError));
       static_assert(std::is_same_v<T, operand_t>);
       REQUIRE((operand_t{std::nullopt} | recover(fnError)).value() == 42);
     }
+  }
+
+  SECTION("constexpr")
+  {
+    using T = fn::optional<int>;
+    constexpr auto fn = []() constexpr noexcept -> int { return 13; };
+    constexpr auto r1 = T{0} | fn::recover(fn);
+    static_assert(r1.value() == 0);
+    constexpr auto r2 = T{} | fn::recover(fn);
+    static_assert(r2.value() == 13);
+
+    SUCCEED();
   }
 }
 
@@ -225,61 +279,6 @@ TEST_CASE("recover noexcept", "[recover][noexcept]")
   static_assert(noexcept(recover_t::apply{}(std::declval<fn::expected<int, Error> &>(), fnThrows)));
   static_assert(noexcept(recover_t::apply{}(std::declval<fn::expected<void, Error> &>(), fnThrows0)));
   static_assert(noexcept(recover_t::apply{}(std::declval<fn::optional<int> &>(), fnThrowsOpt)));
-
-  SUCCEED();
-}
-
-TEST_CASE("constexpr recover expected", "[recover][constexpr][expected]")
-{
-  enum class Error { ThresholdExceeded, SomethingElse };
-  using T = fn::expected<int, Error>;
-
-  constexpr auto fn = [](Error e) constexpr noexcept -> int {
-    if (e == Error::SomethingElse)
-      return 0;
-    return 1;
-  };
-  constexpr auto r1 = T{2} | fn::recover(fn);
-  static_assert(r1.value() == 2);
-  constexpr auto r2 = T{::fn::unexpect, Error::SomethingElse} | fn::recover(fn);
-  static_assert(r2.value() == 0);
-  constexpr auto r3 = T{::fn::unexpect, Error::ThresholdExceeded} | fn::recover(fn);
-  static_assert(r3.value() == 1);
-
-  SUCCEED();
-}
-
-TEST_CASE("constexpr recover expected with sum", "[recover][constexpr][expected][sum]")
-{
-  enum class Error { ThresholdExceeded, SomethingElse };
-  using T = fn::expected<int, fn::sum_for<Error, bool>>;
-
-  constexpr auto fn = fn::overload{[](Error e) constexpr noexcept -> int {
-                                     if (e == Error::SomethingElse)
-                                       return 0;
-                                     return 1;
-                                   },
-                                   [](bool e) constexpr noexcept -> int { return (int)e; }};
-  constexpr auto r1 = T{2} | fn::recover(fn);
-  static_assert(r1.value() == 2);
-  constexpr auto r2 = T{::fn::unexpect, fn::sum{Error::SomethingElse}} | fn::recover(fn);
-  static_assert(r2.value() == 0);
-  constexpr auto r3 = T{::fn::unexpect, fn::sum{true}} | fn::recover(fn);
-  static_assert(r3.value() == 1);
-  constexpr auto r4 = T{::fn::unexpect, fn::sum{Error::ThresholdExceeded}} | fn::recover(fn);
-  static_assert(r4.value() == 1);
-
-  SUCCEED();
-}
-
-TEST_CASE("constexpr recover optional", "[recover][constexpr][optional]")
-{
-  using T = fn::optional<int>;
-  constexpr auto fn = []() constexpr noexcept -> int { return 13; };
-  constexpr auto r1 = T{0} | fn::recover(fn);
-  static_assert(r1.value() == 0);
-  constexpr auto r2 = T{} | fn::recover(fn);
-  static_assert(r2.value() == 13);
 
   SUCCEED();
 }

--- a/tests/fn/recover.cpp
+++ b/tests/fn/recover.cpp
@@ -21,6 +21,7 @@ struct Error final {
   std::string what;
 
   operator std::string_view() const { return what; }
+  auto fn() const & -> int { return static_cast<int>(what.size()); }
 };
 } // namespace
 
@@ -71,6 +72,13 @@ TEST_CASE("recover", "[recover][expected][expected_value]")
       static_assert(std::is_same_v<T, operand_t>);
       REQUIRE((a | recover(fnError)).value() == 8);
     }
+    SECTION("member function")
+    {
+      operand_t a{::fn::unexpect, Error{"Not good"}};
+      using T = decltype(a | recover(&Error::fn));
+      static_assert(std::is_same_v<T, operand_t>);
+      REQUIRE((a | recover(&Error::fn)).value() == 8);
+    }
   }
 
   SECTION("rvalue")
@@ -86,6 +94,12 @@ TEST_CASE("recover", "[recover][expected][expected_value]")
       using T = decltype(operand_t{::fn::unexpect, Error{"Not good"}} | recover(fnError));
       static_assert(std::is_same_v<T, operand_t>);
       REQUIRE((operand_t{::fn::unexpect, Error{"Not good"}} | recover(fnError)).value() == 8);
+    }
+    SECTION("member function")
+    {
+      using T = decltype(operand_t{::fn::unexpect, Error{"Not good"}} | recover(&Error::fn));
+      static_assert(std::is_same_v<T, operand_t>);
+      REQUIRE((operand_t{::fn::unexpect, Error{"Not good"}} | recover(&Error::fn)).value() == 8);
     }
   }
 
@@ -282,3 +296,34 @@ TEST_CASE("recover noexcept", "[recover][noexcept]")
 
   SUCCEED();
 }
+
+namespace fn {
+namespace {
+struct Error {};
+struct Value final {};
+
+template <typename T> constexpr auto fn_Error = [](Error) -> T { throw 0; };
+template <typename T> constexpr auto fn_nullary = []() -> T { throw 0; };
+template <typename T> constexpr auto fn_generic = [](auto &&...) -> T { throw 0; };
+constexpr auto fn_Error_lvalue = [](Error &) -> int { throw 0; };
+constexpr auto fn_Error_rvalue = [](Error &&) -> int { throw 0; };
+} // namespace
+
+// clang-format off
+// The callback consumes the error and must produce the operand's own value type.
+static_assert(invocable_recover<decltype(fn_Error<int>), expected<int, Error>>);
+static_assert(invocable_recover<decltype(fn_Error<unsigned>), expected<int, Error>>);    // conversion to value is enough
+static_assert(not invocable_recover<decltype(fn_Error<Value>), expected<int, Error>>);   // no conversion found
+static_assert(not invocable_recover<decltype(fn_nullary<int>), expected<int, Error>>);   // bad arity
+static_assert(invocable_recover<decltype(fn_generic<int>), expected<int, Error>>);
+static_assert(invocable_recover<decltype(fn_Error<void>), expected<void, Error>>);       // a void value wants void back
+static_assert(not invocable_recover<decltype(fn_Error<int>), expected<void, Error>>);    // never quietly discard a result
+static_assert(invocable_recover<decltype(fn_nullary<int>), optional<int>>);              // optional has no error: nullary
+static_assert(not invocable_recover<decltype(fn_Error<int>), optional<int>>);            // bad arity
+static_assert(not invocable_recover<decltype(fn_generic<int>), choice<int>>);            // no choice disjunct
+static_assert(not invocable_recover<decltype(fn_Error_lvalue), expected<int, Error>>);   // cannot bind temporary to lvalue
+static_assert(invocable_recover<decltype(fn_Error_lvalue), expected<int, Error> &>);
+static_assert(invocable_recover<decltype(fn_Error_rvalue), expected<int, Error>>);
+static_assert(not invocable_recover<decltype(fn_Error_rvalue), expected<int, Error> &>); // cannot bind lvalue to rvalue-ref
+// clang-format on
+} // namespace fn

--- a/tests/fn/sum.cpp
+++ b/tests/fn/sum.cpp
@@ -81,7 +81,7 @@ TEST_CASE("sum basic functionality tests", "[sum]")
 
   using fn::sum;
 
-  WHEN("sum<> unit")
+  SECTION("sum<> unit")
   {
     static_assert(sum<>::size == 0);
     static_assert(sum<>::has_type<bool> == false);
@@ -93,7 +93,7 @@ TEST_CASE("sum basic functionality tests", "[sum]")
     SUCCEED();
   }
 
-  WHEN("as_sum")
+  SECTION("as_sum")
   {
     constexpr auto a = fn::as_sum(12);
     static_assert(std::same_as<decltype(a), fn::sum<int> const>);
@@ -109,7 +109,7 @@ TEST_CASE("sum basic functionality tests", "[sum]")
     static_assert(not noexcept(fn::as_sum(std::in_place_type<long>, 12)));
   }
 
-  WHEN("sum_for")
+  SECTION("sum_for")
   {
     static_assert(std::same_as<fn::sum_for<int>, fn::sum<int>>);
     static_assert(std::same_as<fn::sum_for<int, int>, fn::sum<int>>);
@@ -152,7 +152,7 @@ TEST_CASE("sum basic functionality tests", "[sum]")
     static_assert(std::same_as<fn::sum_for<double, fn::sum<>, fn::sum<bool, int>>, fn::sum<bool, double, int>>);
   }
 
-  WHEN("invocable")
+  SECTION("invocable")
   {
     using type = fn::sum_for<TestType, int>; // sum<...> order is platform-specific; sum_for normalizes per platform
     static_assert(fn::typelist_invocable<decltype([](auto) {}), type &>);
@@ -173,9 +173,20 @@ TEST_CASE("sum basic functionality tests", "[sum]")
 
     static_assert(fn::typelist_invocable<decltype([](auto &) {}), sum<NonCopyable> &>);
     static_assert(not fn::typelist_invocable<decltype([](auto) {}), NonCopyable &>); // copy-constructor not available
+
+    // variadic-generic callback, and a per-category sweep of an lvalue-only overload set
+    using T2 = fn::sum<double, int>;
+    static_assert(fn::typelist_invocable<decltype([](auto...) {}), T2 &>);
+    constexpr auto fnLvalue = fn::overload{[](int &) {}, [](double &) {}};
+    static_assert(fn::typelist_invocable<decltype(fnLvalue), T2 &>);
+    static_assert(not fn::typelist_invocable<decltype(fnLvalue), T2 const &>);
+    static_assert(not fn::typelist_invocable<decltype(fnLvalue), T2>);
+    static_assert(not fn::typelist_invocable<decltype(fnLvalue), T2 const>);
+    static_assert(not fn::typelist_invocable<decltype(fnLvalue), T2 &&>);
+    static_assert(not fn::typelist_invocable<decltype(fnLvalue), T2 const &&>);
   }
 
-  WHEN("check destructor call")
+  SECTION("check destructor call")
   {
     {
       sum<TestType> s{std::in_place_type<TestType>};
@@ -188,7 +199,7 @@ TEST_CASE("sum basic functionality tests", "[sum]")
     CHECK(TestType::count == 0);
   }
 
-  WHEN("single parameter constructor")
+  SECTION("single parameter constructor")
   {
     static_assert(sum<int>::size == 1);
 
@@ -198,7 +209,7 @@ TEST_CASE("sum basic functionality tests", "[sum]")
     constexpr sum<bool> b{false};
     static_assert(b == sum{false});
 
-    WHEN("noexcept")
+    SECTION("noexcept")
     {
       // GAP #280 (converse): the value constructors carry no noexcept specifier at all, so they
       // report noexcept(false) even for an alternative that cannot throw. This under-promise is the
@@ -209,7 +220,7 @@ TEST_CASE("sum basic functionality tests", "[sum]")
       SUCCEED();
     }
 
-    WHEN("explicit (non-convertible) argument")
+    SECTION("explicit (non-convertible) argument")
     {
       // The two value constructors differ only in the argument's convertibility to the alternative:
       // ExplicitCopy's copy constructor is explicit, so an lvalue selects the explicit arm and can
@@ -229,7 +240,7 @@ TEST_CASE("sum basic functionality tests", "[sum]")
       sum<ExplicitCopy> b{std::move(e)};
       CHECK(b.invoke([](auto &&i) -> int { return i.v; }) == 42);
 
-      WHEN("constexpr")
+      SECTION("constexpr")
       {
         constexpr auto c = []() constexpr {
           ExplicitCopy e{42};
@@ -240,7 +251,7 @@ TEST_CASE("sum basic functionality tests", "[sum]")
       }
     }
 
-    WHEN("CTAD")
+    SECTION("CTAD")
     {
       sum a{42};
       static_assert(std::is_same_v<decltype(a), sum<int>>);
@@ -255,7 +266,7 @@ TEST_CASE("sum basic functionality tests", "[sum]")
       static_assert(c.invoke([](auto &&a) -> bool { return a.size() == 3 && a[0] == 3 && a[1] == 14 && a[2] == 15; }));
     }
 
-    WHEN("move from rvalue")
+    SECTION("move from rvalue")
     {
       using T = fn::sum<bool, int>;
       constexpr auto fn = [](auto i) constexpr noexcept -> T { return {std::move(i)}; };
@@ -268,7 +279,7 @@ TEST_CASE("sum basic functionality tests", "[sum]")
       static_assert(b.has_value<int>());
     }
 
-    WHEN("copy from lvalue")
+    SECTION("copy from lvalue")
     {
       using T = fn::sum<bool, int>;
       constexpr auto fn = [](auto i) constexpr noexcept -> T { return {i}; };
@@ -282,12 +293,12 @@ TEST_CASE("sum basic functionality tests", "[sum]")
     }
   }
 
-  WHEN("forwarding constructors (immovable)")
+  SECTION("forwarding constructors (immovable)")
   {
     sum<NonCopyable> a{std::in_place_type<NonCopyable>, 42};
     CHECK(a.invoke([](auto &i) -> bool { return i.v == 42; }));
 
-    WHEN("CTAD")
+    SECTION("CTAD")
     {
       constexpr auto a = sum{std::in_place_type<NonCopyable>, 42};
       static_assert(std::is_same_v<decltype(a), sum<NonCopyable> const>);
@@ -296,7 +307,7 @@ TEST_CASE("sum basic functionality tests", "[sum]")
       static_assert(std::is_same_v<decltype(b), sum<NonCopyable>>);
     }
 
-    WHEN("constraints")
+    SECTION("constraints")
     {
       static_assert(can_in_place<sum<NonCopyable>, NonCopyable, int>);
       static_assert(not can_in_place<sum<NonCopyable>, int, int>); // int is not an alternative
@@ -311,9 +322,9 @@ TEST_CASE("sum basic functionality tests", "[sum]")
     }
   }
 
-  WHEN("forwarding constructors (aggregate)")
+  SECTION("forwarding constructors (aggregate)")
   {
-    WHEN("regular")
+    SECTION("regular")
     {
       sum<std::array<int, 3>> a{std::in_place_type<std::array<int, 3>>, 1, 2, 3};
       static_assert(decltype(a)::has_type<std::array<int, 3>>);
@@ -325,7 +336,7 @@ TEST_CASE("sum basic functionality tests", "[sum]")
       }));
     }
 
-    WHEN("constexpr")
+    SECTION("constexpr")
     {
       constexpr sum<std::array<int, 3>> a{std::in_place_type<std::array<int, 3>>, 1, 2, 3};
       static_assert(decltype(a)::has_type<std::array<int, 3>>);
@@ -338,7 +349,7 @@ TEST_CASE("sum basic functionality tests", "[sum]")
       }));
     }
 
-    WHEN("CTAD")
+    SECTION("CTAD")
     {
       constexpr auto a = sum{std::in_place_type<std::array<int, 3>>, 1, 2, 3};
       static_assert(std::is_same_v<decltype(a), sum<std::array<int, 3>> const>);
@@ -348,12 +359,12 @@ TEST_CASE("sum basic functionality tests", "[sum]")
     }
   }
 
-  WHEN("widening constructor")
+  SECTION("widening constructor")
   {
     using T = sum<bool, double, int>;
     using S = sum<bool, int>;
 
-    WHEN("from lvalue")
+    SECTION("from lvalue")
     {
       S const a{std::in_place_type<int>, 42};
       T b{a};
@@ -362,7 +373,7 @@ TEST_CASE("sum basic functionality tests", "[sum]")
       CHECK(a.has_value(std::in_place_type<int>)); // the source is copied, not consumed
     }
 
-    WHEN("from rvalue")
+    SECTION("from rvalue")
     {
       S a{std::in_place_type<int>, 42};
       T b{std::move(a)};
@@ -370,7 +381,7 @@ TEST_CASE("sum basic functionality tests", "[sum]")
       CHECK(b.invoke([](auto &&i) -> int { return static_cast<int>(i); }) == 42);
     }
 
-    WHEN("in_place_type names the source sum")
+    SECTION("in_place_type names the source sum")
     {
       S const a{std::in_place_type<bool>, true};
       T b{std::in_place_type<S>, a};
@@ -378,7 +389,7 @@ TEST_CASE("sum basic functionality tests", "[sum]")
       CHECK(b.invoke([](auto &&i) -> bool { return static_cast<bool>(i); }));
     }
 
-    WHEN("constexpr")
+    SECTION("constexpr")
     {
       constexpr S a{std::in_place_type<int>, 42};
       constexpr T b{a};
@@ -393,7 +404,7 @@ TEST_CASE("sum basic functionality tests", "[sum]")
       SUCCEED();
     }
 
-    WHEN("constraints")
+    SECTION("constraints")
     {
       // Widening only ever widens: the target must be a superset of the source.
       static_assert(std::is_constructible_v<T, S const &>);
@@ -412,7 +423,7 @@ TEST_CASE("sum basic functionality tests", "[sum]")
       SUCCEED();
     }
 
-    WHEN("noexcept")
+    SECTION("noexcept")
     {
       // GAP #280: all three widening constructors are unconditionally noexcept, though each copies
       // or moves every alternative of the source into the wider union.
@@ -424,7 +435,7 @@ TEST_CASE("sum basic functionality tests", "[sum]")
     }
   }
 
-  WHEN("has_type type mismatch")
+  SECTION("has_type type mismatch")
   {
     using type = sum<bool, int>;
     static_assert(type::has_type<int>);
@@ -447,7 +458,56 @@ TEST_CASE("sum basic functionality tests", "[sum]")
     static_assert(noexcept(std::declval<sum<Throwing> const &>().has_value(std::in_place_type<Throwing>)));
   }
 
-  WHEN("equality comparison")
+  SECTION("index")
+  {
+    constexpr fn::sum<std::array<int, 3>> a{std::in_place_type<std::array<int, 3>>, 3, 14, 15};
+    static_assert(a.index == 0);
+
+    fn::sum<double, int> b{std::in_place_type<int>, 42};
+    CHECK(b.index == 1);
+    constexpr fn::sum<double, int> c{std::in_place_type<int>, 12};
+    static_assert(c.index == 1);
+  }
+
+  SECTION("select_nth")
+  {
+    using T = fn::sum<double, int>;
+    static_assert(T::size == 2);
+    static_assert(std::is_same_v<T::template select_nth<0>, double>);
+    static_assert(std::is_same_v<T::template select_nth<1>, int>);
+
+    SUCCEED();
+  }
+
+  SECTION("get_ptr")
+  {
+    using T = fn::sum<double, int>;
+    T b{std::in_place_type<int>, 42};
+    CHECK(b.template has_value<int>());
+    CHECK(b.has_value(std::in_place_type<int>));
+
+    static_assert(std::is_same_v<decltype(b.get_ptr(std::in_place_type<int>)), int *>);
+    CHECK(b.get_ptr(std::in_place_type<int>) == &b.data.v1);
+    CHECK(b.get_ptr(std::in_place_type<double>) == nullptr);
+    static_assert(std::is_same_v<decltype(std::as_const(b).get_ptr(std::in_place_type<int>)), int const *>);
+    CHECK(std::as_const(b).get_ptr(std::in_place_type<int>) == &b.data.v1);
+    CHECK(std::as_const(b).get_ptr(std::in_place_type<double>) == nullptr);
+    static_assert(noexcept(b.get_ptr(std::in_place_type<int>))); // accurate: no alternative is touched
+    static_assert(noexcept(std::as_const(b).get_ptr(std::in_place_type<int>)));
+    static_assert([](auto &b) constexpr -> bool { //
+      return not requires { b.get_ptr(std::in_place_type<bool>); };
+    }(b)); // bool is not a type member
+
+    T const c{std::in_place_type<double>, 4.25};
+    CHECK(c.get_ptr(std::in_place_type<int>) == nullptr);
+    CHECK(c.get_ptr(std::in_place_type<double>) == &c.data.v0);
+
+    constexpr auto d = fn::sum<double, int>{std::in_place_type<int>, 12};
+    static_assert(d.get_ptr(std::in_place_type<double>) == nullptr);
+    static_assert(*d.get_ptr(std::in_place_type<int>) == 12);
+  }
+
+  SECTION("equality comparison")
   {
     using type = sum<bool, int>;
 
@@ -472,7 +532,7 @@ TEST_CASE("sum basic functionality tests", "[sum]")
     CHECK(sum{0.5} != a);
     CHECK(a != sum{0.5});
 
-    WHEN("constexpr")
+    SECTION("constexpr")
     {
       constexpr type a{std::in_place_type<int>, 42};
       static_assert(std::is_same_v<bool, decltype(a == sum{42})>);
@@ -509,7 +569,7 @@ TEST_CASE("sum basic functionality tests", "[sum]")
       }(a));
     }
 
-    WHEN("noexcept")
+    SECTION("noexcept")
     {
       using T = sum<Throwing>;
 
@@ -533,11 +593,11 @@ TEST_CASE("sum basic functionality tests", "[sum]")
     }
   }
 
-  WHEN("invoke")
+  SECTION("invoke")
   {
     sum<int> a{std::in_place_type<int>, 42};
 
-    WHEN("noexcept")
+    SECTION("noexcept")
     {
       // GAP #280: invoke's noexcept is unconditional, so a callback that can throw - every visitor
       // in the sections below throws - still reports noexcept(true); the throw is std::terminate.
@@ -553,7 +613,7 @@ TEST_CASE("sum basic functionality tests", "[sum]")
       SUCCEED();
     }
 
-    WHEN("value only")
+    SECTION("value only")
     {
       static_assert(std::is_same_v<bool, decltype(a.invoke(fn::overload{[](auto) -> bool { throw 1; },
                                                                         [](int) -> bool { return true; }}))>);
@@ -578,7 +638,7 @@ TEST_CASE("sum basic functionality tests", "[sum]")
           [](auto) -> bool { throw 1; }, [](int &) -> bool { throw 0; }, [](int const &) -> bool { throw 0; },
           [](int &&i) -> bool { return i == 42; }, [](int const &&) -> bool { throw 0; }}));
 
-      WHEN("constexpr")
+      SECTION("constexpr")
       {
         constexpr sum<int> a{std::in_place_type<int>, 42};
         static_assert(a.invoke(fn::overload{
@@ -592,7 +652,7 @@ TEST_CASE("sum basic functionality tests", "[sum]")
       }
     }
 
-    WHEN("extra arguments")
+    SECTION("extra arguments")
     {
       static_assert(std::is_same_v<bool, decltype(a.invoke([](int, int) -> bool { return true; }, 12))>);
 
@@ -626,7 +686,7 @@ TEST_CASE("sum basic functionality tests", "[sum]")
                                              [](int const &&, std::monostate) -> bool { throw 0; }},
                                 std::monostate{}));
 
-      WHEN("constexpr")
+      SECTION("constexpr")
       {
         constexpr sum<int> a{std::in_place_type<int>, 42};
         static_assert(a.invoke(fn::overload{[](auto...) -> bool { return false; }, //
@@ -649,11 +709,11 @@ TEST_CASE("sum basic functionality tests", "[sum]")
     }
   }
 
-  WHEN("invoke_r")
+  SECTION("invoke_r")
   {
     sum<int> a{std::in_place_type<int>, 42};
 
-    WHEN("noexcept")
+    SECTION("noexcept")
     {
       // GAP #280: the same unconditional promise as invoke, the conversion to Ret included.
       constexpr auto throwing = [](int i) noexcept(false) -> bool { return i == 42; };
@@ -665,7 +725,7 @@ TEST_CASE("sum basic functionality tests", "[sum]")
       SUCCEED();
     }
 
-    WHEN("value only")
+    SECTION("value only")
     {
       static_assert(std::is_same_v<bool, decltype(a.template invoke_r<bool>(fn::overload{
                                              [](auto) -> bool { throw 1; }, [](int) -> bool { return true; }}))>);
@@ -687,7 +747,7 @@ TEST_CASE("sum basic functionality tests", "[sum]")
           [](auto) -> bool { throw 1; }, [](int &) -> bool { throw 0; }, [](int const &) -> bool { throw 0; },
           [](int &&) -> bool { return true; }, [](int const &&) -> bool { throw 0; }}));
 
-      WHEN("constexpr")
+      SECTION("constexpr")
       {
         constexpr sum<int> a{std::in_place_type<int>, 42};
         static_assert(a.template invoke_r<bool>(fn::overload{
@@ -703,7 +763,7 @@ TEST_CASE("sum basic functionality tests", "[sum]")
       }
     }
 
-    WHEN("extra arguments")
+    SECTION("extra arguments")
     {
       static_assert(std::is_same_v<bool, decltype(a.template invoke_r<bool>(fn::overload{
                                              [](auto) -> bool { throw 1; }, [](int) -> bool { return true; }}))>);
@@ -741,7 +801,7 @@ TEST_CASE("sum basic functionality tests", "[sum]")
                                                               [](int const &&, std::monostate) -> bool { throw 0; }},
                                                  std::monostate{}));
 
-      WHEN("constexpr")
+      SECTION("constexpr")
       {
         constexpr sum<int> a{std::in_place_type<int>, 42};
         static_assert(
@@ -765,13 +825,13 @@ TEST_CASE("sum basic functionality tests", "[sum]")
     }
   }
 
-  WHEN("sum of packs")
+  SECTION("sum of packs")
   {
     using fn::pack;
     constexpr sum a{pack{"abc", 42, 12.5}};
     static_assert(std::is_same_v<decltype(a), sum<pack<char const(&)[4], int, double>> const>);
 
-    WHEN("constexpr")
+    SECTION("constexpr")
     {
       constexpr auto b
           = a.invoke([]<std::size_t I>(char const(&)[I], int i, double d) { return I + i + static_cast<int>(d); });
@@ -783,7 +843,7 @@ TEST_CASE("sum basic functionality tests", "[sum]")
       SUCCEED();
     }
 
-    WHEN("runtime")
+    SECTION("runtime")
     {
       auto const b = a.invoke([](char const *s, int i, double d) { return std::strlen(s) + i + static_cast<int>(d); });
       CHECK(b == 3 + 42 + 12);
@@ -793,7 +853,7 @@ TEST_CASE("sum basic functionality tests", "[sum]")
     }
   }
 
-  WHEN("structural type")
+  SECTION("structural type")
   {
     // sum is a structural type: a constexpr sum can be a template parameter, with
     // template-argument equivalence comparing the active alternative and its value
@@ -845,7 +905,7 @@ TEST_CASE("sum type collapsing", "[sum][transform][normalized]")
   struct sum_bool {};
   struct sum_bool_int {};
 
-  WHEN("one element")
+  SECTION("one element")
   {
     constexpr auto fn = PassThrough{};
     using type = sum<double>;
@@ -853,7 +913,7 @@ TEST_CASE("sum type collapsing", "[sum][transform][normalized]")
         std::same_as<typename _sum_invoke_result<_collapsing_sum_tag, decltype(fn), type &>::type, sum<double>>);
   }
 
-  WHEN("two elements")
+  SECTION("two elements")
   {
     constexpr auto fn = PassThrough{};
     using type = sum<double, int>;
@@ -861,7 +921,7 @@ TEST_CASE("sum type collapsing", "[sum][transform][normalized]")
         std::same_as<typename _sum_invoke_result<_collapsing_sum_tag, decltype(fn), type &>::type, sum<double, int>>);
   }
 
-  WHEN("one sum, one element only")
+  SECTION("one sum, one element only")
   {
     constexpr auto fn = [](sum_bool const &) -> sum<bool> && { throw 0; };
     using type = sum<sum_bool>;
@@ -869,7 +929,7 @@ TEST_CASE("sum type collapsing", "[sum][transform][normalized]")
         std::same_as<typename _sum_invoke_result<_collapsing_sum_tag, decltype(fn), type &>::type, sum<bool>>);
   }
 
-  WHEN("element and one sum with one element")
+  SECTION("element and one sum with one element")
   {
     constexpr auto fn = overload{PassThrough{}, //
                                  [](sum_bool const &) -> sum<bool> && { throw 0; }};
@@ -878,7 +938,7 @@ TEST_CASE("sum type collapsing", "[sum][transform][normalized]")
         std::same_as<typename _sum_invoke_result<_collapsing_sum_tag, decltype(fn), type &>::type, sum<bool, double>>);
   }
 
-  WHEN("one sum with two elements")
+  SECTION("one sum with two elements")
   {
     constexpr auto fn = [](sum_bool_int const &) -> sum<bool, int> && { throw 0; };
     using type = sum<sum_bool_int>;
@@ -886,7 +946,7 @@ TEST_CASE("sum type collapsing", "[sum][transform][normalized]")
         std::same_as<typename _sum_invoke_result<_collapsing_sum_tag, decltype(fn), type &>::type, sum<bool, int>>);
   }
 
-  WHEN("sum with two elements and sum with one element")
+  SECTION("sum with two elements and sum with one element")
   {
     constexpr auto fn = overload{[](sum_bool_int const &) -> sum<bool, int> && { throw 0; },
                                  [](sum_bool const &) -> sum<bool> && { throw 0; }};
@@ -895,7 +955,7 @@ TEST_CASE("sum type collapsing", "[sum][transform][normalized]")
         std::same_as<typename _sum_invoke_result<_collapsing_sum_tag, decltype(fn), type &>::type, sum<bool, int>>);
   }
 
-  WHEN("two sums with two elements and two elements")
+  SECTION("two sums with two elements and two elements")
   {
     constexpr auto fn = overload{PassThrough{}, [](sum_double_int const &) -> sum<double, int> { throw 0; },
                                  [](sum_bool_int const &) -> sum<bool, int> const { throw 0; }};
@@ -943,7 +1003,7 @@ TEST_CASE("sum transform", "[sum][transform]")
                          [](double const &&) -> bool { throw 0; }})
         == sum<bool, int>{true});
 
-  WHEN("extra arguments")
+  SECTION("extra arguments")
   {
     constexpr auto add = [](double i, int j) noexcept -> double { return i + j; };
     static_assert(std::same_as<decltype(a.transform(add, 3)), sum<double>>);
@@ -953,7 +1013,7 @@ TEST_CASE("sum transform", "[sum][transform]")
     CHECK(std::move(std::as_const(a)).transform(add, 3) == sum{3.5});
     CHECK(std::move(a).transform(add, 3) == sum{3.5});
 
-    WHEN("constexpr")
+    SECTION("constexpr")
     {
       constexpr type b{std::in_place_type<double>, 0.5};
       static_assert(b.transform(add, 3) == sum{3.5});
@@ -962,7 +1022,7 @@ TEST_CASE("sum transform", "[sum][transform]")
     }
   }
 
-  WHEN("noexcept")
+  SECTION("noexcept")
   {
     // GAP #280: transform promises noexcept in every value category no matter what the callback
     // promises - the visitors above all throw. The typed-dispatch internals behind operator& and
@@ -1015,21 +1075,9 @@ TEST_CASE("sum move and copy", "[sum][has_value][get_ptr]")
 {
   using fn::sum;
 
-  WHEN("sum_for")
+  SECTION("move and copy")
   {
-    static_assert(std::same_as<fn::sum_for<int>, fn::sum<int>>);
-    static_assert(std::same_as<fn::sum_for<int, bool>, fn::sum<bool, int>>);
-    static_assert(std::same_as<fn::sum_for<bool, int>, fn::sum<bool, int>>);
-    // Canonical order is platform-specific by design (see the note in the WHEN("sum_for") block of
-    // the TEST_CASE above); assert only the platform-independent guarantees here.
-    static_assert(std::same_as<fn::sum_for<NonCopyable, int>, fn::sum_for<int, NonCopyable>>);
-    static_assert(std::same_as<fn::sum_for<int, bool, NonCopyable>, fn::sum_for<NonCopyable, bool, int>>);
-    static_assert(fn::sum_for<int, bool, NonCopyable>::size == 3);
-  }
-
-  WHEN("move and copy")
-  {
-    WHEN("one type only")
+    SECTION("one type only")
     {
       using T = sum<std::string>;
       T a{std::in_place_type<std::string>, "baz"};
@@ -1056,7 +1104,7 @@ TEST_CASE("sum move and copy", "[sum][has_value][get_ptr]")
       CHECK(c.invoke([](auto &&i) { return i; }) == "baz");
     }
 
-    WHEN("mixed with other types")
+    SECTION("mixed with other types")
     {
       using T = sum<std::string, std::string_view>;
       T a{std::in_place_type<std::string>, "baz"};
@@ -1084,9 +1132,9 @@ TEST_CASE("sum move and copy", "[sum][has_value][get_ptr]")
     }
   }
 
-  WHEN("copy only")
+  SECTION("copy only")
   {
-    WHEN("one type only")
+    SECTION("one type only")
     {
       using T = sum<CopyOnly>;
       T a{std::in_place_type<CopyOnly>, 12};
@@ -1110,7 +1158,7 @@ TEST_CASE("sum move and copy", "[sum][has_value][get_ptr]")
       CHECK(b.invoke([](auto &&i) { return static_cast<int>(i); }) == 12);
     }
 
-    WHEN("mixed with other types")
+    SECTION("mixed with other types")
     {
       using T = fn::sum_for<CopyOnly, double, int>; // sum_for: canonical order is platform-specific
       T a{std::in_place_type<CopyOnly>, 12};
@@ -1135,9 +1183,9 @@ TEST_CASE("sum move and copy", "[sum][has_value][get_ptr]")
     }
   }
 
-  WHEN("move only")
+  SECTION("move only")
   {
-    WHEN("one type only")
+    SECTION("one type only")
     {
       using T = sum<MoveOnly>;
       T a{std::in_place_type<MoveOnly>, 12};
@@ -1161,7 +1209,7 @@ TEST_CASE("sum move and copy", "[sum][has_value][get_ptr]")
       CHECK(b.invoke([](auto &&i) { return static_cast<int>(i); }) == 12);
     }
 
-    WHEN("mixed with other types")
+    SECTION("mixed with other types")
     {
       using T = fn::sum_for<MoveOnly, double, int>; // sum_for: canonical order is platform-specific
       T a{std::in_place_type<MoveOnly>, 12};
@@ -1186,9 +1234,9 @@ TEST_CASE("sum move and copy", "[sum][has_value][get_ptr]")
     }
   }
 
-  WHEN("immovable type")
+  SECTION("immovable type")
   {
-    WHEN("one type only")
+    SECTION("one type only")
     {
       using T = sum<NonCopyable>;
       T a{std::in_place_type<NonCopyable>, 12};
@@ -1208,7 +1256,7 @@ TEST_CASE("sum move and copy", "[sum][has_value][get_ptr]")
       }(std::move(std::as_const(a))));
     }
 
-    WHEN("mixed with other types")
+    SECTION("mixed with other types")
     {
       using T = fn::sum_for<NonCopyable, double, int>; // sum_for: canonical order is platform-specific
       T a{std::in_place_type<NonCopyable>, 12};
@@ -1229,7 +1277,7 @@ TEST_CASE("sum move and copy", "[sum][has_value][get_ptr]")
     }
   }
 
-  WHEN("widening")
+  SECTION("widening")
   {
     // The widening pair carries the copy/move constructors' requirements over to the SOURCE's
     // alternatives: copy-widening needs each of them copyable, move-widening needs each movable.
@@ -1248,7 +1296,7 @@ TEST_CASE("sum move and copy", "[sum][has_value][get_ptr]")
     CHECK(a.invoke([](auto &&i) { return static_cast<int>(i); }) == -1); // moved from
   }
 
-  WHEN("noexcept")
+  SECTION("noexcept")
   {
     // GAP #280: the copy and move constructors are declared unconditionally noexcept, so an
     // alternative whose own copy or move throws terminates instead of propagating. The destructor's
@@ -1260,67 +1308,4 @@ TEST_CASE("sum move and copy", "[sum][has_value][get_ptr]")
     static_assert(std::is_nothrow_destructible_v<sum<Throwing>>);
     SUCCEED();
   }
-}
-
-TEST_CASE("sum", "[sum][has_value][get_ptr]")
-{
-  // NOTE We have 5 different specializations, need to test each
-  using namespace fn;
-
-  constexpr auto fn1 = [](auto) {};
-  constexpr auto fn2 = [](auto...) {};
-  constexpr auto fn3 = overload{[](int &) {}, [](double &) {}};
-
-  constexpr sum<std::array<int, 3>> a{std::in_place_type<std::array<int, 3>>, 3, 14, 15};
-  static_assert(a.index == 0);
-  static_assert(decltype(a)::template has_type<std::array<int, 3>>);
-  static_assert(not decltype(a)::template has_type<int>);
-  static_assert(a.has_value(std::in_place_type<std::array<int, 3>>));
-  static_assert(a.template has_value<std::array<int, 3>>());
-  static_assert(a.invoke([](auto &i) -> bool {
-    return std::same_as<std::array<int, 3> const &, decltype(i)> && i.size() == 3 && i[0] == 3 && i[1] == 14
-           && i[2] == 15;
-  }));
-
-  using T = sum<double, int>;
-  T b{std::in_place_type<int>, 42};
-  static_assert(T::size == 2);
-  static_assert(std::is_same_v<T::template select_nth<0>, double>);
-  static_assert(std::is_same_v<T::template select_nth<1>, int>);
-  static_assert(T::has_type<int>);
-  static_assert(T::has_type<double>);
-  static_assert(not T::has_type<bool>);
-  CHECK(b.index == 1);
-  CHECK(b.template has_value<int>());
-  CHECK(b.has_value(std::in_place_type<int>));
-
-  static_assert(fn::typelist_invocable<decltype(fn1), decltype(b)>);
-  static_assert(fn::typelist_invocable<decltype(fn2), decltype(b)>);
-  static_assert(fn::typelist_invocable<decltype(fn2), decltype(b)>);
-  static_assert(fn::typelist_invocable<decltype(fn3), decltype(b) &>);
-  static_assert(not fn::typelist_invocable<decltype(fn3), decltype(b) const &>);
-  static_assert(not fn::typelist_invocable<decltype(fn3), decltype(b)>);
-  static_assert(not fn::typelist_invocable<decltype(fn3), decltype(b) const>);
-  static_assert(not fn::typelist_invocable<decltype(fn3), decltype(b) &&>);
-  static_assert(not fn::typelist_invocable<decltype(fn3), decltype(b) const &&>);
-
-  static_assert(std::is_same_v<decltype(b.get_ptr(std::in_place_type<int>)), int *>);
-  CHECK(b.get_ptr(std::in_place_type<int>) == &b.data.v1);
-  CHECK(b.get_ptr(std::in_place_type<double>) == nullptr);
-  static_assert(std::is_same_v<decltype(std::as_const(b).get_ptr(std::in_place_type<int>)), int const *>);
-  CHECK(std::as_const(b).get_ptr(std::in_place_type<int>) == &b.data.v1);
-  CHECK(std::as_const(b).get_ptr(std::in_place_type<double>) == nullptr);
-  static_assert(noexcept(b.get_ptr(std::in_place_type<int>))); // accurate: no alternative is touched
-  static_assert(noexcept(std::as_const(b).get_ptr(std::in_place_type<int>)));
-  static_assert([](auto &b) constexpr -> bool { //
-    return not requires { b.get_ptr(std::in_place_type<bool>); };
-  }(b)); // bool is not a type member
-
-  T const c{std::in_place_type<double>, 4.25};
-  CHECK(c.get_ptr(std::in_place_type<int>) == nullptr);
-  CHECK(c.get_ptr(std::in_place_type<double>) == &c.data.v0);
-
-  constexpr auto d = sum<double, int>{std::in_place_type<int>, 12};
-  static_assert(d.get_ptr(std::in_place_type<double>) == nullptr);
-  static_assert(*d.get_ptr(std::in_place_type<int>) == 12);
 }

--- a/tests/fn/sum.cpp
+++ b/tests/fn/sum.cpp
@@ -1560,6 +1560,13 @@ TEST_CASE("sum assignment", "[sum][assignment]")
     CHECK_THROWS_AS(a = bad, std::runtime_error);
     CHECK(a.invoke([](ThrowingCopy const &t) { return t.v; }) == 7); // untouched
 
+    // ... and where the copy does not throw, that same arm runs to completion: the temporary is
+    // built, only then is the old alternative destroyed, and the storage is rebuilt from the
+    // temporary's (nothrow) move
+    sum<ThrowingCopy> const good{ThrowingCopy{5}};
+    a = good;
+    CHECK(a.invoke([](ThrowingCopy const &t) { return t.v; }) == 5);
+
     SECTION("the two arms in one sum")
     {
       // whichever arm the incoming alternative needs, the one being replaced survives a throw

--- a/tests/fn/sum.cpp
+++ b/tests/fn/sum.cpp
@@ -52,6 +52,18 @@ struct Throwing final {
   constexpr bool operator==(Throwing const &o) const noexcept(false) { return v == o.v; }
 };
 
+// Copy is explicit, move is implicit - so an lvalue argument is constructible-but-not-convertible
+// and selects sum's explicit value constructor, while an rvalue selects the implicit one.
+// NOTE no operator int(): with the implicit ExplicitCopy(int) ctor it would open an
+// ExplicitCopy& -> int -> ExplicitCopy path, making the argument convertible after all.
+struct ExplicitCopy final {
+  int v;
+
+  constexpr ExplicitCopy(int i) noexcept : v(i) {}
+  constexpr explicit ExplicitCopy(ExplicitCopy const &o) noexcept : v(o.v) {}
+  constexpr ExplicitCopy(ExplicitCopy &&o) noexcept : v(o.v) {}
+};
+
 // Comparison probes are type-keyed rather than the file's usual value-taking lambda: sum<> has no
 // values to pass one (its default constructor is deleted, by design).
 template <typename L, typename R>
@@ -192,6 +204,37 @@ TEST_CASE("sum basic functionality tests", "[sum]")
       SUCCEED();
     }
 
+    WHEN("explicit (non-convertible) argument")
+    {
+      // The two value constructors differ only in the argument's convertibility to the alternative:
+      // ExplicitCopy's copy constructor is explicit, so an lvalue selects the explicit arm and can
+      // only direct-initialize, while an rvalue (implicit move) selects the implicit one.
+      static_assert(std::is_constructible_v<ExplicitCopy, ExplicitCopy &>);
+      static_assert(not std::is_convertible_v<ExplicitCopy &, ExplicitCopy>);
+
+      static_assert(std::is_constructible_v<sum<ExplicitCopy>, ExplicitCopy &>);
+      static_assert(not std::is_convertible_v<ExplicitCopy &, sum<ExplicitCopy>>); // explicit arm
+      static_assert(std::is_constructible_v<sum<ExplicitCopy>, ExplicitCopy &&>);
+      static_assert(std::is_convertible_v<ExplicitCopy &&, sum<ExplicitCopy>>); // implicit arm
+
+      ExplicitCopy e{42};
+      sum<ExplicitCopy> a{e};
+      CHECK(a.invoke([](auto &&i) -> int { return i.v; }) == 42);
+
+      sum<ExplicitCopy> b{std::move(e)};
+      CHECK(b.invoke([](auto &&i) -> int { return i.v; }) == 42);
+
+      WHEN("constexpr")
+      {
+        constexpr auto c = []() constexpr {
+          ExplicitCopy e{42};
+          return sum<ExplicitCopy>{e};
+        }();
+        static_assert(c.invoke([](auto &&i) -> int { return i.v; }) == 42);
+        SUCCEED();
+      }
+    }
+
     WHEN("CTAD")
     {
       sum a{42};
@@ -283,6 +326,82 @@ TEST_CASE("sum basic functionality tests", "[sum]")
 
       auto b = sum{std::in_place_type<std::array<int, 3>>, 1, 2, 3};
       static_assert(std::is_same_v<decltype(b), sum<std::array<int, 3>>>);
+    }
+  }
+
+  WHEN("widening constructor")
+  {
+    using T = sum<bool, double, int>;
+    using S = sum<bool, int>;
+
+    WHEN("from lvalue")
+    {
+      S const a{std::in_place_type<int>, 42};
+      T b{a};
+      CHECK(b.has_value(std::in_place_type<int>));
+      CHECK(b.invoke([](auto &&i) -> int { return static_cast<int>(i); }) == 42);
+      CHECK(a.has_value(std::in_place_type<int>)); // the source is copied, not consumed
+    }
+
+    WHEN("from rvalue")
+    {
+      S a{std::in_place_type<int>, 42};
+      T b{std::move(a)};
+      CHECK(b.has_value(std::in_place_type<int>));
+      CHECK(b.invoke([](auto &&i) -> int { return static_cast<int>(i); }) == 42);
+    }
+
+    WHEN("in_place_type names the source sum")
+    {
+      S const a{std::in_place_type<bool>, true};
+      T b{std::in_place_type<S>, a};
+      CHECK(b.has_value(std::in_place_type<bool>));
+      CHECK(b.invoke([](auto &&i) -> bool { return static_cast<bool>(i); }));
+    }
+
+    WHEN("constexpr")
+    {
+      constexpr S a{std::in_place_type<int>, 42};
+      constexpr T b{a};
+      static_assert(b.has_value(std::in_place_type<int>));
+      static_assert(b == T{42});
+
+      constexpr T c{S{true}}; // rvalue
+      static_assert(c.has_value(std::in_place_type<bool>));
+
+      constexpr T d{std::in_place_type<S>, a};
+      static_assert(d == b);
+      SUCCEED();
+    }
+
+    WHEN("constraints")
+    {
+      // Widening only ever widens: the target must be a superset of the source.
+      static_assert(std::is_constructible_v<T, S const &>);
+      static_assert(std::is_constructible_v<T, S &&>);
+      static_assert(std::is_constructible_v<T, sum<int> const &>);
+      static_assert(not std::is_constructible_v<sum<int>, S const &>); // narrowing
+      static_assert(not std::is_constructible_v<sum<int>, S &&>);
+      static_assert(not std::is_constructible_v<S, sum<double> const &>); // disjoint
+
+      // The in_place_type form names the SOURCE sum, and is superset-constrained the same way.
+      static_assert(std::is_constructible_v<T, std::in_place_type_t<S>, S const &>);
+      static_assert(not std::is_constructible_v<sum<int>, std::in_place_type_t<S>, S const &>);
+
+      // Same-type construction is the copy/move constructor - the widening pair excludes it.
+      static_assert(std::is_constructible_v<T, T const &>);
+      SUCCEED();
+    }
+
+    WHEN("noexcept")
+    {
+      // GAP #280: all three widening constructors are unconditionally noexcept, though each copies
+      // or moves every alternative of the source into the wider union.
+      using X = fn::sum_for<Throwing, int>;
+      static_assert(noexcept(X{std::declval<sum<Throwing> const &>()}));
+      static_assert(noexcept(X{std::declval<sum<Throwing> &&>()}));
+      static_assert(noexcept(X{std::in_place_type<sum<Throwing>>, std::declval<sum<Throwing> const &>()}));
+      SUCCEED();
     }
   }
 
@@ -799,6 +918,25 @@ TEST_CASE("sum transform", "[sum][transform]")
                          [](double const &&) -> bool { throw 0; }})
         == sum<bool, int>{true});
 
+  WHEN("extra arguments")
+  {
+    constexpr auto add = [](double i, int j) noexcept -> double { return i + j; };
+    static_assert(std::same_as<decltype(a.transform(add, 3)), sum<double>>);
+
+    CHECK(a.transform(add, 3) == sum{3.5});
+    CHECK(std::as_const(a).transform(add, 3) == sum{3.5});
+    CHECK(std::move(std::as_const(a)).transform(add, 3) == sum{3.5});
+    CHECK(std::move(a).transform(add, 3) == sum{3.5});
+
+    WHEN("constexpr")
+    {
+      constexpr type b{std::in_place_type<double>, 0.5};
+      static_assert(b.transform(add, 3) == sum{3.5});
+      static_assert(std::move(b).transform(add, 3) == sum{3.5});
+      SUCCEED();
+    }
+  }
+
   WHEN("noexcept")
   {
     // GAP #280: transform promises noexcept in every value category no matter what the callback
@@ -1098,6 +1236,25 @@ TEST_CASE("sum move and copy", "[sum][has_value][get_ptr]")
     }
   }
 
+  WHEN("widening")
+  {
+    // The widening pair carries the copy/move constructors' requirements over to the SOURCE's
+    // alternatives: copy-widening needs each of them copyable, move-widening needs each movable.
+    static_assert(std::is_constructible_v<fn::sum_for<CopyOnly, int>, sum<CopyOnly> const &>);
+    static_assert(std::is_constructible_v<fn::sum_for<CopyOnly, int>, sum<CopyOnly> &&>); // binds const &
+
+    static_assert(not std::is_constructible_v<fn::sum_for<MoveOnly, int>, sum<MoveOnly> const &>);
+    static_assert(std::is_constructible_v<fn::sum_for<MoveOnly, int>, sum<MoveOnly> &&>);
+
+    static_assert(not std::is_constructible_v<fn::sum_for<NonCopyable, int>, sum<NonCopyable> const &>);
+    static_assert(not std::is_constructible_v<fn::sum_for<NonCopyable, int>, sum<NonCopyable> &&>);
+
+    sum<MoveOnly> a{std::in_place_type<MoveOnly>, 12};
+    fn::sum_for<MoveOnly, int> b{std::move(a)};
+    CHECK(b.invoke([](auto &&i) { return static_cast<int>(i); }) == 12);
+    CHECK(a.invoke([](auto &&i) { return static_cast<int>(i); }) == -1); // moved from
+  }
+
   WHEN("noexcept")
   {
     // GAP #280: the copy and move constructors are declared unconditionally noexcept, so an
@@ -1162,6 +1319,9 @@ TEST_CASE("sum", "[sum][has_value][get_ptr]")
   CHECK(std::as_const(b).get_ptr(std::in_place_type<double>) == nullptr);
   static_assert(noexcept(b.get_ptr(std::in_place_type<int>))); // accurate: no alternative is touched
   static_assert(noexcept(std::as_const(b).get_ptr(std::in_place_type<int>)));
+  static_assert([](auto &b) constexpr -> bool { //
+    return not requires { b.get_ptr(std::in_place_type<bool>); };
+  }(b)); // bool is not a type member
 
   T const c{std::in_place_type<double>, 4.25};
   CHECK(c.get_ptr(std::in_place_type<int>) == nullptr);

--- a/tests/fn/sum.cpp
+++ b/tests/fn/sum.cpp
@@ -39,6 +39,25 @@ template <fn::some_sum auto S> auto read_nttp()
 {
   return S.invoke([](auto const &...args) { return (0.0 + ... + static_cast<double>(args)); });
 }
+
+// Every operation sum performs on an alternative - copy, move, compare - can throw here, while the
+// sum member wrapping it promises noexcept regardless. Witnesses the #280 tripwires below.
+struct Throwing final {
+  int v;
+
+  constexpr operator int() const { return v; }
+  constexpr Throwing(int i) noexcept : v(i) {}
+  constexpr Throwing(Throwing const &o) noexcept(false) : v(o.v) {}
+  constexpr Throwing(Throwing &&o) noexcept(false) : v(o.v) {}
+  constexpr bool operator==(Throwing const &o) const noexcept(false) { return v == o.v; }
+};
+
+// Comparison probes are type-keyed rather than the file's usual value-taking lambda: sum<> has no
+// values to pass one (its default constructor is deleted, by design).
+template <typename L, typename R>
+concept can_eq = requires { std::declval<L const &>() == std::declval<R const &>(); };
+template <typename L, typename R>
+concept can_ne = requires { std::declval<L const &>() != std::declval<R const &>(); };
 } // anonymous namespace
 
 TEST_CASE("sum basic functionality tests", "[sum]")
@@ -52,6 +71,11 @@ TEST_CASE("sum basic functionality tests", "[sum]")
     static_assert(sum<>::size == 0);
     static_assert(sum<>::has_type<bool> == false);
     static_assert(std::same_as<fn::sum_for<sum<>, sum<>>, sum<>>);
+    static_assert(not std::is_default_constructible_v<sum<>>); // the deleted default ctor is the point
+    static_assert(std::is_nothrow_copy_constructible_v<sum<>>);
+    static_assert(std::is_nothrow_move_constructible_v<sum<>>);
+    static_assert(std::is_nothrow_destructible_v<sum<>>);
+    SUCCEED();
   }
 
   WHEN("as_sum")
@@ -63,6 +87,11 @@ TEST_CASE("sum basic functionality tests", "[sum]")
     constexpr auto b = fn::as_sum(std::in_place_type<long>, 12);
     static_assert(std::same_as<decltype(b), fn::sum<long> const>);
     static_assert(b == fn::sum{12l});
+
+    // GAP #280 (converse): neither lift carries a noexcept specifier, so both report noexcept(false)
+    // even where nothing can throw. The same conditional-noexcept work fixes over- and under-promise.
+    static_assert(not noexcept(fn::as_sum(12)));
+    static_assert(not noexcept(fn::as_sum(std::in_place_type<long>, 12)));
   }
 
   WHEN("sum_for")
@@ -151,6 +180,17 @@ TEST_CASE("sum basic functionality tests", "[sum]")
 
     constexpr sum<bool> b{false};
     static_assert(b == sum{false});
+
+    WHEN("noexcept")
+    {
+      // GAP #280 (converse): the value constructors carry no noexcept specifier at all, so they
+      // report noexcept(false) even for an alternative that cannot throw. This under-promise is the
+      // safe direction - an unnecessary EH edge, not a terminate - but it is equally inaccurate.
+      static_assert(std::is_nothrow_constructible_v<int, int>);
+      static_assert(not noexcept(sum<int>{42}));
+      static_assert(not noexcept(sum<int>{std::in_place_type<int>, 42}));
+      SUCCEED();
+    }
 
     WHEN("CTAD")
     {
@@ -261,6 +301,12 @@ TEST_CASE("sum basic functionality tests", "[sum]")
     static_assert([](auto const &a) constexpr -> bool { //
       return not requires { a.template has_value<double>(); };
     }(a)); // double is not a type member
+
+    // Accurate, unlike the members below: reading the discriminator touches no alternative, so the
+    // promise holds even when every operation on that alternative can throw.
+    static_assert(noexcept(a.has_value(std::in_place_type<int>)));
+    static_assert(noexcept(a.template has_value<int>()));
+    static_assert(noexcept(std::declval<sum<Throwing> const &>().has_value(std::in_place_type<Throwing>)));
   }
 
   WHEN("equality comparison")
@@ -324,11 +370,50 @@ TEST_CASE("sum basic functionality tests", "[sum]")
         return not requires { a != 0.5; }; // no implicit conversion
       }(a));
     }
+
+    WHEN("noexcept")
+    {
+      using T = sum<Throwing>;
+
+      // GAP #280: both operators are unconditionally noexcept, yet operator== reaches into the
+      // alternative's own comparison - a throwing one terminates rather than propagating.
+      static_assert(not noexcept(std::declval<Throwing const &>() == std::declval<Throwing const &>()));
+      static_assert(noexcept(std::declval<T const &>() == std::declval<T const &>()));
+      static_assert(noexcept(std::declval<T const &>() != std::declval<T const &>()));
+
+      // GAP #281: operator!= drops the two sizeof...>0 conjuncts operator== carries, so against a
+      // sum<> operand it reports itself viable and then fails to compile in its own body (which
+      // calls operator==). Benign only because no object of sum<> can exist to call it with.
+      static_assert(can_eq<sum<int>, sum<int>>);
+      static_assert(can_ne<sum<int>, sum<int>>);
+      static_assert(not can_eq<sum<int>, sum<>>);
+      static_assert(can_ne<sum<int>, sum<>>);
+      static_assert(not can_eq<sum<>, sum<>>);
+      static_assert(can_ne<sum<>, sum<>>);
+
+      SUCCEED();
+    }
   }
 
   WHEN("invoke")
   {
     sum<int> a{std::in_place_type<int>, 42};
+
+    WHEN("noexcept")
+    {
+      // GAP #280: invoke's noexcept is unconditional, so a callback that can throw - every visitor
+      // in the sections below throws - still reports noexcept(true); the throw is std::terminate.
+      constexpr auto throwing = [](int i) noexcept(false) -> bool { return i == 42; };
+      static_assert(not noexcept(throwing(42)));
+      static_assert(noexcept(a.invoke(throwing)));
+      static_assert(noexcept(std::as_const(a).invoke(throwing)));
+      static_assert(noexcept(std::move(a).invoke(throwing)));
+      static_assert(noexcept(std::move(std::as_const(a)).invoke(throwing)));
+
+      constexpr auto throwing2 = [](int i, std::monostate) noexcept(false) -> bool { return i == 42; };
+      static_assert(noexcept(a.invoke(throwing2, std::monostate{}))); // extra arguments, same promise
+      SUCCEED();
+    }
 
     WHEN("value only")
     {
@@ -423,6 +508,18 @@ TEST_CASE("sum basic functionality tests", "[sum]")
   WHEN("invoke_r")
   {
     sum<int> a{std::in_place_type<int>, 42};
+
+    WHEN("noexcept")
+    {
+      // GAP #280: the same unconditional promise as invoke, the conversion to Ret included.
+      constexpr auto throwing = [](int i) noexcept(false) -> bool { return i == 42; };
+      static_assert(noexcept(a.template invoke_r<bool>(throwing)));
+      static_assert(noexcept(std::as_const(a).template invoke_r<bool>(throwing)));
+      static_assert(noexcept(std::move(a).template invoke_r<bool>(throwing)));
+      static_assert(noexcept(std::move(std::as_const(a)).template invoke_r<bool>(throwing)));
+      static_assert(noexcept(a.template invoke_r<long>(throwing))); // converting the result, too
+      SUCCEED();
+    }
 
     WHEN("value only")
     {
@@ -701,6 +798,28 @@ TEST_CASE("sum transform", "[sum][transform]")
                          [](double const &) -> bool { throw 0; }, [](double &&i) -> bool { return i == 0.5; },
                          [](double const &&) -> bool { throw 0; }})
         == sum<bool, int>{true});
+
+  WHEN("noexcept")
+  {
+    // GAP #280: transform promises noexcept in every value category no matter what the callback
+    // promises - the visitors above all throw. The typed-dispatch internals behind operator& and
+    // the widening constructors carry the same unconditional promise.
+    constexpr auto throwing = [](double i) noexcept(false) -> bool { return i == 0.5; };
+    static_assert(noexcept(a.transform(throwing)));
+    static_assert(noexcept(std::as_const(a).transform(throwing)));
+    static_assert(noexcept(std::move(a).transform(throwing)));
+    static_assert(noexcept(std::move(std::as_const(a)).transform(throwing)));
+
+    constexpr auto typed = []<typename T>(std::in_place_type_t<T>, auto &&v) noexcept(false) -> bool {
+      return static_cast<double>(v) == 0.5;
+    };
+    static_assert(noexcept(std::as_const(a)._transform(typed)));
+    static_assert(noexcept(std::move(a)._transform(typed)));
+    static_assert(noexcept(std::as_const(a).template _invoke<bool>(typed)));
+    static_assert(noexcept(std::move(a).template _invoke<bool>(typed)));
+
+    SUCCEED();
+  }
 }
 
 namespace {
@@ -978,6 +1097,19 @@ TEST_CASE("sum move and copy", "[sum][has_value][get_ptr]")
       }(std::move(std::as_const(a))));
     }
   }
+
+  WHEN("noexcept")
+  {
+    // GAP #280: the copy and move constructors are declared unconditionally noexcept, so an
+    // alternative whose own copy or move throws terminates instead of propagating. The destructor's
+    // promise, by contrast, is accurate - destroying the alternatives here cannot throw.
+    static_assert(not std::is_nothrow_copy_constructible_v<Throwing>);
+    static_assert(not std::is_nothrow_move_constructible_v<Throwing>);
+    static_assert(std::is_nothrow_copy_constructible_v<sum<Throwing>>);
+    static_assert(std::is_nothrow_move_constructible_v<sum<Throwing>>);
+    static_assert(std::is_nothrow_destructible_v<sum<Throwing>>);
+    SUCCEED();
+  }
 }
 
 TEST_CASE("sum", "[sum][has_value][get_ptr]")
@@ -1028,6 +1160,8 @@ TEST_CASE("sum", "[sum][has_value][get_ptr]")
   static_assert(std::is_same_v<decltype(std::as_const(b).get_ptr(std::in_place_type<int>)), int const *>);
   CHECK(std::as_const(b).get_ptr(std::in_place_type<int>) == &b.data.v1);
   CHECK(std::as_const(b).get_ptr(std::in_place_type<double>) == nullptr);
+  static_assert(noexcept(b.get_ptr(std::in_place_type<int>))); // accurate: no alternative is touched
+  static_assert(noexcept(std::as_const(b).get_ptr(std::in_place_type<int>)));
 
   T const c{std::in_place_type<double>, 4.25};
   CHECK(c.get_ptr(std::in_place_type<int>) == nullptr);

--- a/tests/fn/sum.cpp
+++ b/tests/fn/sum.cpp
@@ -190,6 +190,8 @@ TEST_CASE("sum basic functionality tests", "[sum]")
 
   WHEN("single parameter constructor")
   {
+    static_assert(sum<int>::size == 1);
+
     constexpr sum<int> a = 12;
     static_assert(a == sum{12});
 
@@ -556,19 +558,25 @@ TEST_CASE("sum basic functionality tests", "[sum]")
       static_assert(std::is_same_v<bool, decltype(a.invoke(fn::overload{[](auto) -> bool { throw 1; },
                                                                         [](int) -> bool { return true; }}))>);
 
-      CHECK(a.invoke(fn::overload{[](auto) -> bool { throw 1; }, [](int &) -> bool { return true; },
+      // a result type other than bool, to witness the deduced return
+      constexpr auto fn1 = [](auto i) noexcept -> std::size_t { return sizeof(i); };
+      static_assert(std::is_same_v<std::size_t, decltype(a.invoke(fn1))>);
+      CHECK(a.invoke(fn1) == sizeof(int));
+      CHECK(a.data.v0 == 42); // white-box: the value went into the first alternative
+
+      CHECK(a.invoke(fn::overload{[](auto) -> bool { throw 1; }, [](int &i) -> bool { return i == 42; },
                                   [](int const &) -> bool { throw 0; }, [](int &&) -> bool { throw 0; },
                                   [](int const &&) -> bool { throw 0; }}));
       CHECK(std::as_const(a).invoke(fn::overload{
-          [](auto) -> bool { throw 1; }, [](int &) -> bool { throw 0; }, [](int const &) -> bool { return true; },
+          [](auto) -> bool { throw 1; }, [](int &) -> bool { throw 0; }, [](int const &i) -> bool { return i == 42; },
           [](int &&) -> bool { throw 0; }, [](int const &&) -> bool { throw 0; }}));
       CHECK(std::move(std::as_const(a))
                 .invoke(fn::overload{[](auto) -> bool { throw 1; }, [](int &) -> bool { throw 0; },
                                      [](int const &) -> bool { throw 0; }, [](int &&) -> bool { throw 0; },
-                                     [](int const &&) -> bool { return true; }}));
-      CHECK(std::move(a).invoke(fn::overload{[](auto) -> bool { throw 1; }, [](int &) -> bool { throw 0; },
-                                             [](int const &) -> bool { throw 0; }, [](int &&) -> bool { return true; },
-                                             [](int const &&) -> bool { throw 0; }}));
+                                     [](int const &&i) -> bool { return i == 42; }}));
+      CHECK(std::move(a).invoke(fn::overload{
+          [](auto) -> bool { throw 1; }, [](int &) -> bool { throw 0; }, [](int const &) -> bool { throw 0; },
+          [](int &&i) -> bool { return i == 42; }, [](int const &&) -> bool { throw 0; }}));
 
       WHEN("constexpr")
       {
@@ -1002,38 +1010,6 @@ struct CopyOnly final {
   constexpr CopyOnly &operator=(CopyOnly &&s) = delete;
 };
 } // anonymous namespace
-
-TEST_CASE("sum functions", "[sum][invoke]")
-{
-  using namespace fn;
-  constexpr auto fn1 = [](auto i) noexcept -> std::size_t { return sizeof(i); };
-
-  sum<int> a{std::in_place_type<int>, 42};
-  static_assert(decltype(a)::size == 1);
-  CHECK(a.data.v0 == 42);
-
-  CHECK(a.invoke(fn1) == 4);
-  CHECK(a.invoke(  //
-      fn::overload{//
-                   [](auto) -> bool { throw 1; }, [](int &i) -> bool { return i == 42; },
-                   [](int const &) -> bool { throw 0; }, [](int &&) -> bool { throw 0; },
-                   [](int const &&) -> bool { throw 0; }}));
-  CHECK(std::as_const(a).invoke( //
-      fn::overload{              //
-                   [](auto) -> bool { throw 1; }, [](int &) -> bool { throw 0; },
-                   [](int const &i) -> bool { return i == 42; }, [](int &&) -> bool { throw 0; },
-                   [](int const &&) -> bool { throw 0; }}));
-  CHECK(std::move(std::as_const(a))
-            .invoke(         //
-                fn::overload{//
-                             [](auto) -> bool { throw 1; }, [](int &) -> bool { throw 0; },
-                             [](int const &) -> bool { throw 0; }, [](int &&) -> bool { throw 0; },
-                             [](int const &&i) -> bool { return i == 42; }}));
-  CHECK(std::move(a).invoke( //
-      fn::overload{          //
-                   [](auto) -> bool { throw 1; }, [](int &) -> bool { throw 0; }, [](int const &) -> bool { throw 0; },
-                   [](int &&i) -> bool { return i == 42; }, [](int const &&) -> bool { throw 0; }}));
-}
 
 TEST_CASE("sum move and copy", "[sum][has_value][get_ptr]")
 {

--- a/tests/fn/sum.cpp
+++ b/tests/fn/sum.cpp
@@ -70,6 +70,9 @@ template <typename L, typename R>
 concept can_eq = requires { std::declval<L const &>() == std::declval<R const &>(); };
 template <typename L, typename R>
 concept can_ne = requires { std::declval<L const &>() != std::declval<R const &>(); };
+
+template <typename S, typename T, typename... Args>
+concept can_in_place = requires(Args... args) { S{std::in_place_type<T>, args...}; };
 } // anonymous namespace
 
 TEST_CASE("sum basic functionality tests", "[sum]")
@@ -289,6 +292,20 @@ TEST_CASE("sum basic functionality tests", "[sum]")
 
       auto b = sum{std::in_place_type<NonCopyable>, 42};
       static_assert(std::is_same_v<decltype(b), sum<NonCopyable>>);
+    }
+
+    WHEN("constraints")
+    {
+      static_assert(can_in_place<sum<NonCopyable>, NonCopyable, int>);
+      static_assert(not can_in_place<sum<NonCopyable>, int, int>); // int is not an alternative
+
+      // GAP #284: the constructor requires only has_type<T> - it never checks that T is
+      // constructible from the arguments. So a bad argument list is reported viable here and then
+      // fails to compile inside variadic_union, outside the immediate context and beyond SFINAE's
+      // reach. Both of these should read `not`, and will once the conjunct is added.
+      static_assert(can_in_place<sum<NonCopyable>, NonCopyable>);               // no default ctor
+      static_assert(can_in_place<sum<NonCopyable>, NonCopyable, char const *>); // not constructible from
+      SUCCEED();
     }
   }
 

--- a/tests/fn/transform.cpp
+++ b/tests/fn/transform.cpp
@@ -51,23 +51,23 @@ TEST_CASE("transform", "[transform][expected][expected_value][pack]")
   static_assert(is::not_invocable_with_any([]() -> int { throw 0; }));                                // bad arity
   static_assert(is::not_invocable_with_any([](int, int) -> int { throw 0; }));                        // bad arity
 
-  WHEN("operand is lvalue")
+  SECTION("lvalue")
   {
-    WHEN("operand is value")
+    SECTION("value")
     {
       operand_t a{std::in_place, 12};
       using T = decltype(a | transform(fnValue));
       static_assert(std::is_same_v<T, operand_t>);
       REQUIRE((a | transform(fnValue)).value() == 13);
 
-      WHEN("change type")
+      SECTION("change type")
       {
         using T = decltype(a | transform(fnXabs));
         static_assert(std::is_same_v<T, fn::expected<Xint, Error>>);
         REQUIRE((a | transform(fnXabs)).value().value == 4);
       }
     }
-    WHEN("operand is error")
+    SECTION("error")
     {
       operand_t a{::fn::unexpect, Error{"Not good"}};
       using T = decltype(a | transform(wrong));
@@ -80,38 +80,38 @@ TEST_CASE("transform", "[transform][expected][expected_value][pack]")
     }
   }
 
-  WHEN("operand is pack")
+  SECTION("pack")
   {
     using operand_t = fn::expected<fn::pack<int, double>, Error>;
     operand_t a{std::in_place, fn::pack{84, 0.5}};
     constexpr auto fnPack = [](int i, double d) constexpr -> int { return i * d; };
     using T = decltype(a | transform(fnPack));
     static_assert(std::is_same_v<T, fn::expected<int, Error>>);
-    WHEN("operand is value") { REQUIRE((a | transform(fnPack)).value() == 42); }
+    SECTION("value") { REQUIRE((a | transform(fnPack)).value() == 42); }
 
-    WHEN("operand is error")
+    SECTION("error")
     {
       constexpr auto wrong = [](auto...) -> int { throw 0; };
       REQUIRE((operand_t{::fn::unexpect, Error{"Not good"}} | transform(wrong)).error().what == "Not good");
     }
   }
 
-  WHEN("operand is rvalue")
+  SECTION("rvalue")
   {
-    WHEN("operand is value")
+    SECTION("value")
     {
       using T = decltype(operand_t{std::in_place, 12} | transform(fnValue));
       static_assert(std::is_same_v<T, operand_t>);
       REQUIRE((operand_t{std::in_place, 12} | transform(fnValue)).value() == 13);
 
-      WHEN("change type")
+      SECTION("change type")
       {
         using T = decltype(operand_t{std::in_place, 12} | transform(fnXabs));
         static_assert(std::is_same_v<T, fn::expected<Xint, Error>>);
         REQUIRE((operand_t{std::in_place, 12} | transform(fnXabs)).value().value == 4);
       }
     }
-    WHEN("operand is error")
+    SECTION("error")
     {
       using T = decltype(operand_t{::fn::unexpect, Error{"Not good"}} | transform(wrong));
       static_assert(std::is_same_v<T, operand_t>);
@@ -120,6 +120,88 @@ TEST_CASE("transform", "[transform][expected][expected_value][pack]")
                   .error()
                   .what
               == "Not good");
+    }
+  }
+
+  SECTION("constexpr")
+  {
+    enum class Error { ThresholdExceeded, SomethingElse };
+    using T = fn::expected<int, Error>;
+
+    SECTION("same value type")
+    {
+      constexpr auto fn = [](int i) constexpr noexcept -> int {
+        if (i < 2)
+          return i + 1;
+        return i;
+      };
+      constexpr auto r1 = T{0} | fn::transform(fn);
+      static_assert(r1.value() == 1);
+      constexpr auto r2 = r1 | fn::transform(fn) | fn::transform(fn) | fn::transform(fn);
+      static_assert(r2.value() == 2);
+      constexpr auto r3 = T{::fn::unexpect, Error::SomethingElse} | fn::transform(fn);
+      static_assert(r3.error() == Error::SomethingElse);
+
+      SUCCEED();
+    }
+
+    SECTION("different value type")
+    {
+      constexpr auto fn = [](int i) constexpr noexcept -> bool { return (i == 1); };
+      constexpr auto r1 = T{1} | fn::transform(fn);
+      static_assert(std::is_same_v<decltype(r1), fn::expected<bool, Error> const>);
+      static_assert(r1.value() == true);
+      constexpr auto r2 = T{0} | fn::transform(fn);
+      static_assert(r2.value() == false);
+      constexpr auto r3 = T{2} | fn::transform(fn);
+      static_assert(r3.value() == false);
+      constexpr auto r4 = T{::fn::unexpect, Error::SomethingElse} | fn::transform(fn);
+      static_assert(r4.error() == Error::SomethingElse);
+
+      SUCCEED();
+    }
+
+    SECTION("sum")
+    {
+      using T = fn::expected<fn::sum_for<Xint, int>, Error>;
+
+      SECTION("same value type")
+      {
+        constexpr auto fn = fn::overload{[](int i) constexpr noexcept -> fn::sum_for<Xint, int> {
+                                           if (i < 3)
+                                             return {i + 1};
+                                           return i;
+                                         },
+                                         [](Xint v) constexpr noexcept -> fn::sum_for<Xint, int> { return v.value; }};
+        constexpr auto r1 = T{0} | fn::transform(fn);
+        static_assert(std::is_same_v<decltype(r1), fn::expected<fn::sum_for<Xint, int>, Error> const>);
+        static_assert(r1.value() == fn::sum{1});
+        constexpr auto r2 = r1 | fn::transform(fn) | fn::transform(fn) | fn::transform(fn);
+        static_assert(r2.value() == fn::sum{3});
+        constexpr auto r3 = T{Xint{4}} | fn::transform(fn);
+        static_assert(r3.value() == fn::sum{4});
+        constexpr auto r4 = T{::fn::unexpect, Error::SomethingElse} | fn::transform(fn);
+        static_assert(r4.error() == Error::SomethingElse);
+
+        SUCCEED();
+      }
+
+      SECTION("different value type")
+      {
+        constexpr auto fn = fn::overload{[](int i) constexpr noexcept -> bool { return i == 1; },
+                                         [](Xint v) constexpr noexcept -> int { return v.value; }};
+        constexpr auto r1 = T{1} | fn::transform(fn);
+        static_assert(std::is_same_v<decltype(r1), fn::expected<fn::sum<bool, int>, Error> const>);
+        static_assert(r1.value() == fn::sum{true});
+        constexpr auto r2 = T{0} | fn::transform(fn);
+        static_assert(r2.value() == fn::sum{false});
+        constexpr auto r3 = T{Xint{3}} | fn::transform(fn);
+        static_assert(r3.value() == fn::sum{3});
+        constexpr auto r4 = T{::fn::unexpect, Error::SomethingElse} | fn::transform(fn);
+        static_assert(r4.error() == Error::SomethingElse);
+
+        SUCCEED();
+      }
     }
   }
 }
@@ -168,9 +250,9 @@ TEST_CASE("transform", "[transform][expected][expected_void]")
   static_assert(is::not_invocable_with_any([](auto) -> int { throw 0; }));       // bad arity
   static_assert(is::not_invocable_with_any([](auto, auto) -> int { throw 0; })); // bad arity
 
-  WHEN("operand is lvalue")
+  SECTION("lvalue")
   {
-    WHEN("operand is value")
+    SECTION("value")
     {
       operand_t a{std::in_place};
       using T = decltype(a | transform(fnValue));
@@ -178,14 +260,14 @@ TEST_CASE("transform", "[transform][expected][expected_void]")
       (a | transform(fnValue)).value();
       REQUIRE(count == 1);
 
-      WHEN("change type")
+      SECTION("change type")
       {
         using T = decltype(a | transform(fnXabs));
         static_assert(std::is_same_v<T, fn::expected<Xint, Error>>);
         REQUIRE((a | transform(fnXabs)).value().value == 42);
       }
     }
-    WHEN("operand is error")
+    SECTION("error")
     {
       operand_t a{::fn::unexpect, Error{"Not good"}};
       using T = decltype(a | transform(wrong));
@@ -198,23 +280,23 @@ TEST_CASE("transform", "[transform][expected][expected_void]")
     }
   }
 
-  WHEN("operand is rvalue")
+  SECTION("rvalue")
   {
-    WHEN("operand is value")
+    SECTION("value")
     {
       using T = decltype(operand_t{std::in_place} | transform(fnValue));
       static_assert(std::is_same_v<T, operand_t>);
       (operand_t{std::in_place} | transform(fnValue)).value();
       REQUIRE(count == 1);
 
-      WHEN("change type")
+      SECTION("change type")
       {
         using T = decltype(operand_t{std::in_place} | transform(fnXabs));
         static_assert(std::is_same_v<T, fn::expected<Xint, Error>>);
         REQUIRE((operand_t{std::in_place} | transform(fnXabs)).value().value == 42);
       }
     }
-    WHEN("operand is error")
+    SECTION("error")
     {
       using T = decltype(operand_t{::fn::unexpect, Error{"Not good"}} | transform(wrong));
       static_assert(std::is_same_v<T, operand_t>);
@@ -275,23 +357,23 @@ TEST_CASE("transform", "[transform][optional][pack]")
   static_assert(is::not_invocable_with_any([]() -> int { throw 0; }));                                // bad arity
   static_assert(is::not_invocable_with_any([](int, int) -> int { throw 0; }));                        // bad arity
 
-  WHEN("operand is lvalue")
+  SECTION("lvalue")
   {
-    WHEN("operand is value")
+    SECTION("value")
     {
       operand_t a{12};
       using T = decltype(a | transform(fnValue));
       static_assert(std::is_same_v<T, operand_t>);
       REQUIRE((a | transform(fnValue)).value() == 13);
 
-      WHEN("change type")
+      SECTION("change type")
       {
         using T = decltype(a | transform(fnXabs));
         static_assert(std::is_same_v<T, fn::optional<Xint>>);
         REQUIRE((a | transform(fnXabs)).value().value == 4);
       }
     }
-    WHEN("operand is error")
+    SECTION("error")
     {
       operand_t a{std::nullopt};
       using T = decltype(a | transform(wrong));
@@ -300,7 +382,7 @@ TEST_CASE("transform", "[transform][optional][pack]")
     }
   }
 
-  WHEN("operand is pack")
+  SECTION("pack")
   {
     using operand_t = fn::optional<fn::pack<int, double>>;
     operand_t a{std::in_place, fn::pack{84, 0.5}};
@@ -308,37 +390,124 @@ TEST_CASE("transform", "[transform][optional][pack]")
     using T = decltype(a | transform(fnPack));
     static_assert(std::is_same_v<T, fn::optional<int>>);
 
-    WHEN("operand is value") { REQUIRE((a | transform(fnPack)).value() == 42); }
+    SECTION("value") { REQUIRE((a | transform(fnPack)).value() == 42); }
 
-    WHEN("operand is error")
+    SECTION("error")
     {
       constexpr auto wrong = [](auto...) -> int { throw 0; };
       REQUIRE(not(operand_t{std::nullopt} | transform(wrong)).has_value());
     }
   }
 
-  WHEN("operand is rvalue")
+  SECTION("rvalue")
   {
-    WHEN("operand is value")
+    SECTION("value")
     {
       using T = decltype(operand_t{12} | transform(fnValue));
       static_assert(std::is_same_v<T, operand_t>);
       REQUIRE((operand_t{12} | transform(fnValue)).value() == 13);
 
-      WHEN("change type")
+      SECTION("change type")
       {
         using T = decltype(operand_t{12} | transform(fnXabs));
         static_assert(std::is_same_v<T, fn::optional<Xint>>);
         REQUIRE((operand_t{12} | transform(fnXabs)).value().value == 4);
       }
     }
-    WHEN("operand is error")
+    SECTION("error")
     {
       using T = decltype(operand_t{std::nullopt} | transform(wrong));
       static_assert(std::is_same_v<T, operand_t>);
       REQUIRE(not(operand_t{std::nullopt} //
                   | transform(wrong))
                      .has_value());
+    }
+  }
+
+  SECTION("constexpr")
+  {
+    using T = fn::optional<int>;
+
+    SECTION("same value type")
+    {
+      constexpr auto fn = [](int i) constexpr noexcept -> int {
+        if (i < 2)
+          return i + 1;
+        return i;
+      };
+      constexpr auto r1 = T{0} | fn::transform(fn);
+      static_assert(r1.value() == 1);
+      constexpr auto r2 = r1 | fn::transform(fn) | fn::transform(fn) | fn::transform(fn);
+      static_assert(r2.value() == 2);
+      constexpr auto r4 = T{} | fn::transform(fn);
+      static_assert(not r4.has_value());
+
+      SUCCEED();
+    }
+
+    SECTION("different value type")
+    {
+      constexpr auto fn1 = [](int i) constexpr noexcept -> bool {
+        if (i == 1)
+          return true;
+        return false;
+      };
+      constexpr auto r1 = T{1} | fn::transform(fn1);
+      static_assert(std::is_same_v<decltype(r1), fn::optional<bool> const>);
+      static_assert(r1.value() == true);
+      constexpr auto r2 = T{0} | fn::transform(fn1);
+      static_assert(r2.value() == false);
+      constexpr auto r3 = T{2} | fn::transform(fn1);
+      static_assert(r3.value() == false);
+      constexpr auto r4 = T{} | fn::transform(fn1);
+      static_assert(not r4.has_value());
+
+      SUCCEED();
+    }
+
+    SECTION("sum")
+    {
+      using T = fn::optional<fn::sum_for<Xint, int>>;
+
+      SECTION("same value type")
+      {
+        constexpr auto fn = fn::overload{[](int i) constexpr noexcept -> fn::sum_for<Xint, int> {
+                                           if (i < 3)
+                                             return {i + 1};
+                                           return i;
+                                         },
+                                         [](Xint v) constexpr noexcept -> fn::sum_for<Xint, int> { return v.value; }};
+        constexpr auto r1 = T{0} | fn::transform(fn);
+        static_assert(std::is_same_v<decltype(r1), fn::optional<fn::sum_for<Xint, int>> const>);
+        static_assert(r1.value() == fn::sum{1});
+        constexpr auto r2 = r1 | fn::transform(fn) | fn::transform(fn) | fn::transform(fn);
+        static_assert(r2.value() == fn::sum{3});
+        constexpr auto r3 = T{Xint{5}} | fn::transform(fn) | fn::transform(fn) | fn::transform(fn);
+        static_assert(r3.value() == fn::sum{5});
+        constexpr auto r4 = T{} | fn::transform(fn);
+        static_assert(not r4.has_value());
+
+        SUCCEED();
+      }
+
+      SECTION("different value type")
+      {
+        constexpr auto fn1 = fn::overload{[](int i) constexpr noexcept -> bool { return i == 1; },
+                                          [](Xint v) constexpr noexcept -> int { return v.value; }};
+        constexpr auto r1 = T{1} | fn::transform(fn1);
+        static_assert(std::is_same_v<decltype(r1), fn::optional<fn::sum<bool, int>> const>);
+        static_assert(r1.value() == fn::sum{true});
+        constexpr auto r2 = T{0} | fn::transform(fn1);
+        static_assert(r2.value() == fn::sum{false});
+        constexpr auto r3 = T{2} | fn::transform(fn1);
+        static_assert(r3.value() == fn::sum{false});
+        constexpr auto r4 = T{Xint{5}} | fn::transform(fn1);
+        static_assert(r4.value() == fn::sum{5});
+        constexpr auto r5 = T{} | fn::transform(fn1);
+        static_assert(not r5.has_value());
+
+        SUCCEED();
+      }
     }
   }
 }
@@ -395,16 +564,16 @@ TEST_CASE("transform choice", "[transform][choice]")
   static_assert(is::not_invocable_with_any([]() -> operand_t { throw 0; }));         // bad arity
   static_assert(is::not_invocable_with_any([](int, int) -> operand_t { throw 0; })); // bad arity
 
-  WHEN("operand is lvalue")
+  SECTION("lvalue")
   {
-    WHEN("operand is value")
+    SECTION("value")
     {
       operand_t a{12};
       using T = decltype(a | transform(fnValue));
       static_assert(std::is_same_v<T, fn::choice<int>>);
       REQUIRE(*(a | transform(fnValue)).get_ptr<int>() == 13);
 
-      WHEN("change type")
+      SECTION("change type")
       {
         using T = decltype(a | transform(fnXabs));
         static_assert(std::is_same_v<T, fn::choice<Xint>>);
@@ -413,20 +582,56 @@ TEST_CASE("transform choice", "[transform][choice]")
     }
   }
 
-  WHEN("operand is rvalue")
+  SECTION("rvalue")
   {
-    WHEN("operand is value")
+    SECTION("value")
     {
       using T = decltype(operand_t{12} | transform(fnValue));
       static_assert(std::is_same_v<T, fn::choice<int>>);
       REQUIRE(*(operand_t{12} | transform(fnValue)).get_ptr<int>() == 13);
 
-      WHEN("change type")
+      SECTION("change type")
       {
         using T = decltype(operand_t{12} | transform(fnXabs));
         static_assert(std::is_same_v<T, fn::choice<Xint>>);
         REQUIRE((operand_t{12} | transform(fnXabs)).get_ptr<Xint>()->value == 4);
       }
+    }
+  }
+
+  SECTION("constexpr")
+  {
+    using T = fn::choice<double, int>;
+
+    SECTION("same value type")
+    {
+      constexpr auto fn = [](int i) constexpr noexcept -> int {
+        if (i < 1)
+          return i + 1;
+        return i;
+      };
+      constexpr auto r1 = T{0} | fn::transform(fn);
+      static_assert(r1.transform([](int i) -> int { return i; }) == fn::choice{1});
+      constexpr auto r2 = T{0.5} | fn::transform(fn);
+      static_assert(r2.transform([](int i) -> int { return i; }) == fn::choice{1});
+      constexpr auto r3 = r1 | fn::transform(fn) | fn::transform(fn) | fn::transform(fn);
+      static_assert(r2.transform([](int i) -> int { return i; }) == fn::choice{1});
+
+      SUCCEED();
+    }
+
+    SECTION("different value type")
+    {
+      constexpr auto fn1 = [](int i) constexpr noexcept -> bool { return (i == 1); };
+      constexpr auto r1 = T{1} | fn::transform(fn1);
+      static_assert(std::is_same_v<decltype(r1), fn::choice<bool> const>);
+      static_assert(r1.transform([](bool i) -> bool { return i; }) == fn::choice{true});
+      constexpr auto r2 = T{0} | fn::transform(fn1);
+      static_assert(r2.transform([](bool i) -> bool { return i; }) == fn::choice{false});
+      constexpr auto r3 = T{2} | fn::transform(fn1);
+      static_assert(r3.transform([](bool i) -> bool { return i; }) == fn::choice{false});
+
+      SUCCEED();
     }
   }
 }
@@ -446,202 +651,6 @@ TEST_CASE("transform noexcept", "[transform][choice][noexcept]")
   static_assert(noexcept(std::declval<operand_t &>().transform(fnThrows)));
 
   static_assert(noexcept(transform_t::apply{}(std::declval<operand_t &>(), fnThrows))); // GAP #285
-
-  SUCCEED();
-}
-
-TEST_CASE("constexpr transform expected", "[transform][constexpr][expected]")
-{
-  enum class Error { ThresholdExceeded, SomethingElse };
-  using T = fn::expected<int, Error>;
-
-  WHEN("same value type")
-  {
-    constexpr auto fn = [](int i) constexpr noexcept -> int {
-      if (i < 2)
-        return i + 1;
-      return i;
-    };
-    constexpr auto r1 = T{0} | fn::transform(fn);
-    static_assert(r1.value() == 1);
-    constexpr auto r2 = r1 | fn::transform(fn) | fn::transform(fn) | fn::transform(fn);
-    static_assert(r2.value() == 2);
-    constexpr auto r3 = T{::fn::unexpect, Error::SomethingElse} | fn::transform(fn);
-    static_assert(r3.error() == Error::SomethingElse);
-  }
-
-  WHEN("different value type")
-  {
-    constexpr auto fn = [](int i) constexpr noexcept -> bool { return (i == 1); };
-    constexpr auto r1 = T{1} | fn::transform(fn);
-    static_assert(std::is_same_v<decltype(r1), fn::expected<bool, Error> const>);
-    static_assert(r1.value() == true);
-    constexpr auto r2 = T{0} | fn::transform(fn);
-    static_assert(r2.value() == false);
-    constexpr auto r3 = T{2} | fn::transform(fn);
-    static_assert(r3.value() == false);
-    constexpr auto r4 = T{::fn::unexpect, Error::SomethingElse} | fn::transform(fn);
-    static_assert(r4.error() == Error::SomethingElse);
-  }
-
-  SUCCEED();
-}
-
-TEST_CASE("constexpr transform expected with sum", "[transform][constexpr][expected][sum]")
-{
-  enum class Error { ThresholdExceeded, SomethingElse };
-  using T = fn::expected<fn::sum_for<Xint, int>, Error>;
-
-  WHEN("same value type")
-  {
-    constexpr auto fn = fn::overload{[](int i) constexpr noexcept -> fn::sum_for<Xint, int> {
-                                       if (i < 3)
-                                         return {i + 1};
-                                       return i;
-                                     },
-                                     [](Xint v) constexpr noexcept -> fn::sum_for<Xint, int> { return v.value; }};
-    constexpr auto r1 = T{0} | fn::transform(fn);
-    static_assert(std::is_same_v<decltype(r1), fn::expected<fn::sum_for<Xint, int>, Error> const>);
-    static_assert(r1.value() == fn::sum{1});
-    constexpr auto r2 = r1 | fn::transform(fn) | fn::transform(fn) | fn::transform(fn);
-    static_assert(r2.value() == fn::sum{3});
-    constexpr auto r3 = T{Xint{4}} | fn::transform(fn);
-    static_assert(r3.value() == fn::sum{4});
-    constexpr auto r4 = T{::fn::unexpect, Error::SomethingElse} | fn::transform(fn);
-    static_assert(r4.error() == Error::SomethingElse);
-  }
-
-  WHEN("different value type")
-  {
-    constexpr auto fn = fn::overload{[](int i) constexpr noexcept -> bool { return i == 1; },
-                                     [](Xint v) constexpr noexcept -> int { return v.value; }};
-    constexpr auto r1 = T{1} | fn::transform(fn);
-    static_assert(std::is_same_v<decltype(r1), fn::expected<fn::sum<bool, int>, Error> const>);
-    static_assert(r1.value() == fn::sum{true});
-    constexpr auto r2 = T{0} | fn::transform(fn);
-    static_assert(r2.value() == fn::sum{false});
-    constexpr auto r3 = T{Xint{3}} | fn::transform(fn);
-    static_assert(r3.value() == fn::sum{3});
-    constexpr auto r4 = T{::fn::unexpect, Error::SomethingElse} | fn::transform(fn);
-    static_assert(r4.error() == Error::SomethingElse);
-  }
-
-  SUCCEED();
-}
-
-TEST_CASE("constexpr transform optional", "[transform][constexpr][optional]")
-{
-  using T = fn::optional<int>;
-
-  WHEN("same value type")
-  {
-    constexpr auto fn = [](int i) constexpr noexcept -> int {
-      if (i < 2)
-        return i + 1;
-      return i;
-    };
-    constexpr auto r1 = T{0} | fn::transform(fn);
-    static_assert(r1.value() == 1);
-    constexpr auto r2 = r1 | fn::transform(fn) | fn::transform(fn) | fn::transform(fn);
-    static_assert(r2.value() == 2);
-    constexpr auto r4 = T{} | fn::transform(fn);
-    static_assert(not r4.has_value());
-  }
-
-  WHEN("different value type")
-  {
-    constexpr auto fn1 = [](int i) constexpr noexcept -> bool {
-      if (i == 1)
-        return true;
-      return false;
-    };
-    constexpr auto r1 = T{1} | fn::transform(fn1);
-    static_assert(std::is_same_v<decltype(r1), fn::optional<bool> const>);
-    static_assert(r1.value() == true);
-    constexpr auto r2 = T{0} | fn::transform(fn1);
-    static_assert(r2.value() == false);
-    constexpr auto r3 = T{2} | fn::transform(fn1);
-    static_assert(r3.value() == false);
-    constexpr auto r4 = T{} | fn::transform(fn1);
-    static_assert(not r4.has_value());
-  }
-
-  SUCCEED();
-}
-
-TEST_CASE("constexpr transform optional with sum", "[transform][constexpr][optional][sum]")
-{
-  using T = fn::optional<fn::sum_for<Xint, int>>;
-
-  WHEN("same value type")
-  {
-    constexpr auto fn = fn::overload{[](int i) constexpr noexcept -> fn::sum_for<Xint, int> {
-                                       if (i < 3)
-                                         return {i + 1};
-                                       return i;
-                                     },
-                                     [](Xint v) constexpr noexcept -> fn::sum_for<Xint, int> { return v.value; }};
-    constexpr auto r1 = T{0} | fn::transform(fn);
-    static_assert(std::is_same_v<decltype(r1), fn::optional<fn::sum_for<Xint, int>> const>);
-    static_assert(r1.value() == fn::sum{1});
-    constexpr auto r2 = r1 | fn::transform(fn) | fn::transform(fn) | fn::transform(fn);
-    static_assert(r2.value() == fn::sum{3});
-    constexpr auto r3 = T{Xint{5}} | fn::transform(fn) | fn::transform(fn) | fn::transform(fn);
-    static_assert(r3.value() == fn::sum{5});
-    constexpr auto r4 = T{} | fn::transform(fn);
-    static_assert(not r4.has_value());
-  }
-
-  WHEN("different value type")
-  {
-    constexpr auto fn1 = fn::overload{[](int i) constexpr noexcept -> bool { return i == 1; },
-                                      [](Xint v) constexpr noexcept -> int { return v.value; }};
-    constexpr auto r1 = T{1} | fn::transform(fn1);
-    static_assert(std::is_same_v<decltype(r1), fn::optional<fn::sum<bool, int>> const>);
-    static_assert(r1.value() == fn::sum{true});
-    constexpr auto r2 = T{0} | fn::transform(fn1);
-    static_assert(r2.value() == fn::sum{false});
-    constexpr auto r3 = T{2} | fn::transform(fn1);
-    static_assert(r3.value() == fn::sum{false});
-    constexpr auto r4 = T{Xint{5}} | fn::transform(fn1);
-    static_assert(r4.value() == fn::sum{5});
-    constexpr auto r5 = T{} | fn::transform(fn1);
-    static_assert(not r5.has_value());
-  }
-
-  SUCCEED();
-}
-
-TEST_CASE("constexpr transform choice", "[transform][constexpr][choice]")
-{
-  using T = fn::choice<double, int>;
-
-  WHEN("same value type")
-  {
-    constexpr auto fn = [](int i) constexpr noexcept -> int {
-      if (i < 1)
-        return i + 1;
-      return i;
-    };
-    constexpr auto r1 = T{0} | fn::transform(fn);
-    static_assert(r1.transform([](int i) -> int { return i; }) == fn::choice{1});
-    constexpr auto r2 = T{0.5} | fn::transform(fn);
-    static_assert(r2.transform([](int i) -> int { return i; }) == fn::choice{1});
-    constexpr auto r3 = r1 | fn::transform(fn) | fn::transform(fn) | fn::transform(fn);
-    static_assert(r2.transform([](int i) -> int { return i; }) == fn::choice{1});
-  }
-
-  WHEN("different value type")
-  {
-    constexpr auto fn1 = [](int i) constexpr noexcept -> bool { return (i == 1); };
-    constexpr auto r1 = T{1} | fn::transform(fn1);
-    static_assert(std::is_same_v<decltype(r1), fn::choice<bool> const>);
-    static_assert(r1.transform([](bool i) -> bool { return i; }) == fn::choice{true});
-    constexpr auto r2 = T{0} | fn::transform(fn1);
-    static_assert(r2.transform([](bool i) -> bool { return i; }) == fn::choice{false});
-    constexpr auto r3 = T{2} | fn::transform(fn1);
-    static_assert(r3.transform([](bool i) -> bool { return i; }) == fn::choice{false});
-  }
 
   SUCCEED();
 }

--- a/tests/fn/transform.cpp
+++ b/tests/fn/transform.cpp
@@ -22,6 +22,8 @@ struct Error final {
 
 struct Xint final {
   int value;
+
+  auto fn() const & -> int { return value + 1; }
 };
 } // namespace
 
@@ -78,6 +80,14 @@ TEST_CASE("transform", "[transform][expected][expected_value][pack]")
                   .what
               == "Not good");
     }
+    SECTION("member function")
+    {
+      using operand_t = fn::expected<Xint, Error>;
+      operand_t a{std::in_place, Xint{12}};
+      using T = decltype(a | transform(&Xint::fn));
+      static_assert(std::is_same_v<T, fn::expected<int, Error>>);
+      REQUIRE((a | transform(&Xint::fn)).value() == 13);
+    }
   }
 
   SECTION("pack")
@@ -120,6 +130,13 @@ TEST_CASE("transform", "[transform][expected][expected_value][pack]")
                   .error()
                   .what
               == "Not good");
+    }
+    SECTION("member function")
+    {
+      using operand_t = fn::expected<Xint, Error>;
+      using T = decltype(operand_t{std::in_place, Xint{12}} | transform(&Xint::fn));
+      static_assert(std::is_same_v<T, fn::expected<int, Error>>);
+      REQUIRE((operand_t{std::in_place, Xint{12}} | transform(&Xint::fn)).value() == 13);
     }
   }
 
@@ -380,6 +397,14 @@ TEST_CASE("transform", "[transform][optional][pack]")
       static_assert(std::is_same_v<T, operand_t>);
       REQUIRE(not(a | transform(wrong)).has_value());
     }
+    SECTION("member function")
+    {
+      using operand_t = fn::optional<Xint>;
+      operand_t a{std::in_place, Xint{12}};
+      using T = decltype(a | transform(&Xint::fn));
+      static_assert(std::is_same_v<T, fn::optional<int>>);
+      REQUIRE((a | transform(&Xint::fn)).value() == 13);
+    }
   }
 
   SECTION("pack")
@@ -421,6 +446,13 @@ TEST_CASE("transform", "[transform][optional][pack]")
       REQUIRE(not(operand_t{std::nullopt} //
                   | transform(wrong))
                      .has_value());
+    }
+    SECTION("member function")
+    {
+      using operand_t = fn::optional<Xint>;
+      using T = decltype(operand_t{std::in_place, Xint{12}} | transform(&Xint::fn));
+      static_assert(std::is_same_v<T, fn::optional<int>>);
+      REQUIRE((operand_t{std::in_place, Xint{12}} | transform(&Xint::fn)).value() == 13);
     }
   }
 
@@ -654,3 +686,42 @@ TEST_CASE("transform noexcept", "[transform][choice][noexcept]")
 
   SUCCEED();
 }
+
+namespace fn {
+namespace {
+struct Error {};
+struct Value final {};
+
+template <typename T> constexpr auto fn_int = [](int) -> T { throw 0; };
+template <typename T> constexpr auto fn_generic = [](auto &&...) -> T { throw 0; };
+constexpr auto fn_int_lvalue = [](int &) -> int { throw 0; };
+constexpr auto fn_int_rvalue = [](int &&) -> int { throw 0; };
+} // namespace
+
+// clang-format off
+// The callback returns a plain value, which must convert into the operand's own monad.
+static_assert(invocable_transform<decltype(fn_int<int>), expected<int, Error>>);
+static_assert(invocable_transform<decltype(fn_int<Value>), expected<int, Error>>);              // may change the type
+static_assert(not invocable_transform<decltype(fn_int<int>), expected<Value, Error>>);          // wrong parameter type
+static_assert(invocable_transform<decltype(fn_generic<int>), expected<Value, Error>>);
+static_assert(invocable_transform<decltype(fn_generic<int>), expected<void, Error>>);           // void: nullary callback
+static_assert(not invocable_transform<decltype(fn_int<int>), expected<void, Error>>);           // void: unary is bad arity
+static_assert(invocable_transform<decltype(fn_int<void>), expected<int, Error>>); // a void return transforms the value
+                                                                                  // side to expected<void, Error>
+static_assert(invocable_transform<decltype(fn_int<int>), optional<int>>);
+static_assert(not invocable_transform<decltype(fn_int<int>), optional<Value>>);                 // wrong parameter type
+static_assert(invocable_transform<decltype(fn_generic<int>), optional<Value>>);
+static_assert(invocable_transform<decltype(fn_generic<int>), choice<int>>);
+static_assert(not invocable_transform<decltype(fn_int<int>), choice<Value>>);            // must serve every alternative
+static_assert(not invocable_transform<decltype(fn_int_lvalue), expected<int, Error>>);   // cannot bind temporary to lvalue
+static_assert(invocable_transform<decltype(fn_int_lvalue), expected<int, Error> &>);
+static_assert(invocable_transform<decltype(fn_int_rvalue), expected<int, Error>>);
+static_assert(not invocable_transform<decltype(fn_int_rvalue), expected<int, Error> &>); // cannot bind lvalue to rvalue-ref
+
+// A sum value dispatches through sum::transform, which requires the callback to cover ALL alternatives.
+static_assert(invocable_transform<decltype(fn_generic<int>), expected<sum<Value, int>, Error>>);
+static_assert(not invocable_transform<decltype(fn_int<int>), expected<sum<Value, int>, Error>>); // int alone is not exhaustive
+static_assert(invocable_transform<decltype(fn_generic<int>), optional<sum<Value, int>>>);
+static_assert(not invocable_transform<decltype(fn_int<int>), optional<sum<Value, int>>>);
+// clang-format on
+} // namespace fn

--- a/tests/fn/transform.cpp
+++ b/tests/fn/transform.cpp
@@ -719,9 +719,9 @@ static_assert(invocable_transform<decltype(fn_int_rvalue), expected<int, Error>>
 static_assert(not invocable_transform<decltype(fn_int_rvalue), expected<int, Error> &>); // cannot bind lvalue to rvalue-ref
 
 // A sum value dispatches through sum::transform, which requires the callback to cover ALL alternatives.
-static_assert(invocable_transform<decltype(fn_generic<int>), expected<sum<Value, int>, Error>>);
-static_assert(not invocable_transform<decltype(fn_int<int>), expected<sum<Value, int>, Error>>); // int alone is not exhaustive
-static_assert(invocable_transform<decltype(fn_generic<int>), optional<sum<Value, int>>>);
-static_assert(not invocable_transform<decltype(fn_int<int>), optional<sum<Value, int>>>);
+static_assert(invocable_transform<decltype(fn_generic<int>), expected<sum_for<Value, int>, Error>>);
+static_assert(not invocable_transform<decltype(fn_int<int>), expected<sum_for<Value, int>, Error>>); // int alone is not exhaustive
+static_assert(invocable_transform<decltype(fn_generic<int>), optional<sum_for<Value, int>>>);
+static_assert(not invocable_transform<decltype(fn_int<int>), optional<sum_for<Value, int>>>);
 // clang-format on
 } // namespace fn

--- a/tests/fn/transform.cpp
+++ b/tests/fn/transform.cpp
@@ -124,6 +124,32 @@ TEST_CASE("transform", "[transform][expected][expected_value][pack]")
   }
 }
 
+TEST_CASE("transform noexcept", "[transform][expected][expected_value][noexcept]")
+{
+  using namespace fn;
+
+  using operand_t = fn::expected<int, Error>;
+
+  constexpr auto fnNothrow = [](int i) noexcept -> int { return i + 1; };
+  constexpr auto fnThrows = [](int i) noexcept(false) -> int { return i + 1; };
+
+  // The member weighs the callback AND the copy of the untouched error. Error carries a std::string,
+  // whose copy can throw, so even a noexcept callback leaves the member potentially-throwing.
+  static_assert(not std::is_nothrow_copy_constructible_v<Error>);
+  static_assert(not noexcept(std::declval<operand_t &>().transform(fnNothrow)));
+
+  // Give it an error whose copy cannot throw, and the callback alone decides.
+  using nothrow_t = fn::expected<int, int>;
+  static_assert(noexcept(std::declval<nothrow_t &>().transform(fnNothrow)));
+  static_assert(not noexcept(std::declval<nothrow_t &>().transform(fnThrows)));
+
+  // GAP #285: transform_t::apply discards that, being unconditionally noexcept - as is the rest of
+  // the pipeline it is reached through (pinned in tests/fn/functor.cpp).
+  static_assert(noexcept(transform_t::apply{}(std::declval<nothrow_t &>(), fnThrows)));
+
+  SUCCEED();
+}
+
 TEST_CASE("transform", "[transform][expected][expected_void]")
 {
   using namespace fn;
@@ -199,6 +225,28 @@ TEST_CASE("transform", "[transform][expected][expected_void]")
               == "Not good");
     }
   }
+}
+
+TEST_CASE("transform noexcept", "[transform][expected][expected_void][noexcept]")
+{
+  using namespace fn;
+
+  using operand_t = fn::expected<void, Error>;
+
+  constexpr auto fnNothrow = []() noexcept -> int { return 1; };
+  constexpr auto fnThrows = []() noexcept(false) -> int { return 1; };
+
+  // As for a non-void value: the untouched Error's copy can throw, so isolate the callback with an
+  // error whose copy cannot.
+  static_assert(not noexcept(std::declval<operand_t &>().transform(fnNothrow)));
+
+  using nothrow_t = fn::expected<void, int>;
+  static_assert(noexcept(std::declval<nothrow_t &>().transform(fnNothrow)));
+  static_assert(not noexcept(std::declval<nothrow_t &>().transform(fnThrows)));
+
+  static_assert(noexcept(transform_t::apply{}(std::declval<nothrow_t &>(), fnThrows))); // GAP #285
+
+  SUCCEED();
 }
 
 TEST_CASE("transform", "[transform][optional][pack]")
@@ -295,6 +343,24 @@ TEST_CASE("transform", "[transform][optional][pack]")
   }
 }
 
+TEST_CASE("transform noexcept", "[transform][optional][noexcept]")
+{
+  using namespace fn;
+
+  using operand_t = fn::optional<int>;
+
+  constexpr auto fnNothrow = [](int i) noexcept -> int { return i + 1; };
+  constexpr auto fnThrows = [](int i) noexcept(false) -> int { return i + 1; };
+
+  // An optional has no error side to copy, so the callback alone decides.
+  static_assert(noexcept(std::declval<operand_t &>().transform(fnNothrow)));
+  static_assert(not noexcept(std::declval<operand_t &>().transform(fnThrows)));
+
+  static_assert(noexcept(transform_t::apply{}(std::declval<operand_t &>(), fnThrows))); // GAP #285
+
+  SUCCEED();
+}
+
 TEST_CASE("transform choice", "[transform][choice]")
 {
   using namespace fn;
@@ -363,6 +429,25 @@ TEST_CASE("transform choice", "[transform][choice]")
       }
     }
   }
+}
+
+TEST_CASE("transform noexcept", "[transform][choice][noexcept]")
+{
+  using namespace fn;
+
+  using operand_t = fn::choice<bool, double, int>;
+
+  constexpr auto fnThrows = [](auto i) noexcept(false) -> int { return static_cast<int>(i) + 1; };
+
+  // GAP #280: choice parts company with optional and expected here - its own transform is
+  // unconditionally noexcept, dispatching through sum::transform, so even the MEMBER over-promises.
+  // The same operation therefore has different exception behaviour depending on the monad it is
+  // written against.
+  static_assert(noexcept(std::declval<operand_t &>().transform(fnThrows)));
+
+  static_assert(noexcept(transform_t::apply{}(std::declval<operand_t &>(), fnThrows))); // GAP #285
+
+  SUCCEED();
 }
 
 TEST_CASE("constexpr transform expected", "[transform][constexpr][expected]")

--- a/tests/fn/transform_error.cpp
+++ b/tests/fn/transform_error.cpp
@@ -110,6 +110,36 @@ TEST_CASE("transform_error", "[transform_error][expected]")
   }
 }
 
+TEST_CASE("transform_error noexcept", "[transform_error][expected][noexcept]")
+{
+  using namespace fn;
+
+  using operand_t = fn::expected<int, Error>;
+
+  constexpr auto fnNothrow = [](Error const &) noexcept -> Xerror { return {0}; };
+  constexpr auto fnThrows = [](Error const &) noexcept(false) -> Xerror { return {0}; };
+
+  // transform_error leaves the VALUE alone, so - mirroring or_else - the member weighs the callback
+  // together with the copy of that value. Here the value is an int, whose copy cannot throw, so the
+  // callback alone decides.
+  static_assert(noexcept(std::declval<operand_t &>().transform_error(fnNothrow)));
+  static_assert(not noexcept(std::declval<operand_t &>().transform_error(fnThrows)));
+
+  // Give it a value whose copy can throw, and the member says so even for a noexcept callback - the
+  // body really does copy the value across (which is what #278 is about: the requires-clause omits
+  // the conjunct that would let a move-only value SFINAE out cleanly, though the noexcept spec below
+  // does account for the copy).
+  using throwing_value_t = fn::expected<std::string, Error>;
+  constexpr auto fnNothrow2 = [](Error const &) noexcept -> Xerror { return {0}; };
+  static_assert(not std::is_nothrow_copy_constructible_v<std::string>);
+  static_assert(not noexcept(std::declval<throwing_value_t &>().transform_error(fnNothrow2)));
+
+  // GAP #285: transform_error_t::apply discards all of it, being unconditionally noexcept.
+  static_assert(noexcept(transform_error_t::apply{}(std::declval<operand_t &>(), fnThrows)));
+
+  SUCCEED();
+}
+
 TEST_CASE("transform_error", "[transform_error][optional]")
 {
   using namespace fn;

--- a/tests/fn/transform_error.cpp
+++ b/tests/fn/transform_error.cpp
@@ -278,7 +278,7 @@ static_assert(invocable_transform_error<decltype(fn_Error_rvalue), expected<int,
 static_assert(not invocable_transform_error<decltype(fn_Error_rvalue), expected<int, Error> &>);  // cannot bind lvalue to rvalue-ref
 
 // A sum error dispatches through sum::transform - the callback must cover ALL alternatives.
-static_assert(invocable_transform_error<decltype(fn_generic<Xerror>), expected<int, sum<Error, Value>>>);
-static_assert(not invocable_transform_error<decltype(fn_Error<Xerror>), expected<int, sum<Error, Value>>>); // not exhaustive
+static_assert(invocable_transform_error<decltype(fn_generic<Xerror>), expected<int, sum_for<Error, Value>>>);
+static_assert(not invocable_transform_error<decltype(fn_Error<Xerror>), expected<int, sum_for<Error, Value>>>); // not exhaustive
 // clang-format on
 } // namespace fn

--- a/tests/fn/transform_error.cpp
+++ b/tests/fn/transform_error.cpp
@@ -16,14 +16,15 @@
 using namespace util;
 
 namespace {
+struct Xerror final {
+  std::size_t value;
+};
+
 struct Error final {
   std::string what;
 
   operator std::string_view() const { return what; }
-};
-
-struct Xerror final {
-  std::size_t value;
+  auto fn() const & -> Xerror { return {what.size()}; }
 };
 } // namespace
 
@@ -79,6 +80,13 @@ TEST_CASE("transform_error", "[transform_error][expected]")
         static_assert(std::is_same_v<T, fn::expected<int, Xerror>>);
         REQUIRE((a | transform_error(fnXerror)).error().value == 8);
       }
+
+      SECTION("member function")
+      {
+        using T = decltype(a | transform_error(&Error::fn));
+        static_assert(std::is_same_v<T, fn::expected<int, Xerror>>);
+        REQUIRE((a | transform_error(&Error::fn)).error().value == 8);
+      }
     }
   }
 
@@ -105,6 +113,13 @@ TEST_CASE("transform_error", "[transform_error][expected]")
         using T = decltype(operand_t{::fn::unexpect, Error{"Not good"}} | transform_error(fnXerror));
         static_assert(std::is_same_v<T, fn::expected<int, Xerror>>);
         REQUIRE((operand_t{::fn::unexpect, Error{"Not good"}} | transform_error(fnXerror)).error().value == 8);
+      }
+
+      SECTION("member function")
+      {
+        using T = decltype(operand_t{::fn::unexpect, Error{"Not good"}} | transform_error(&Error::fn));
+        static_assert(std::is_same_v<T, fn::expected<int, Xerror>>);
+        REQUIRE((operand_t{::fn::unexpect, Error{"Not good"}} | transform_error(&Error::fn)).error().value == 8);
       }
     }
   }
@@ -231,3 +246,39 @@ TEST_CASE("transform_error", "[transform_error][optional]")
 
   SUCCEED();
 }
+
+namespace fn {
+namespace {
+struct Error {};
+struct Xerror final : Error {};
+struct Value final {};
+
+template <typename T> constexpr auto fn_Error = [](Error) -> T { throw 0; };
+template <typename T> constexpr auto fn_generic = [](auto &&...) -> T { throw 0; };
+constexpr auto fn_Error_lvalue = [](Error &) -> Xerror { throw 0; };
+constexpr auto fn_Error_rvalue = [](Error &&) -> Xerror { throw 0; };
+} // namespace
+
+// clang-format off
+// The callback maps the error; what it returns must convert into an unexpected.
+static_assert(invocable_transform_error<decltype(fn_Error<Xerror>), expected<int, Error>>);
+static_assert(invocable_transform_error<decltype(fn_Error<Xerror>), expected<void, Error>>);      // void value is fine
+static_assert(invocable_transform_error<decltype(fn_generic<Xerror>), expected<Value, Error>>);
+static_assert(not invocable_transform_error<decltype(fn_Error<Xerror>), expected<int, Value>>);   // wrong parameter type
+// GAP #290: a void-returning callback should be rejected here, but the concept HARD-ERRORS instead
+// of yielding false - convertible_to_unexpected instantiates unexpected<void>, whose validity
+// mandate is a class-body static_assert, outside any immediate context. Contrast transform, where a
+// void return is legitimate and convertible_to_expected guards void with its own arm. No negative
+// probe is possible until #290 is fixed.
+static_assert(not invocable_transform_error<decltype(fn_generic<Xerror>), optional<int>>);        // optional has no error to map
+static_assert(not invocable_transform_error<decltype(fn_generic<Xerror>), choice<int>>);          // neither has choice
+static_assert(not invocable_transform_error<decltype(fn_Error_lvalue), expected<int, Error>>);    // cannot bind temporary to lvalue
+static_assert(invocable_transform_error<decltype(fn_Error_lvalue), expected<int, Error> &>);
+static_assert(invocable_transform_error<decltype(fn_Error_rvalue), expected<int, Error>>);
+static_assert(not invocable_transform_error<decltype(fn_Error_rvalue), expected<int, Error> &>);  // cannot bind lvalue to rvalue-ref
+
+// A sum error dispatches through sum::transform - the callback must cover ALL alternatives.
+static_assert(invocable_transform_error<decltype(fn_generic<Xerror>), expected<int, sum<Error, Value>>>);
+static_assert(not invocable_transform_error<decltype(fn_Error<Xerror>), expected<int, sum<Error, Value>>>); // not exhaustive
+// clang-format on
+} // namespace fn

--- a/tests/fn/transform_error.cpp
+++ b/tests/fn/transform_error.cpp
@@ -53,16 +53,16 @@ TEST_CASE("transform_error", "[transform_error][expected]")
   static_assert(is::not_invocable_with_any([]() -> Error { throw 0; }));                                  // bad arity
   static_assert(is::not_invocable_with_any([](int, int) -> Error { throw 0; }));                          // bad arity
 
-  WHEN("operand is lvalue")
+  SECTION("lvalue")
   {
-    WHEN("operand is value")
+    SECTION("value")
     {
       operand_t a{std::in_place, 12};
       using T = decltype(a | transform_error(wrong));
       static_assert(std::is_same_v<T, operand_t>);
       REQUIRE((a | transform_error(wrong)).value() == 12);
     }
-    WHEN("operand is error")
+    SECTION("error")
     {
       operand_t a{::fn::unexpect, Error{"Not good"}};
       using T = decltype(a | transform_error(fnError));
@@ -73,7 +73,7 @@ TEST_CASE("transform_error", "[transform_error][expected]")
                   .what
               == "Got: Not good");
 
-      WHEN("change type")
+      SECTION("change type")
       {
         using T = decltype(a | transform_error(fnXerror));
         static_assert(std::is_same_v<T, fn::expected<int, Xerror>>);
@@ -82,15 +82,15 @@ TEST_CASE("transform_error", "[transform_error][expected]")
     }
   }
 
-  WHEN("operand is rvalue")
+  SECTION("rvalue")
   {
-    WHEN("operand is value")
+    SECTION("value")
     {
       using T = decltype(operand_t{std::in_place, 12} | transform_error(wrong));
       static_assert(std::is_same_v<T, operand_t>);
       REQUIRE((operand_t{std::in_place, 12} | transform_error(wrong)).value() == 12);
     }
-    WHEN("operand is error")
+    SECTION("error")
     {
       using T = decltype(operand_t{::fn::unexpect, Error{"Not good"}} | transform_error(fnError));
       static_assert(std::is_same_v<T, operand_t>);
@@ -100,11 +100,89 @@ TEST_CASE("transform_error", "[transform_error][expected]")
                   .what
               == "Got: Not good");
 
-      WHEN("change type")
+      SECTION("change type")
       {
         using T = decltype(operand_t{::fn::unexpect, Error{"Not good"}} | transform_error(fnXerror));
         static_assert(std::is_same_v<T, fn::expected<int, Xerror>>);
         REQUIRE((operand_t{::fn::unexpect, Error{"Not good"}} | transform_error(fnXerror)).error().value == 8);
+      }
+    }
+  }
+
+  SECTION("constexpr")
+  {
+    enum class Error { ThresholdExceeded, SomethingElse, Unknown };
+    using T = fn::expected<int, Error>;
+
+    SECTION("same error type")
+    {
+      constexpr auto fn = [](Error e) constexpr noexcept -> Error {
+        if (e == Error::ThresholdExceeded)
+          return e;
+        return Error::SomethingElse;
+      };
+      constexpr auto r1 = T{0} | fn::transform_error(fn);
+      static_assert(r1.value() == 0);
+      constexpr auto r2 = T{::fn::unexpect, Error::ThresholdExceeded} | fn::transform_error(fn);
+      static_assert(r2.error() == Error::ThresholdExceeded);
+      constexpr auto r3 = T{::fn::unexpect, Error::SomethingElse} | fn::transform_error(fn);
+      static_assert(r3.error() == Error::SomethingElse);
+      constexpr auto r4 = T{::fn::unexpect, Error::Unknown} | fn::transform_error(fn);
+      static_assert(r4.error() == Error::SomethingElse);
+
+      SUCCEED();
+    }
+
+    SECTION("different error type")
+    {
+      struct UnrecoverableError final {
+        constexpr UnrecoverableError() {}
+        constexpr bool operator==(UnrecoverableError const &) const noexcept = default;
+      };
+      constexpr auto fn = [](Error) constexpr noexcept -> UnrecoverableError { return {}; };
+      constexpr auto r1 = T{0} | fn::transform_error(fn);
+      static_assert(std::is_same_v<decltype(r1), fn::expected<int, UnrecoverableError> const>);
+      static_assert(r1.value() == 0);
+      constexpr auto r2 = T{::fn::unexpect, Error::ThresholdExceeded} | fn::transform_error(fn);
+      static_assert(r2.error() == UnrecoverableError{});
+      constexpr auto r3 = T{::fn::unexpect, Error::SomethingElse} | fn::transform_error(fn);
+      static_assert(r3.error() == UnrecoverableError{});
+
+      SUCCEED();
+    }
+
+    SECTION("sum")
+    {
+      using T = fn::expected<int, fn::sum_for<Error, bool>>;
+
+      SECTION("same error type")
+      {
+        constexpr auto fn = fn::overload{[](bool i) constexpr noexcept -> fn::sum_for<Error, bool> { return not i; },
+                                         [](Error v) constexpr noexcept -> fn::sum_for<Error, bool> { return v; }};
+        constexpr auto r1 = T{::fn::unexpect, fn::sum{Error::SomethingElse}} | fn::transform_error(fn);
+        static_assert(std::is_same_v<decltype(r1), fn::expected<int, fn::sum_for<Error, bool>> const>);
+        static_assert(r1.error() == fn::sum{Error::SomethingElse});
+        constexpr auto r2 = T{::fn::unexpect, fn::sum{true}} | fn::transform_error(fn);
+        static_assert(r2.error() == fn::sum{false});
+        constexpr auto r3 = T{42} | fn::transform_error(fn);
+        static_assert(r3.value() == 42);
+
+        SUCCEED();
+      }
+
+      SECTION("different error type")
+      {
+        constexpr auto fn = fn::overload{[](bool i) constexpr noexcept -> bool { return not i; },
+                                         [](Error v) constexpr noexcept -> int { return static_cast<int>(v) + 1; }};
+        constexpr auto r1 = T{::fn::unexpect, fn::sum{Error::SomethingElse}} | fn::transform_error(fn);
+        static_assert(std::is_same_v<decltype(r1), fn::expected<int, fn::sum<bool, int>> const>);
+        static_assert(r1.error() == fn::sum{2});
+        constexpr auto r2 = T{::fn::unexpect, fn::sum{true}} | fn::transform_error(fn);
+        static_assert(r2.error() == fn::sum{false});
+        constexpr auto r3 = T{42} | fn::transform_error(fn);
+        static_assert(r3.value() == 42);
+
+        SUCCEED();
       }
     }
   }
@@ -150,79 +228,6 @@ TEST_CASE("transform_error", "[transform_error][optional]")
   // That's all testing needed. Cannot use tranform_error with optional, since
   // there is no error type to operate on
   static_assert(not monadic_invocable<transform_error_t, operand_t, decltype(fnError)>);
-}
-
-TEST_CASE("constexpr transform_error expected", "[transform_error][constexpr][expected]")
-{
-  enum class Error { ThresholdExceeded, SomethingElse, Unknown };
-  using T = fn::expected<int, Error>;
-
-  WHEN("same error type")
-  {
-    constexpr auto fn = [](Error e) constexpr noexcept -> Error {
-      if (e == Error::ThresholdExceeded)
-        return e;
-      return Error::SomethingElse;
-    };
-    constexpr auto r1 = T{0} | fn::transform_error(fn);
-    static_assert(r1.value() == 0);
-    constexpr auto r2 = T{::fn::unexpect, Error::ThresholdExceeded} | fn::transform_error(fn);
-    static_assert(r2.error() == Error::ThresholdExceeded);
-    constexpr auto r3 = T{::fn::unexpect, Error::SomethingElse} | fn::transform_error(fn);
-    static_assert(r3.error() == Error::SomethingElse);
-    constexpr auto r4 = T{::fn::unexpect, Error::Unknown} | fn::transform_error(fn);
-    static_assert(r4.error() == Error::SomethingElse);
-  }
-
-  WHEN("different error type")
-  {
-    struct UnrecoverableError final {
-      constexpr UnrecoverableError() {}
-      constexpr bool operator==(UnrecoverableError const &) const noexcept = default;
-    };
-    constexpr auto fn = [](Error) constexpr noexcept -> UnrecoverableError { return {}; };
-    constexpr auto r1 = T{0} | fn::transform_error(fn);
-    static_assert(std::is_same_v<decltype(r1), fn::expected<int, UnrecoverableError> const>);
-    static_assert(r1.value() == 0);
-    constexpr auto r2 = T{::fn::unexpect, Error::ThresholdExceeded} | fn::transform_error(fn);
-    static_assert(r2.error() == UnrecoverableError{});
-    constexpr auto r3 = T{::fn::unexpect, Error::SomethingElse} | fn::transform_error(fn);
-    static_assert(r3.error() == UnrecoverableError{});
-  }
-
-  SUCCEED();
-}
-
-TEST_CASE("constexpr transform_error expected with sum", "[transform_error][constexpr][expected][sum]")
-{
-  enum class Error { ThresholdExceeded, SomethingElse };
-  using T = fn::expected<int, fn::sum_for<Error, bool>>;
-
-  WHEN("same value type")
-  {
-    constexpr auto fn = fn::overload{[](bool i) constexpr noexcept -> fn::sum_for<Error, bool> { return not i; },
-                                     [](Error v) constexpr noexcept -> fn::sum_for<Error, bool> { return v; }};
-    constexpr auto r1 = T{::fn::unexpect, fn::sum{Error::SomethingElse}} | fn::transform_error(fn);
-    static_assert(std::is_same_v<decltype(r1), fn::expected<int, fn::sum_for<Error, bool>> const>);
-    static_assert(r1.error() == fn::sum{Error::SomethingElse});
-    constexpr auto r2 = T{::fn::unexpect, fn::sum{true}} | fn::transform_error(fn);
-    static_assert(r2.error() == fn::sum{false});
-    constexpr auto r3 = T{42} | fn::transform_error(fn);
-    static_assert(r3.value() == 42);
-  }
-
-  WHEN("different value type")
-  {
-    constexpr auto fn = fn::overload{[](bool i) constexpr noexcept -> bool { return not i; },
-                                     [](Error v) constexpr noexcept -> int { return static_cast<int>(v) + 1; }};
-    constexpr auto r1 = T{::fn::unexpect, fn::sum{Error::SomethingElse}} | fn::transform_error(fn);
-    static_assert(std::is_same_v<decltype(r1), fn::expected<int, fn::sum<bool, int>> const>);
-    static_assert(r1.error() == fn::sum{2});
-    constexpr auto r2 = T{::fn::unexpect, fn::sum{true}} | fn::transform_error(fn);
-    static_assert(r2.error() == fn::sum{false});
-    constexpr auto r3 = T{42} | fn::transform_error(fn);
-    static_assert(r3.value() == 42);
-  }
 
   SUCCEED();
 }

--- a/tests/fn/utility.cpp
+++ b/tests/fn/utility.cpp
@@ -149,7 +149,7 @@ TEST_CASE("overload", "[overload]")
 
 TEST_CASE("make lift", "[make]")
 {
-  WHEN("aggregate constructor")
+  SECTION("aggregate constructor")
   {
     constexpr auto a = fn::make<std::array<int, 2>>(3, 5);
     static_assert(std::is_same_v<decltype(a), std::array<int, 2> const>);
@@ -160,7 +160,7 @@ TEST_CASE("make lift", "[make]")
     CHECK(b[1] == 5);
   }
 
-  WHEN("aggregate class")
+  SECTION("aggregate class")
   {
     constexpr auto a = fn::make<Agg>(12);
     static_assert(std::is_same_v<decltype(a), Agg const>);
@@ -169,7 +169,7 @@ TEST_CASE("make lift", "[make]")
     CHECK(fn::make<Agg>(12).i == 12);
   }
 
-  WHEN("paren fallback")
+  SECTION("paren fallback")
   {
     // The second overload takes over only where the first is not viable, which is the one thing the
     // pair of them is for - and ParenOnly is the case that separates them.
@@ -184,7 +184,7 @@ TEST_CASE("make lift", "[make]")
     CHECK(fn::make<ParenOnly>(1).i == 1);
   }
 
-  WHEN("constraints")
+  SECTION("constraints")
   {
     static_assert(can_make<Agg, int>);
     static_assert(not can_make<Agg, char const *>); // not constructible from it

--- a/tests/fn/utility.cpp
+++ b/tests/fn/utility.cpp
@@ -7,13 +7,12 @@
 
 #include <catch2/catch_all.hpp>
 
-#include "util/static_check.hpp"
-
+#include <array>
 #include <concepts>
+#include <initializer_list>
+#include <string>
 #include <type_traits>
 #include <utility>
-
-using namespace util;
 
 namespace fn {
 // clang-format off
@@ -73,25 +72,61 @@ static_assert(std::is_same_v<decltype(apply_const_lvalue<float const &&>(std::de
 // clang-format on
 } // namespace fn
 
+namespace {
+
+struct Agg final {
+  int const i;
+};
+
+// Braces prefer an initializer_list constructor, so deleting it makes P unbraceable while leaving
+// P(int) reachable through parentheses - which is precisely the case make's second overload exists
+// for, and the only way to select it.
+struct ParenOnly final {
+  int i;
+
+  constexpr ParenOnly(int v) noexcept : i(v) {}
+  ParenOnly(std::initializer_list<int>) = delete;
+};
+
+// Type-keyed, and so dependent: a requires-expression written directly against a concrete type is a
+// hard error when the requirement is invalid, rather than the false one wants.
+template <typename T, typename... Args>
+concept can_brace = requires(Args... args) { T{args...}; };
+template <typename T, typename... Args>
+concept can_paren = requires(Args... args) { T(args...); };
+template <typename T, typename... Args>
+concept can_make = requires(Args... args) { fn::make<T>(args...); };
+
+} // namespace
+
 TEST_CASE("overload", "[overload]")
 {
-  using is = static_check::bind<decltype([](auto &&fn) constexpr {
+  constexpr auto can_call = [](auto &&fn) constexpr {
     return requires {
       fn();
       fn(1);
     };
-  })>;
+  };
 
   // example use
-  static_assert(is::invocable(fn::overload{[](auto...) {}}));       // generic
-  static_assert(is::invocable(fn::overload{[]() {}, [](auto) {}})); // generic with fixed arity
-  static_assert(is::invocable(fn::overload{[]() {}, [](int) {}}));  // fixed type
-  static_assert(is::invocable(fn::overload{[]() {}, [](bool) {}})); // built-in conversion
-  static_assert(is::invocable(
+  static_assert(can_call(fn::overload{[](auto...) {}}));       // generic
+  static_assert(can_call(fn::overload{[]() {}, [](auto) {}})); // generic with fixed arity
+  static_assert(can_call(fn::overload{[]() {}, [](int) {}}));  // fixed type
+  static_assert(can_call(fn::overload{[]() {}, [](bool) {}})); // built-in conversion
+  static_assert(can_call(
       fn::overload{[]() -> void {}, [](int i) -> std::string { return std::to_string(i); }})); // different return types
 
-  static_assert(is::not_invocable(fn::overload{[]() {}}));    // missing int overload
-  static_assert(is::not_invocable(fn::overload{[](int) {}})); // missing void overload
+  static_assert(not can_call(fn::overload{[]() {}}));    // missing int overload
+  static_assert(not can_call(fn::overload{[](int) {}})); // missing void overload
+
+  // noexcept follows the alternative that overload resolution actually picks, rather than being
+  // flattened across them - the accuracy the verbs and sum do not manage
+  constexpr auto mixed = fn::overload{[](int) noexcept -> int { return 1; }, //
+                                      [](double) -> int { return 2; }};
+  static_assert(noexcept(mixed(1)));
+  static_assert(not noexcept(mixed(1.5)));
+  CHECK(mixed(1) == 1);
+  CHECK(mixed(1.5) == 2);
 
   struct A {
     constexpr auto operator()(int i) const noexcept -> int { return i + 1; }
@@ -112,22 +147,54 @@ TEST_CASE("overload", "[overload]")
   static_assert(fn::overload{A{}}(3) == 4);
 }
 
-TEST_CASE("make lift")
+TEST_CASE("make lift", "[make]")
 {
   WHEN("aggregate constructor")
   {
     constexpr auto a = fn::make<std::array<int, 2>>(3, 5);
     static_assert(std::is_same_v<decltype(a), std::array<int, 2> const>);
     static_assert(a[0] == 3 && a[1] == 5);
+
+    auto const b = fn::make<std::array<int, 2>>(3, 5); // runtime twin
+    CHECK(b[0] == 3);
+    CHECK(b[1] == 5);
   }
 
   WHEN("aggregate class")
   {
-    struct A {
-      int const i;
-    };
-    constexpr auto a = fn::make<A>(12);
-    static_assert(std::is_same_v<decltype(a), A const>);
+    constexpr auto a = fn::make<Agg>(12);
+    static_assert(std::is_same_v<decltype(a), Agg const>);
     static_assert(a.i == 12);
+
+    CHECK(fn::make<Agg>(12).i == 12);
+  }
+
+  WHEN("paren fallback")
+  {
+    // The second overload takes over only where the first is not viable, which is the one thing the
+    // pair of them is for - and ParenOnly is the case that separates them.
+    static_assert(not can_brace<ParenOnly, int>);
+    static_assert(can_paren<ParenOnly, int>);
+    static_assert(can_make<ParenOnly, int>);
+
+    constexpr auto p = fn::make<ParenOnly>(1);
+    static_assert(std::is_same_v<decltype(p), ParenOnly const>);
+    static_assert(p.i == 1);
+
+    CHECK(fn::make<ParenOnly>(1).i == 1);
+  }
+
+  WHEN("constraints")
+  {
+    static_assert(can_make<Agg, int>);
+    static_assert(not can_make<Agg, char const *>); // not constructible from it
+    static_assert(not can_make<Agg, int, int>);     // too many initialisers
+
+    // make carries no noexcept specifier, so it reports potentially-throwing even where the
+    // construction cannot throw - the same converse accuracy gap as the as_sum and as_pack lifts.
+    static_assert(std::is_nothrow_constructible_v<Agg, int>);
+    static_assert(not noexcept(fn::make<Agg>(12)));
+
+    SUCCEED();
   }
 }

--- a/tests/fn/utility.cpp
+++ b/tests/fn/utility.cpp
@@ -192,8 +192,10 @@ TEST_CASE("make lift", "[make]")
 
     // make carries no noexcept specifier, so it reports potentially-throwing even where the
     // construction cannot throw - the same converse accuracy gap as the as_sum and as_pack lifts.
-    static_assert(std::is_nothrow_constructible_v<Agg, int>);
-    static_assert(not noexcept(fn::make<Agg>(12)));
+    static_assert(std::is_nothrow_constructible_v<int, int>);
+    static_assert(not noexcept(fn::make<int>(12))); // brace overload
+    static_assert(std::is_nothrow_constructible_v<ParenOnly, int>);
+    static_assert(not noexcept(fn::make<ParenOnly>(1))); // paren fallback overload
 
     SUCCEED();
   }

--- a/tests/fn/value_or.cpp
+++ b/tests/fn/value_or.cpp
@@ -26,16 +26,16 @@ TEST_CASE("value_or", "[value_or][expected][expected_value]")
   using namespace fn;
 
   using operand_t = fn::expected<int, Error>;
-  WHEN("operand is lvalue")
+  SECTION("lvalue")
   {
-    WHEN("operand is value")
+    SECTION("value")
     {
       operand_t a{std::in_place, 12};
       using T = decltype(a | value_or(3));
       static_assert(std::is_same_v<T, operand_t>);
       REQUIRE((a | value_or(3)).value() == 12);
     }
-    WHEN("operand is error")
+    SECTION("error")
     {
       operand_t a{::fn::unexpect, Error{"Not good"}};
       using T = decltype(a | value_or(3));
@@ -44,15 +44,15 @@ TEST_CASE("value_or", "[value_or][expected][expected_value]")
     }
   }
 
-  WHEN("operand is rvalue")
+  SECTION("rvalue")
   {
-    WHEN("operand is value")
+    SECTION("value")
     {
       using T = decltype(operand_t{std::in_place, 12} | value_or(3));
       static_assert(std::is_same_v<T, operand_t>);
       REQUIRE((operand_t{std::in_place, 12} | value_or(3)).value() == 12);
     }
-    WHEN("operand is error")
+    SECTION("error")
     {
       using T = decltype(operand_t{::fn::unexpect, Error{"Not good"}} | value_or(3));
       static_assert(std::is_same_v<T, operand_t>);
@@ -60,27 +60,40 @@ TEST_CASE("value_or", "[value_or][expected][expected_value]")
     }
   }
 
-  WHEN("move only argument")
+  SECTION("move-only")
   {
     using operand_t = fn::expected<helper_move_only, Error>;
-    WHEN("pass multiple constructor arguments")
+    SECTION("multiple ctor args")
     {
-      WHEN("operand is value")
+      SECTION("value")
       {
         operand_t a{std::in_place, 2, 3};
         REQUIRE((std::move(a) | value_or(3, 5)).value().v == 2 * 3 * from_rval);
       }
-      WHEN("operand is error")
+      SECTION("error")
       {
         operand_t a{::fn::unexpect, Error{"Not good"}};
         REQUIRE((std::move(a) | value_or(3, 5)).value().v == 3 * 5);
       }
     }
-    WHEN("use move ctor")
+    SECTION("move ctor")
     {
       operand_t a{::fn::unexpect, Error{"Not good"}};
       REQUIRE((std::move(a) | value_or(helper_move_only{3, 7})).value().v == 21 * from_rval * from_rval);
     }
+  }
+
+  SECTION("constexpr")
+  {
+    enum class Error { ThresholdExceeded, SomethingElse };
+    using T = fn::expected<int, Error>;
+
+    constexpr auto r1 = T{2} | fn::value_or(3);
+    static_assert(r1.value() == 2);
+    constexpr auto r2 = T{::fn::unexpect, Error::SomethingElse} | fn::value_or(3);
+    static_assert(r2.value() == 3);
+
+    SUCCEED();
   }
 }
 
@@ -90,16 +103,16 @@ TEST_CASE("value_or", "[value_or][optional]")
 
   using operand_t = fn::optional<int>;
 
-  WHEN("operand is lvalue")
+  SECTION("lvalue")
   {
-    WHEN("operand is value")
+    SECTION("value")
     {
       operand_t a{12};
       using T = decltype(a | value_or(3));
       static_assert(std::is_same_v<T, operand_t>);
       REQUIRE((a | value_or(3)).value() == 12);
     }
-    WHEN("operand is error")
+    SECTION("error")
     {
       operand_t a{std::nullopt};
       using T = decltype(a | value_or(3));
@@ -108,15 +121,15 @@ TEST_CASE("value_or", "[value_or][optional]")
     }
   }
 
-  WHEN("operand is rvalue")
+  SECTION("rvalue")
   {
-    WHEN("operand is value")
+    SECTION("value")
     {
       using T = decltype(operand_t{12} | value_or(3));
       static_assert(std::is_same_v<T, operand_t>);
       REQUIRE((operand_t{12} | value_or(3)).value() == 12);
     }
-    WHEN("operand is error")
+    SECTION("error")
     {
       using T = decltype(operand_t{std::nullopt} | value_or(3));
       static_assert(std::is_same_v<T, operand_t>);
@@ -124,11 +137,22 @@ TEST_CASE("value_or", "[value_or][optional]")
     }
   }
 
-  WHEN("move only argument")
+  SECTION("move-only")
   {
     using operand_t = fn::optional<helper_move_only>;
     operand_t a{std::nullopt};
     REQUIRE((std::move(a) | value_or(helper_move_only{5, 7})).value().v == 35 * from_rval * from_rval);
+  }
+
+  SECTION("constexpr")
+  {
+    using T = fn::optional<int>;
+    constexpr auto r1 = T{0} | fn::value_or(3);
+    static_assert(r1.value() == 0);
+    constexpr auto r2 = T{} | fn::value_or(3);
+    static_assert(r2.value() == 3);
+
+    SUCCEED();
   }
 }
 
@@ -146,30 +170,6 @@ TEST_CASE("value_or noexcept", "[value_or][noexcept]")
   // Where the fallback cannot throw to build, the promise happens to be right.
   static_assert(std::is_nothrow_constructible_v<int, int>);
   static_assert(noexcept(value_or_t::apply{}(std::declval<fn::expected<int, Error> &>(), 42)));
-
-  SUCCEED();
-}
-
-TEST_CASE("constexpr value_or expected", "[value_or][constexpr][expected]")
-{
-  enum class Error { ThresholdExceeded, SomethingElse };
-  using T = fn::expected<int, Error>;
-
-  constexpr auto r1 = T{2} | fn::value_or(3);
-  static_assert(r1.value() == 2);
-  constexpr auto r2 = T{::fn::unexpect, Error::SomethingElse} | fn::value_or(3);
-  static_assert(r2.value() == 3);
-
-  SUCCEED();
-}
-
-TEST_CASE("constexpr value_or optional", "[value_or][constexpr][optional]")
-{
-  using T = fn::optional<int>;
-  constexpr auto r1 = T{0} | fn::value_or(3);
-  static_assert(r1.value() == 0);
-  constexpr auto r2 = T{} | fn::value_or(3);
-  static_assert(r2.value() == 3);
 
   SUCCEED();
 }

--- a/tests/fn/value_or.cpp
+++ b/tests/fn/value_or.cpp
@@ -173,3 +173,24 @@ TEST_CASE("value_or noexcept", "[value_or][noexcept]")
 
   SUCCEED();
 }
+
+namespace fn {
+namespace {
+struct Error {};
+struct Value final {};
+} // namespace
+
+// clang-format off
+// Not a callable verb: the arguments must construct the operand's own value type.
+static_assert(invocable_value_or<expected<int, Error>, int>);
+static_assert(invocable_value_or<expected<int, Error>, unsigned>);                 // conversion is enough
+static_assert(invocable_value_or<expected<helper_move_only, Error>, int, int>);    // multi-argument construction
+static_assert(not invocable_value_or<expected<int, Error>, char const *>);         // no conversion found
+static_assert(not invocable_value_or<expected<int, Error>, int, int>);             // too many initialisers
+static_assert(not invocable_value_or<expected<Value, Error>, int>);                // wrong type
+static_assert(not invocable_value_or<expected<void, Error>, int>);                 // void has no value to fall back to
+static_assert(invocable_value_or<optional<int>, int>);
+static_assert(not invocable_value_or<optional<int>, char const *>);
+static_assert(not invocable_value_or<choice<int>, int>);                           // no choice disjunct
+// clang-format on
+} // namespace fn

--- a/tests/fn/value_or.cpp
+++ b/tests/fn/value_or.cpp
@@ -132,6 +132,24 @@ TEST_CASE("value_or", "[value_or][optional]")
   }
 }
 
+TEST_CASE("value_or noexcept", "[value_or][noexcept]")
+{
+  using namespace fn;
+
+  // value_or takes no callback, but its apply still builds the fallback value from the arguments -
+  // inside a lambda it hands to or_else - and that construction can throw: making a std::string from
+  // a literal allocates. GAP #285: the apply is unconditionally noexcept regardless.
+  static_assert(not std::is_nothrow_constructible_v<std::string, char const *>);
+  static_assert(noexcept(value_or_t::apply{}(std::declval<fn::expected<std::string, Error> &>(), "abc")));
+  static_assert(noexcept(value_or_t::apply{}(std::declval<fn::optional<std::string> &>(), "abc")));
+
+  // Where the fallback cannot throw to build, the promise happens to be right.
+  static_assert(std::is_nothrow_constructible_v<int, int>);
+  static_assert(noexcept(value_or_t::apply{}(std::declval<fn::expected<int, Error> &>(), 42)));
+
+  SUCCEED();
+}
+
 TEST_CASE("constexpr value_or expected", "[value_or][constexpr][expected]")
 {
   enum class Error { ThresholdExceeded, SomethingElse };

--- a/tests/pfn/expected.cpp
+++ b/tests/pfn/expected.cpp
@@ -1097,7 +1097,7 @@ TEST_CASE("expected non void", "[expected][polyfill]")
 
     SECTION("non-trivial both")
     {
-      using T = expected<helper, helper_t<1>>;
+      using T = expected<helper, helper_t<prop::throw_value>>;
       static_assert(std::is_copy_constructible_v<T>);
       static_assert(not std::is_trivially_copy_constructible_v<T>);
       static_assert(not extension || std::is_nothrow_copy_constructible_v<T>);
@@ -1272,11 +1272,13 @@ TEST_CASE("expected non void", "[expected][polyfill]")
 
   SECTION("assignment")
   {
-    using M = helper_t<2>;  // nothrow move constructible
-    using E = helper_t<3>;  // may throw on move and copy
-    using C = helper_t<4>;  // nothrow copy constructible
-    using G = helper_t<33>; // nothrow copy constructible; throwing move constructible
-    using H = helper_t<40>; // nothrow copy/move constructible; throwing copy/move assignable
+    using M = helper_t<prop::throw_copy | prop::throw_value>;                    // nothrow move constructible
+    using E = helper_t<prop::throw_copy | prop::throw_move | prop::throw_value>; // may throw on move and copy
+    using C = helper_t<prop::throw_move | prop::throw_value>;                    // nothrow copy constructible
+    using G
+        = helper_t<prop::throw_move | prop::runtime_move>; // nothrow copy constructible; throwing move constructible
+    using H = helper_t<prop::throw_copy_assign
+                       | prop::throw_move_assign>; // nothrow copy/move constructible; throwing copy/move assignable
     static_assert(not std::is_nothrow_copy_constructible_v<M>);
     static_assert(std::is_nothrow_move_constructible_v<M>);
     static_assert(not std::is_nothrow_copy_constructible_v<E>);
@@ -2340,7 +2342,7 @@ TEST_CASE("expected non void", "[expected][polyfill]")
 
   SECTION("emplace")
   {
-    using T = expected<helper_t<8>, Error>;
+    using T = expected<helper_t<prop::regular>, Error>;
     SECTION("value to value")
     {
       {
@@ -2374,14 +2376,14 @@ TEST_CASE("expected non void", "[expected][polyfill]")
     SECTION("move-only value type")
     {
       // emplace constructs in place, so it needs neither copy nor move of the value.
-      expected<helper_move_only_t<8>, Error> a(unexpect, Error::file_not_found);
+      expected<helper_move_only_t<prop::regular>, Error> a(unexpect, Error::file_not_found);
       a.emplace(7);
       CHECK(a.value().v == 7);
     }
 
     SECTION("immovable value type")
     {
-      expected<helper_immovable_t<8>, Error> a(unexpect, Error::unknown);
+      expected<helper_immovable_t<prop::regular>, Error> a(unexpect, Error::unknown);
       a.emplace(6, 7);
       CHECK(a.value().v == 6 * 7);
     }
@@ -2697,7 +2699,7 @@ TEST_CASE("expected non void", "[expected][polyfill]")
 
     SECTION("swap error/value")
     {
-      using T = expected<helper, helper_t<1>>;
+      using T = expected<helper, helper_t<prop::throw_value>>;
       T a(unexpect, 19);
       T b(27);
       swap(a, b);
@@ -2709,7 +2711,7 @@ TEST_CASE("expected non void", "[expected][polyfill]")
     {
       SECTION("nothrow")
       {
-        using T = expected<helper, helper_t<1>>;
+        using T = expected<helper, helper_t<prop::throw_value>>;
         T a(17);
         T b(unexpect, 29);
         swap(a, b);
@@ -2717,11 +2719,11 @@ TEST_CASE("expected non void", "[expected][polyfill]")
         CHECK(b.value().v == 17 * from_rval);
       }
 
-      static_assert(not std::is_nothrow_move_constructible_v<helper_t<33>>);
-      static_assert(std::is_nothrow_move_constructible_v<helper_t<30>>);
+      static_assert(not std::is_nothrow_move_constructible_v<helper_t<prop::throw_move | prop::runtime_move>>);
+      static_assert(std::is_nothrow_move_constructible_v<helper_t<prop::runtime_move>>);
       SECTION("nothrow error")
       {
-        using T = expected<helper_t<33>, helper_t<30>>;
+        using T = expected<helper_t<prop::throw_move | prop::runtime_move>, helper_t<prop::runtime_move>>;
         SECTION("happy path")
         {
           T a(13);
@@ -2747,7 +2749,7 @@ TEST_CASE("expected non void", "[expected][polyfill]")
 
       SECTION("nothrow value")
       {
-        using T = expected<helper_t<30>, helper_t<33>>;
+        using T = expected<helper_t<prop::runtime_move>, helper_t<prop::throw_move | prop::runtime_move>>;
         SECTION("happy path")
         {
           T a(7);
@@ -3000,7 +3002,7 @@ TEST_CASE("expected non void", "[expected][polyfill]")
       SECTION("noexcept extension")
       {
         {
-          using T = expected<helper_t<2>, Error>;
+          using T = expected<helper_t<prop::throw_copy | prop::throw_value>, Error>;
           static_assert(not std::is_nothrow_copy_constructible_v<T::value_type>);
           static_assert(std::is_nothrow_move_constructible_v<T::value_type>);
           static_assert(not std::is_nothrow_convertible_v<int, T::value_type>);
@@ -3013,7 +3015,7 @@ TEST_CASE("expected non void", "[expected][polyfill]")
         }
 
         {
-          using T = expected<helper_t<4>, Error>;
+          using T = expected<helper_t<prop::throw_move | prop::throw_value>, Error>;
           static_assert(std::is_nothrow_copy_constructible_v<T::value_type>);
           static_assert(not std::is_nothrow_move_constructible_v<T::value_type>);
           static_assert(not std::is_nothrow_convertible_v<int, T::value_type>);
@@ -3101,7 +3103,7 @@ TEST_CASE("expected non void", "[expected][polyfill]")
       SECTION("noexcept extension")
       {
         {
-          using T = expected<int, helper_t<2>>;
+          using T = expected<int, helper_t<prop::throw_copy | prop::throw_value>>;
           static_assert(not std::is_nothrow_copy_constructible_v<T::error_type>);
           static_assert(std::is_nothrow_move_constructible_v<T::error_type>);
           static_assert(not std::is_nothrow_convertible_v<int, T::error_type>);
@@ -3114,7 +3116,7 @@ TEST_CASE("expected non void", "[expected][polyfill]")
         }
 
         {
-          using T = expected<int, helper_t<4>>;
+          using T = expected<int, helper_t<prop::throw_move | prop::throw_value>>;
           static_assert(std::is_nothrow_copy_constructible_v<T::error_type>);
           static_assert(not std::is_nothrow_move_constructible_v<T::error_type>);
           static_assert(not std::is_nothrow_convertible_v<int, T::error_type>);
@@ -4194,11 +4196,13 @@ TEST_CASE("expected void", "[expected_void][polyfill]")
 
   SECTION("assignment")
   {
-    using M = helper_t<2>;  // nothrow move constructible
-    using E = helper_t<3>;  // may throw on move and copy
-    using C = helper_t<4>;  // nothrow copy constructible
-    using G = helper_t<33>; // nothrow copy constructible; throwing move constructible
-    using H = helper_t<40>; // nothrow copy/move constructible; throwing copy/move assignable
+    using M = helper_t<prop::throw_copy | prop::throw_value>;                    // nothrow move constructible
+    using E = helper_t<prop::throw_copy | prop::throw_move | prop::throw_value>; // may throw on move and copy
+    using C = helper_t<prop::throw_move | prop::throw_value>;                    // nothrow copy constructible
+    using G
+        = helper_t<prop::throw_move | prop::runtime_move>; // nothrow copy constructible; throwing move constructible
+    using H = helper_t<prop::throw_copy_assign
+                       | prop::throw_move_assign>; // nothrow copy/move constructible; throwing copy/move assignable
     static_assert(not std::is_nothrow_copy_constructible_v<M>);
     static_assert(std::is_nothrow_move_constructible_v<M>);
     static_assert(not std::is_nothrow_copy_constructible_v<E>);
@@ -5045,7 +5049,7 @@ TEST_CASE("expected void", "[expected_void][polyfill]")
 
     SECTION("swap error/value")
     {
-      using T = expected<void, helper_t<1>>;
+      using T = expected<void, helper_t<prop::throw_value>>;
       T a(unexpect, 19);
       T b;
       swap(a, b);
@@ -5061,7 +5065,7 @@ TEST_CASE("expected void", "[expected_void][polyfill]")
     {
       SECTION("nothrow")
       {
-        using T = expected<void, helper_t<1>>;
+        using T = expected<void, helper_t<prop::throw_value>>;
         T a;
         T b(unexpect, 29);
         swap(a, b);
@@ -5073,12 +5077,12 @@ TEST_CASE("expected void", "[expected_void][polyfill]")
         CHECK(b.has_value());
       }
 
-      static_assert(not std::is_nothrow_move_constructible_v<helper_t<33>>);
-      static_assert(std::is_nothrow_move_constructible_v<helper_t<30>>);
+      static_assert(not std::is_nothrow_move_constructible_v<helper_t<prop::throw_move | prop::runtime_move>>);
+      static_assert(std::is_nothrow_move_constructible_v<helper_t<prop::runtime_move>>);
 
       SECTION("throw error")
       {
-        using T = expected<void, helper_t<33>>;
+        using T = expected<void, helper_t<prop::throw_move | prop::runtime_move>>;
         SECTION("happy path")
         {
           T a;
@@ -5313,7 +5317,7 @@ TEST_CASE("expected void", "[expected_void][polyfill]")
       SECTION("noexcept extension")
       {
         {
-          using T = expected<void, helper_t<2>>;
+          using T = expected<void, helper_t<prop::throw_copy | prop::throw_value>>;
           static_assert(not std::is_nothrow_copy_constructible_v<T::error_type>);
           static_assert(std::is_nothrow_move_constructible_v<T::error_type>);
           static_assert(not std::is_nothrow_convertible_v<int, T::error_type>);
@@ -5326,7 +5330,7 @@ TEST_CASE("expected void", "[expected_void][polyfill]")
         }
 
         {
-          using T = expected<void, helper_t<4>>;
+          using T = expected<void, helper_t<prop::throw_move | prop::throw_value>>;
           static_assert(std::is_nothrow_copy_constructible_v<T::error_type>);
           static_assert(not std::is_nothrow_move_constructible_v<T::error_type>);
           static_assert(not std::is_nothrow_convertible_v<int, T::error_type>);

--- a/tests/pfn/optional.cpp
+++ b/tests/pfn/optional.cpp
@@ -133,7 +133,8 @@ TEST_CASE("optional", "[optional][polyfill]")
       static_assert(std::is_constructible_v<T, std::in_place_t, int>);
       static_assert(not std::is_constructible_v<T, std::in_place_t>); // helper has no default ctor
       static_assert(not extension || not std::is_nothrow_constructible_v<T, std::in_place_t, int>);
-      static_assert(not extension || std::is_nothrow_constructible_v<optional<helper_t<8>>, std::in_place_t, int>);
+      static_assert(not extension
+                    || std::is_nothrow_constructible_v<optional<helper_t<prop::regular>>, std::in_place_t, int>);
 
       // value ctor path is witnessed by helper_t::state
       int const s0 = helper::state;
@@ -283,8 +284,8 @@ TEST_CASE("optional", "[optional][polyfill]")
       (void)b;
       (void)c;
 
-      // move of the engaged state is witnessed via helper_t<30>::state
-      using H = helper_t<30>;
+      // move of the engaged state is witnessed via helper_t<prop::runtime_move>::state
+      using H = helper_t<prop::runtime_move>;
       static_assert(not std::is_trivially_move_constructible_v<optional<H>>);
       int const s0 = H::state;
       optional<H> d(std::in_place, 7); // value ctor: state += 7
@@ -294,7 +295,7 @@ TEST_CASE("optional", "[optional][polyfill]")
 
     SECTION("noexcept(false) from value type")
     {
-      using T = optional<helper_t<2>>; // throwing copy ctor, nothrow move ctor
+      using T = optional<helper_t<prop::throw_copy>>; // throwing copy ctor, nothrow move ctor
       static_assert(std::is_copy_constructible_v<T>);
       static_assert(not std::is_trivially_copy_constructible_v<T>);
       static_assert(not std::is_nothrow_copy_constructible_v<T>);
@@ -400,10 +401,11 @@ TEST_CASE("optional", "[optional][polyfill]")
   SECTION("assignment")
   {
     // helper_t<V> fixtures used below (see helper_types.hpp for the full nothrow table)
-    using M = helper_t<2>;  // nothrow move constructible, throwing copy constructible
-    using E = helper_t<3>;  // may throw on move and copy
-    using C = helper_t<4>;  // nothrow copy constructible, throwing move constructible
-    using H = helper_t<40>; // nothrow copy/move constructible; throwing copy/move assignable
+    using M = helper_t<prop::throw_copy>;                    // nothrow move constructible, throwing copy constructible
+    using E = helper_t<prop::throw_copy | prop::throw_move>; // may throw on move and copy
+    using C = helper_t<prop::throw_move>;                    // nothrow copy constructible, throwing move constructible
+    using H = helper_t<prop::throw_copy_assign
+                       | prop::throw_move_assign>; // nothrow copy/move constructible; throwing copy/move assignable
     static_assert(not std::is_nothrow_copy_constructible_v<M>);
     static_assert(std::is_nothrow_move_constructible_v<M>);
     static_assert(not std::is_nothrow_copy_constructible_v<E>);
@@ -801,8 +803,8 @@ TEST_CASE("optional", "[optional][polyfill]")
       static_assert(not std::is_nothrow_constructible_v<helper, int>);
       static_assert(not noexcept(std::declval<T &>().emplace(1)));
 
-      static_assert(std::is_nothrow_constructible_v<helper_t<8>, int>);
-      static_assert(not extension || not noexcept(std::declval<optional<helper_t<8>> &>().emplace(1)));
+      static_assert(std::is_nothrow_constructible_v<helper_t<prop::regular>, int>);
+      static_assert(not extension || not noexcept(std::declval<optional<helper_t<prop::regular>> &>().emplace(1)));
       SUCCEED();
     }
 
@@ -969,8 +971,8 @@ TEST_CASE("optional", "[optional][polyfill]")
     SECTION("exception")
     {
       // a throwing move during the cross-state transfer: engagement states unchanged
-      using T = optional<helper_t<3>>;
-      static_assert(not std::is_nothrow_move_constructible_v<helper_t<3>>);
+      using T = optional<helper_t<prop::throw_copy | prop::throw_move>>;
+      static_assert(not std::is_nothrow_move_constructible_v<helper_t<prop::throw_copy | prop::throw_move>>);
 
       // constructed via the initializer_list ctor (no V<8 throw-check there) to get a
       // stored 0 without the value ctor itself throwing first

--- a/tests/util/helper_types.hpp
+++ b/tests/util/helper_types.hpp
@@ -51,26 +51,6 @@ constexpr prop operator&(prop a, prop b) noexcept
   return static_cast<prop>(static_cast<U>(a) & static_cast<U>(b));
 }
 
-// Transitional: map the legacy helper_t<int> selector onto flags, so unconverted call sites keep
-// compiling while their tests migrate to the named flags. Remove the int overload (and this comment)
-// once no call site instantiates a fixture with an integer.
-constexpr prop prop_of(prop p) noexcept { return p; }
-constexpr prop prop_of(int V) noexcept
-{
-  prop f = prop::regular;
-  if (V >= 2 && V < 4)
-    f = f | prop::throw_copy;
-  if ((V >= 3 && V < 5) || (V >= 33 && V < 35))
-    f = f | prop::throw_move;
-  if (V >= 40 && V < 41)
-    f = f | prop::throw_copy_assign | prop::throw_move_assign;
-  if (V < 8)
-    f = f | prop::throw_value;
-  if (V >= 30)
-    f = f | prop::runtime_move;
-  return f;
-}
-
 // Common value storage and value constructors shared by the three fixtures; the copy/move behaviour
 // (witnessed, deleted, or throwing) is layered on by the derived templates below.
 template <prop F> struct helper_value_base {
@@ -124,8 +104,7 @@ protected:
 
 // Fully copyable and movable witness. Each special member multiplies `v` by its prime and,
 // per the flags in F, may be noexcept(false) and throw on a zero result.
-template <auto Cfg> struct helper_t : helper_value_base<prop_of(Cfg)> {
-  static constexpr prop F = prop_of(Cfg);
+template <prop F> struct helper_t : helper_value_base<F> {
   using base = helper_value_base<F>;
   static constexpr bool throws_copy = (F & prop::throw_copy) != prop::regular;
   static constexpr bool throws_move = (F & prop::throw_move) != prop::regular;
@@ -147,7 +126,7 @@ template <auto Cfg> struct helper_t : helper_value_base<prop_of(Cfg)> {
   }
 
   constexpr helper_t(helper_t &&o) noexcept(not throws_move)
-    requires((prop_of(Cfg) & prop::runtime_move) == prop::regular)
+    requires((F & prop::runtime_move) == prop::regular)
       : base(typename base::raw_t{}, o.v)
   {
     v *= from_rval;
@@ -158,7 +137,7 @@ template <auto Cfg> struct helper_t : helper_value_base<prop_of(Cfg)> {
   }
 
   helper_t(helper_t &&o) noexcept(not throws_move)
-    requires((prop_of(Cfg) & prop::runtime_move) != prop::regular)
+    requires((F & prop::runtime_move) != prop::regular)
       : base(typename base::raw_t{}, o.v)
   {
     v *= from_rval;
@@ -224,8 +203,7 @@ template <auto Cfg> struct helper_t : helper_value_base<prop_of(Cfg)> {
 
 // Move-only witness: copy construction/assignment deleted, moves witnessed. runtime_move does not
 // apply (the move constructor is always constexpr, matching the fixture's only historical use).
-template <auto Cfg> struct helper_move_only_t : helper_value_base<prop_of(Cfg)> {
-  static constexpr prop F = prop_of(Cfg);
+template <prop F> struct helper_move_only_t : helper_value_base<F> {
   using base = helper_value_base<F>;
   static constexpr bool throws_move = (F & prop::throw_move) != prop::regular;
   static constexpr bool throws_move_assign = (F & prop::throw_move_assign) != prop::regular;
@@ -265,8 +243,8 @@ template <auto Cfg> struct helper_move_only_t : helper_value_base<prop_of(Cfg)> 
 };
 
 // Immovable witness: all copy/move deleted; only in-place constructible (from a value) and observable.
-template <auto Cfg> struct helper_immovable_t : helper_value_base<prop_of(Cfg)> {
-  using base = helper_value_base<prop_of(Cfg)>;
+template <prop F> struct helper_immovable_t : helper_value_base<F> {
+  using base = helper_value_base<F>;
 
   using base::base;
   using base::v;
@@ -280,7 +258,7 @@ template <auto Cfg> struct helper_immovable_t : helper_value_base<prop_of(Cfg)> 
 };
 
 // Swap multiplies each witness by its prime.
-template <auto Cfg> constexpr void swap(helper_t<Cfg> &l, helper_t<Cfg> &r)
+template <prop F> constexpr void swap(helper_t<F> &l, helper_t<F> &r)
 {
   std::swap(l.v, r.v);
   l.v *= swapped;
@@ -316,11 +294,5 @@ static_assert(not std::is_copy_constructible_v<helper_immovable>);
 static_assert(not std::is_move_constructible_v<helper_immovable>);
 static_assert(not std::is_copy_assignable_v<helper_immovable>);
 static_assert(not std::is_move_assignable_v<helper_immovable>);
-
-// Legacy shim sanity: a few representative integer selectors still map to the right behaviour.
-// Remove together with the prop_of(int) overload once no call site uses an integer selector.
-static_assert(not std::is_nothrow_copy_constructible_v<helper_t<2>>);
-static_assert(not std::is_nothrow_move_constructible_v<helper_t<3>>);
-static_assert(not std::is_nothrow_move_assignable_v<helper_t<40>>);
 
 #endif // INCLUDE_TESTS_UTIL_HELPER_TYPES

--- a/tests/util/helper_types.hpp
+++ b/tests/util/helper_types.hpp
@@ -65,9 +65,11 @@ template <prop F> struct helper_value_base {
 
   // Non-constexpr on purpose: guarantees the constructor is emitted (never folded away) so a test
   // relying on it shows up in coverage, and lets `state` witness that construction actually ran.
-  helper_value_base(std::integral auto... a) noexcept(not throws_value)
-    requires(sizeof...(a) > 0) // intentionally implicit when sizeof...(a) == 1
-      : v((1 * ... * a))
+  // First argument peeled rather than `std::integral auto...` + requires(sizeof...(a) > 0): clang 16
+  // (and AppleClang 15) crashes or mis-evaluates a constraint naming the pack once the constructor
+  // is inherited. Intentionally implicit when called with a single argument.
+  template <std::integral A0, std::integral... A>
+  helper_value_base(A0 a0, A... a) noexcept(not throws_value) : v((a0 * ... * a))
   {
     if constexpr (throws_value) {
       if (v == 0)
@@ -78,9 +80,8 @@ template <prop F> struct helper_value_base {
 
   helper_value_base(helper_list_t list) noexcept : v(init(list)) { state += v; }
 
-  constexpr helper_value_base(helper_list_t list, std::integral auto... a) noexcept
-    requires(sizeof...(a) > 0)
-      : v(init(list, a...)) //
+  template <std::integral A0, std::integral... A>
+  constexpr helper_value_base(helper_list_t list, A0 a0, A... a) noexcept : v(init(list, a0, a...))
   {
   }
 

--- a/tests/util/helper_types.hpp
+++ b/tests/util/helper_types.hpp
@@ -3,6 +3,9 @@
 // Distributed under the ISC License. See accompanying file LICENSE.md
 // or copy at https://opensource.org/licenses/ISC
 
+#ifndef INCLUDE_TESTS_UTIL_HELPER_TYPES
+#define INCLUDE_TESTS_UTIL_HELPER_TYPES
+
 #include <compare>
 #include <concepts>
 #include <initializer_list>
@@ -10,7 +13,8 @@
 #include <type_traits>
 #include <utility>
 
-// Use prime numbers to record Foo states in witness
+// Prime factors recording which special member ran: the witness value is multiplied by one of
+// these, so a test can recover the exact copy/move/swap path from the factorization.
 enum helper_witness {
   from_lval = 53, //
   from_lval_const = 59,
@@ -21,119 +25,85 @@ enum helper_witness {
 
 using helper_list_t = std::initializer_list<double>;
 
-template <int V> struct helper_t {
-  static inline int state = 0;
+// Behaviour axes for the witness fixtures, combined with operator|. The default (regular == 0) is
+// copyable, movable and every special member noexcept; each flag opts one operation into throwing
+// (noexcept(false), throws when the resulting value is zero). runtime_move additionally makes the
+// move constructor non-constexpr so it cannot be elided and is observable in `state` and coverage.
+enum class prop : unsigned {
+  regular = 0,
+  throw_copy = 1U << 0,        // copy constructor
+  throw_move = 1U << 1,        // move constructor
+  throw_copy_assign = 1U << 2, // copy assignment
+  throw_move_assign = 1U << 3, // move assignment
+  throw_value = 1U << 4,       // value (integral arguments) constructor
+  runtime_move = 1U << 5,      // non-constexpr move constructor; accumulates into `state`
+};
 
+constexpr prop operator|(prop a, prop b) noexcept
+{
+  using U = std::underlying_type_t<prop>;
+  return static_cast<prop>(static_cast<U>(a) | static_cast<U>(b));
+}
+
+constexpr prop operator&(prop a, prop b) noexcept
+{
+  using U = std::underlying_type_t<prop>;
+  return static_cast<prop>(static_cast<U>(a) & static_cast<U>(b));
+}
+
+// Transitional: map the legacy helper_t<int> selector onto flags, so unconverted call sites keep
+// compiling while their tests migrate to the named flags. Remove the int overload (and this comment)
+// once no call site instantiates a fixture with an integer.
+constexpr prop prop_of(prop p) noexcept { return p; }
+constexpr prop prop_of(int V) noexcept
+{
+  prop f = prop::regular;
+  if (V >= 2 && V < 4)
+    f = f | prop::throw_copy;
+  if ((V >= 3 && V < 5) || (V >= 33 && V < 35))
+    f = f | prop::throw_move;
+  if (V >= 40 && V < 41)
+    f = f | prop::throw_copy_assign | prop::throw_move_assign;
+  if (V < 8)
+    f = f | prop::throw_value;
+  if (V >= 30)
+    f = f | prop::runtime_move;
+  return f;
+}
+
+// Common value storage and value constructors shared by the three fixtures; the copy/move behaviour
+// (witnessed, deleted, or throwing) is layered on by the derived templates below.
+template <prop F> struct helper_value_base {
+  static constexpr bool throws_value = (F & prop::throw_value) != prop::regular;
+
+  static inline int state = 0;
   int v = {};
 
-  // No default constructor
-  helper_t() = delete;
+  helper_value_base() = delete;
+  constexpr ~helper_value_base() noexcept {}
+  constexpr bool operator==(helper_value_base const &) const noexcept = default;
 
-  constexpr ~helper_t() noexcept {};
-
-  constexpr bool operator==(helper_t const &) const noexcept = default;
-
-  // Assignment operators will multiply witness by a prime
-  constexpr helper_t &operator=(helper_t &o) noexcept(V < 40 || V >= 41)
-  {
-    if constexpr (V >= 40 && V < 41) {
-      if (o.v == 0)
-        throw std::runtime_error("invalid input");
-    }
-    v = o.v;
-    v *= from_lval;
-    return *this;
-  }
-
-  constexpr helper_t &operator=(helper_t const &o) noexcept(V < 40 || V >= 41)
-  {
-    if constexpr (V >= 40 && V < 41) {
-      if (o.v == 0)
-        throw std::runtime_error("invalid input");
-    }
-    v = o.v;
-    v *= from_lval_const;
-    return *this;
-  }
-
-  constexpr helper_t &operator=(helper_t &&o) noexcept(V < 40 || V >= 41)
-  {
-    if constexpr (V >= 40 && V < 41) {
-      if (o.v == 0)
-        throw std::runtime_error("invalid input");
-    }
-    v = o.v;
-    v *= from_rval;
-    return *this;
-  }
-
-  constexpr helper_t &operator=(helper_t const &&o) noexcept(V < 40 || V >= 41)
-  {
-    if constexpr (V >= 40 && V < 41) {
-      if (o.v == 0)
-        throw std::runtime_error("invalid input");
-    }
-    v = o.v;
-    v *= from_rval_const;
-    return *this;
-  }
-
-  // See table below
-  constexpr helper_t(helper_t &o) noexcept : v(o.v) { v *= from_lval; }
-  constexpr helper_t(helper_t const &o) noexcept(V < 2 || V >= 4) : v(o.v)
-  {
-    v *= from_lval_const;
-    if constexpr (V >= 2 && V < 4) {
-      if (v == 0)
-        throw std::runtime_error("invalid input");
-    }
-  }
-  constexpr helper_t(helper_t &&o) noexcept(V < 3 || V >= 5)
-    requires(V < 30)
-      : v(o.v)
-  {
-    v *= from_rval;
-    if constexpr (V >= 3 && V < 5) {
-      if (v == 0)
-        throw std::runtime_error("invalid input");
-    }
-  }
-  helper_t(helper_t &&o) noexcept(V < 33 || V >= 35)
-    requires(V >= 30)
-      : v(o.v)
-  {
-    v *= from_rval;
-    state += v;
-    if constexpr (V >= 33 && V < 35) {
-      if (v == 0)
-        throw std::runtime_error("invalid input");
-    }
-  }
-  constexpr helper_t(helper_t const &&o) noexcept : v(o.v) { v *= from_rval_const; }
-
-  // The intent of non-constexpr constructors is to make sure that they are never optimized away,
-  // thus ensuring that any code which relies on them in tests will show up in coverage reports.
-  helper_t(std::integral auto... a) noexcept(V >= 8)
+  // Non-constexpr on purpose: guarantees the constructor is emitted (never folded away) so a test
+  // relying on it shows up in coverage, and lets `state` witness that construction actually ran.
+  helper_value_base(std::integral auto... a) noexcept(not throws_value)
     requires(sizeof...(a) > 0) // intentionally implicit when sizeof...(a) == 1
       : v((1 * ... * a))
   {
-    if constexpr (V < 8) {
+    if constexpr (throws_value) {
       if (v == 0)
         throw std::runtime_error("invalid input");
     }
     state += v;
   }
 
-  helper_t(helper_list_t list) noexcept(true) : v(init(list)) { state += v; }
+  helper_value_base(helper_list_t list) noexcept : v(init(list)) { state += v; }
 
-  // Potentially throwing constructor
-  constexpr helper_t(helper_list_t list, std::integral auto... a) noexcept(true)
+  constexpr helper_value_base(helper_list_t list, std::integral auto... a) noexcept
     requires(sizeof...(a) > 0)
       : v(init(list, a...)) //
   {
   }
 
-  // ... and the actual exception being thrown
   static constexpr int init(helper_list_t l, auto &&...a) noexcept
   {
     double ret = (1 * ... * a);
@@ -143,73 +113,89 @@ template <int V> struct helper_t {
     return static_cast<int>(ret);
   }
 
-  // Disable comparison operators; compare .v instead
-  friend bool operator==(helper_t, std::integral auto) = delete;
-  friend std::strong_ordering operator<=>(helper_t, helper_t) = delete;
+protected:
+  struct raw_t {
+    explicit raw_t() = default;
+  };
+  // Side-effect-free initialiser used by the witnessing copy/move constructors of the derived
+  // fixtures, which must set `v` without running the value constructor's throw/`state` logic.
+  constexpr helper_value_base(raw_t, int value) noexcept : v(value) {}
 };
 
-//     helper_t<V>
-// V   nothrow_copy_ctor  nothrow_move_ctor  nothrow_copy_assign  nothrow_move_assign
-// 0   1                  1                  1                    1
-// 1   1                  1                  1                    1
-// 2   0                  1                  1                    1
-// 3   0                  0                  1                    1
-// 4   1                  0                  1                    1
-// 5   1                  1                  1                    1
-// 40  1                  1                  0                    0
-static_assert(std::is_nothrow_copy_constructible_v<helper_t<0>>);
-static_assert(std::is_nothrow_move_constructible_v<helper_t<0>>);
-static_assert(std::is_nothrow_copy_constructible_v<helper_t<1>>);
-static_assert(std::is_nothrow_move_constructible_v<helper_t<1>>);
-static_assert(not std::is_nothrow_copy_constructible_v<helper_t<2>>);
-static_assert(std::is_nothrow_move_constructible_v<helper_t<2>>);
-static_assert(not std::is_nothrow_copy_constructible_v<helper_t<3>>);
-static_assert(not std::is_nothrow_move_constructible_v<helper_t<3>>);
-static_assert(std::is_nothrow_copy_constructible_v<helper_t<4>>);
-static_assert(not std::is_nothrow_move_constructible_v<helper_t<4>>);
-static_assert(std::is_nothrow_copy_constructible_v<helper_t<5>>);
-static_assert(std::is_nothrow_move_constructible_v<helper_t<5>>);
-static_assert(std::is_nothrow_copy_constructible_v<helper_t<40>>);
-static_assert(std::is_nothrow_move_constructible_v<helper_t<40>>);
-static_assert(not std::is_nothrow_copy_assignable_v<helper_t<40>>);
-static_assert(not std::is_nothrow_move_assignable_v<helper_t<40>>);
+// Fully copyable and movable witness. Each special member multiplies `v` by its prime and,
+// per the flags in F, may be noexcept(false) and throw on a zero result.
+template <auto Cfg> struct helper_t : helper_value_base<prop_of(Cfg)> {
+  static constexpr prop F = prop_of(Cfg);
+  using base = helper_value_base<F>;
+  static constexpr bool throws_copy = (F & prop::throw_copy) != prop::regular;
+  static constexpr bool throws_move = (F & prop::throw_move) != prop::regular;
+  static constexpr bool throws_copy_assign = (F & prop::throw_copy_assign) != prop::regular;
+  static constexpr bool throws_move_assign = (F & prop::throw_move_assign) != prop::regular;
 
-// Swap will also multiply witness by a prime
-template <auto V> constexpr void swap(helper_t<V> &l, helper_t<V> &r)
-{
-  std::swap(l.v, r.v);
-  l.v *= swapped;
-  r.v *= swapped;
-}
+  using base::base;
+  using base::v;
 
-using helper = helper_t<0>;
+  constexpr helper_t(helper_t &o) noexcept : base(typename base::raw_t{}, o.v) { v *= from_lval; }
 
-// Move-only counterpart to helper_t: copy construction/assignment are deleted;
-// the move operations are witnessed by a prime factor and parameterized by V with
-// the same scheme as helper_t (V in [3,5) throws on move-construct, V in [40,41)
-// throws on move-assign, V < 8 throws on the value constructor).
-template <int V> struct helper_move_only_t {
-  int v = {};
-
-  helper_move_only_t() = delete;
-  constexpr ~helper_move_only_t() noexcept {};
-
-  helper_move_only_t(helper_move_only_t const &) = delete;
-  helper_move_only_t &operator=(helper_move_only_t const &) = delete;
-
-  constexpr helper_move_only_t(helper_move_only_t &&o) noexcept(V < 3 || V >= 5) : v(o.v)
+  constexpr helper_t(helper_t const &o) noexcept(not throws_copy) : base(typename base::raw_t{}, o.v)
   {
-    v *= from_rval;
-    if constexpr (V >= 3 && V < 5) {
+    v *= from_lval_const;
+    if constexpr (throws_copy) {
       if (v == 0)
         throw std::runtime_error("invalid input");
     }
   }
-  constexpr helper_move_only_t(helper_move_only_t const &&o) noexcept : v(o.v) { v *= from_rval_const; }
 
-  constexpr helper_move_only_t &operator=(helper_move_only_t &&o) noexcept(V < 40 || V >= 41)
+  constexpr helper_t(helper_t &&o) noexcept(not throws_move)
+    requires((prop_of(Cfg) & prop::runtime_move) == prop::regular)
+      : base(typename base::raw_t{}, o.v)
   {
-    if constexpr (V >= 40 && V < 41) {
+    v *= from_rval;
+    if constexpr (throws_move) {
+      if (v == 0)
+        throw std::runtime_error("invalid input");
+    }
+  }
+
+  helper_t(helper_t &&o) noexcept(not throws_move)
+    requires((prop_of(Cfg) & prop::runtime_move) != prop::regular)
+      : base(typename base::raw_t{}, o.v)
+  {
+    v *= from_rval;
+    base::state += v;
+    if constexpr (throws_move) {
+      if (v == 0)
+        throw std::runtime_error("invalid input");
+    }
+  }
+
+  constexpr helper_t(helper_t const &&o) noexcept : base(typename base::raw_t{}, o.v) { v *= from_rval_const; }
+
+  constexpr helper_t &operator=(helper_t &o) noexcept(not throws_copy_assign)
+  {
+    if constexpr (throws_copy_assign) {
+      if (o.v == 0)
+        throw std::runtime_error("invalid input");
+    }
+    v = o.v;
+    v *= from_lval;
+    return *this;
+  }
+
+  constexpr helper_t &operator=(helper_t const &o) noexcept(not throws_copy_assign)
+  {
+    if constexpr (throws_copy_assign) {
+      if (o.v == 0)
+        throw std::runtime_error("invalid input");
+    }
+    v = o.v;
+    v *= from_lval_const;
+    return *this;
+  }
+
+  constexpr helper_t &operator=(helper_t &&o) noexcept(not throws_move_assign)
+  {
+    if constexpr (throws_move_assign) {
       if (o.v == 0)
         throw std::runtime_error("invalid input");
     }
@@ -218,57 +204,123 @@ template <int V> struct helper_move_only_t {
     return *this;
   }
 
-  helper_move_only_t(std::integral auto... a) noexcept(V >= 8)
-    requires(sizeof...(a) > 0) // intentionally implicit when sizeof...(a) == 1
-      : v((1 * ... * a))
+  constexpr helper_t &operator=(helper_t const &&o) noexcept(not throws_move_assign)
   {
-    if constexpr (V < 8) {
+    if constexpr (throws_move_assign) {
+      if (o.v == 0)
+        throw std::runtime_error("invalid input");
+    }
+    v = o.v;
+    v *= from_rval_const;
+    return *this;
+  }
+
+  constexpr bool operator==(helper_t const &) const noexcept = default;
+
+  // Disable comparison operators; compare .v instead
+  friend bool operator==(helper_t, std::integral auto) = delete;
+  friend std::strong_ordering operator<=>(helper_t, helper_t) = delete;
+};
+
+// Move-only witness: copy construction/assignment deleted, moves witnessed. runtime_move does not
+// apply (the move constructor is always constexpr, matching the fixture's only historical use).
+template <auto Cfg> struct helper_move_only_t : helper_value_base<prop_of(Cfg)> {
+  static constexpr prop F = prop_of(Cfg);
+  using base = helper_value_base<F>;
+  static constexpr bool throws_move = (F & prop::throw_move) != prop::regular;
+  static constexpr bool throws_move_assign = (F & prop::throw_move_assign) != prop::regular;
+
+  using base::base;
+  using base::v;
+
+  helper_move_only_t(helper_move_only_t const &) = delete;
+  helper_move_only_t &operator=(helper_move_only_t const &) = delete;
+
+  constexpr helper_move_only_t(helper_move_only_t &&o) noexcept(not throws_move) : base(typename base::raw_t{}, o.v)
+  {
+    v *= from_rval;
+    if constexpr (throws_move) {
       if (v == 0)
         throw std::runtime_error("invalid input");
     }
   }
 
+  constexpr helper_move_only_t(helper_move_only_t const &&o) noexcept : base(typename base::raw_t{}, o.v)
+  {
+    v *= from_rval_const;
+  }
+
+  constexpr helper_move_only_t &operator=(helper_move_only_t &&o) noexcept(not throws_move_assign)
+  {
+    if constexpr (throws_move_assign) {
+      if (o.v == 0)
+        throw std::runtime_error("invalid input");
+    }
+    v = o.v;
+    v *= from_rval;
+    return *this;
+  }
+
   constexpr bool operator==(helper_move_only_t const &) const noexcept = default;
 };
 
-static_assert(not std::is_copy_constructible_v<helper_move_only_t<0>>);
-static_assert(std::is_move_constructible_v<helper_move_only_t<0>>);
-static_assert(std::is_nothrow_move_constructible_v<helper_move_only_t<0>>);
-static_assert(not std::is_nothrow_move_constructible_v<helper_move_only_t<3>>); // throwing move ctor
-static_assert(not std::is_copy_assignable_v<helper_move_only_t<0>>);
-static_assert(std::is_move_assignable_v<helper_move_only_t<0>>);
-static_assert(not std::is_nothrow_move_assignable_v<helper_move_only_t<40>>); // throwing move assign
+// Immovable witness: all copy/move deleted; only in-place constructible (from a value) and observable.
+template <auto Cfg> struct helper_immovable_t : helper_value_base<prop_of(Cfg)> {
+  using base = helper_value_base<prop_of(Cfg)>;
 
-// Non-copyable AND non-movable: can only be constructed in place (from a value)
-// and observed; V < 8 makes the value constructor throw on a zero result.
-template <int V> struct helper_immovable_t {
-  int v = {};
-
-  helper_immovable_t() = delete;
-  constexpr ~helper_immovable_t() noexcept {};
+  using base::base;
+  using base::v;
 
   helper_immovable_t(helper_immovable_t const &) = delete;
   helper_immovable_t(helper_immovable_t &&) = delete;
   helper_immovable_t &operator=(helper_immovable_t const &) = delete;
   helper_immovable_t &operator=(helper_immovable_t &&) = delete;
 
-  helper_immovable_t(std::integral auto... a) noexcept(V >= 8)
-    requires(sizeof...(a) > 0) // intentionally implicit when sizeof...(a) == 1
-      : v((1 * ... * a))
-  {
-    if constexpr (V < 8) {
-      if (v == 0)
-        throw std::runtime_error("invalid input");
-    }
-  }
-
   constexpr bool operator==(helper_immovable_t const &) const noexcept = default;
 };
 
-static_assert(not std::is_copy_constructible_v<helper_immovable_t<0>>);
-static_assert(not std::is_move_constructible_v<helper_immovable_t<0>>);
-static_assert(not std::is_copy_assignable_v<helper_immovable_t<0>>);
-static_assert(not std::is_move_assignable_v<helper_immovable_t<0>>);
+// Swap multiplies each witness by its prime.
+template <auto Cfg> constexpr void swap(helper_t<Cfg> &l, helper_t<Cfg> &r)
+{
+  std::swap(l.v, r.v);
+  l.v *= swapped;
+  r.v *= swapped;
+}
 
-using helper_move_only = helper_move_only_t<0>;
-using helper_immovable = helper_immovable_t<0>;
+using helper = helper_t<prop::throw_value>;
+using helper_move_only = helper_move_only_t<prop::throw_value>;
+using helper_immovable = helper_immovable_t<prop::throw_value>;
+
+static_assert(std::is_nothrow_copy_constructible_v<helper>);
+static_assert(std::is_nothrow_move_constructible_v<helper>);
+static_assert(std::is_nothrow_copy_assignable_v<helper>);
+static_assert(std::is_nothrow_move_assignable_v<helper>);
+
+static_assert(not std::is_nothrow_copy_constructible_v<helper_t<prop::throw_copy>>);
+static_assert(std::is_nothrow_move_constructible_v<helper_t<prop::throw_copy>>);
+static_assert(std::is_nothrow_copy_constructible_v<helper_t<prop::throw_move>>);
+static_assert(not std::is_nothrow_move_constructible_v<helper_t<prop::throw_move>>);
+static_assert(not std::is_nothrow_copy_assignable_v<helper_t<prop::throw_copy_assign>>);
+static_assert(std::is_nothrow_move_assignable_v<helper_t<prop::throw_copy_assign>>);
+static_assert(std::is_nothrow_copy_assignable_v<helper_t<prop::throw_move_assign>>);
+static_assert(not std::is_nothrow_move_assignable_v<helper_t<prop::throw_move_assign>>);
+
+static_assert(not std::is_copy_constructible_v<helper_move_only>);
+static_assert(std::is_nothrow_move_constructible_v<helper_move_only>);
+static_assert(not std::is_nothrow_move_constructible_v<helper_move_only_t<prop::throw_move>>);
+static_assert(not std::is_copy_assignable_v<helper_move_only>);
+static_assert(std::is_nothrow_move_assignable_v<helper_move_only>);
+static_assert(not std::is_nothrow_move_assignable_v<helper_move_only_t<prop::throw_move_assign>>);
+
+static_assert(not std::is_copy_constructible_v<helper_immovable>);
+static_assert(not std::is_move_constructible_v<helper_immovable>);
+static_assert(not std::is_copy_assignable_v<helper_immovable>);
+static_assert(not std::is_move_assignable_v<helper_immovable>);
+
+// Legacy shim sanity: a few representative integer selectors still map to the right behaviour.
+// Remove together with the prop_of(int) overload once no call site uses an integer selector.
+static_assert(not std::is_nothrow_copy_constructible_v<helper_t<2>>);
+static_assert(not std::is_nothrow_move_constructible_v<helper_t<3>>);
+static_assert(not std::is_nothrow_move_assignable_v<helper_t<40>>);
+
+#endif // INCLUDE_TESTS_UTIL_HELPER_TYPES

--- a/tests/util/static_check.hpp
+++ b/tests/util/static_check.hpp
@@ -6,11 +6,13 @@
 #ifndef TESTS_UTIL_STATIC_CHECK
 #define TESTS_UTIL_STATIC_CHECK
 
-#include <fn/functional.hpp>
-#include <fn/monadic.hpp>
-
 #include <type_traits>
+#include <utility>
 
+// Sweeps a verb's invocability across every value category of its operand - the instrument that pins
+// down libfn's ref-qualified overload resolution. Deliberately built on `std::is_invocable` alone,
+// never on fn's own concepts: a harness that judged fn with fn would share any bug with the code it
+// judges, and so be blind to it. Nothing here may include a libfn header.
 namespace util {
 
 template <typename OperandType> struct lvalue {
@@ -40,15 +42,15 @@ template <typename OperandType> struct prvalue {
 struct static_check {
   template <typename CheckType> struct bind {
     [[nodiscard]] static constexpr auto invocable(auto &&...fns) noexcept -> bool
-      requires(fn::is_invocable_r<bool, CheckType, decltype(fns)...>::value)
+      requires(std::is_invocable_r_v<bool, CheckType, decltype(fns)...>)
     {
-      return CheckType()(FWD(fns)...);
+      return CheckType()(std::forward<decltype(fns)>(fns)...);
     }
 
     [[nodiscard]] static constexpr auto not_invocable(auto &&...fns) noexcept -> bool
-      requires(fn::is_invocable_r<bool, CheckType, decltype(fns)...>::value)
+      requires(std::is_invocable_r_v<bool, CheckType, decltype(fns)...>)
     {
-      return not invocable(FWD(fns)...);
+      return not invocable(std::forward<decltype(fns)>(fns)...);
     }
   };
 };
@@ -57,39 +59,46 @@ template <typename OperandType, template <typename> typename CommandType> struct
   template <template <typename> typename... Categories>
   [[nodiscard]] static constexpr auto invocable(auto &&...fns) noexcept -> bool
   {
-    return (static_check::bind<CommandType<typename Categories<OperandType>::type>>::invocable(FWD(fns)...) && ...);
+    return (static_check::bind<CommandType<typename Categories<OperandType>::type>>::invocable(
+                std::forward<decltype(fns)>(fns)...)
+            && ...);
   }
 
   template <template <typename> typename... Categories>
   [[nodiscard]] static constexpr auto not_invocable(auto &&...fns) noexcept -> bool
   {
-    return (static_check::bind<CommandType<typename Categories<OperandType>::type>>::not_invocable(FWD(fns)...) && ...);
+    return (static_check::bind<CommandType<typename Categories<OperandType>::type>>::not_invocable(
+                std::forward<decltype(fns)>(fns)...)
+            && ...);
   }
 
   [[nodiscard]] static constexpr auto invocable_with_any(auto &&...fns) noexcept -> bool
   {
-    return invocable<lvalue, cvalue, rvalue, clvalue, crvalue, prvalue>(FWD(fns)...);
+    return invocable<lvalue, cvalue, rvalue, clvalue, crvalue, prvalue>(std::forward<decltype(fns)>(fns)...);
   }
 
   [[nodiscard]] static constexpr auto not_invocable_with_any(auto &&...fns) noexcept -> bool
   {
-    return not_invocable<lvalue, cvalue, rvalue, clvalue, crvalue, prvalue>(FWD(fns)...);
+    return not_invocable<lvalue, cvalue, rvalue, clvalue, crvalue, prvalue>(std::forward<decltype(fns)>(fns)...);
   }
 };
 
 template <typename OperationType, typename OperandType> class monadic_static_check {
+  // The verb is reached through its `apply`, exactly as `operator|` reaches it, so this asks the same
+  // question the pipeline does - but asks it of std::is_invocable rather than fn::monadic_invocable.
+  // Each verb's `apply` constrains its own operand to a monadic type, so no separate gate is needed.
   template <typename... HandlerTypes> struct binder {
     template <typename T> struct right {
       [[nodiscard]] constexpr auto operator()(auto &&...fns) const noexcept -> bool
       {
-        return fn::monadic_invocable<OperationType, T, decltype(fns)..., HandlerTypes...>;
+        return std::is_invocable_v<typename OperationType::apply, T, decltype(fns)..., HandlerTypes...>;
       }
     };
 
     template <typename T> struct left {
       [[nodiscard]] constexpr auto operator()(auto &&...fns) const noexcept -> bool
       {
-        return fn::monadic_invocable<OperationType, T, HandlerTypes..., decltype(fns)...>;
+        return std::is_invocable_v<typename OperationType::apply, T, HandlerTypes..., decltype(fns)...>;
       }
     };
   };
@@ -105,24 +114,24 @@ public:
 
   [[nodiscard]] static constexpr auto invocable_with_any(auto &&...fns) noexcept -> bool
   {
-    return bind::invocable_with_any(FWD(fns)...);
+    return bind::invocable_with_any(std::forward<decltype(fns)>(fns)...);
   }
 
   [[nodiscard]] static constexpr auto not_invocable_with_any(auto &&...fns) noexcept -> bool
   {
-    return bind::not_invocable_with_any(FWD(fns)...);
+    return bind::not_invocable_with_any(std::forward<decltype(fns)>(fns)...);
   }
 
   template <template <typename> typename... Categories>
   [[nodiscard]] static constexpr auto invocable(auto &&...fns) noexcept -> bool
   {
-    return bind::template invocable<Categories...>(FWD(fns)...);
+    return bind::template invocable<Categories...>(std::forward<decltype(fns)>(fns)...);
   }
 
   template <template <typename> typename... Categories>
   [[nodiscard]] static constexpr auto not_invocable(auto &&...fns) noexcept -> bool
   {
-    return bind::template not_invocable<Categories...>(FWD(fns)...);
+    return bind::template not_invocable<Categories...>(std::forward<decltype(fns)>(fns)...);
   }
 };
 


### PR DESCRIPTION
Brings the test suite to a consistent bar, in two passes: first what every file *covers*, then what every file *looks like*. Tests only — `include/` is unchanged.

**Coverage.** Every `fn` test file now checks four dimensions: a runtime check on each behaviour, a constant-evaluation twin, an exact assertion of the deduced `noexcept`, and `requires`-clause accuracy with both positive and negative SFINAE. This addresses the three problems the issue names:

*Under-testing*: surface that had no tests at all is now covered — `sum`'s widening constructors, `make`'s parenthesis fallback overload, `transform`'s extra-arguments path, seven exported concepts that appeared nowhere in the suite, direct probes of every verb's `invocable_*` concept, and pointer-to-member callables for the verbs that never fed one through the pipe.

*Over-testing*: duplication was removed only where it could be shown mechanically, and each removal was agreed explicitly — a test case whose grid was a verbatim clone of another's, the surface `choice` re-tested despite inheriting it from `sum`, a `sum_for` block repeated line-for-line in an unrelated case, and a catch-all `TEST_CASE("sum")` dissolved into named sections so that its unique content (`index`, `select_nth`, `get_ptr`) lives where a reader would look for it.

*Inconsistent coverage*: the `noexcept` and `requires` dimensions, previously near-absent outside the polyfill suites, now apply uniformly across the monads, `sum`/`pack`/`choice`, and all eleven functors.

**Structure.** Every file now follows the shape of `tests/pfn/expected.cpp`: plain nested `SECTION`s forming a product of test dimensions, with short names. The BDD macros are gone, and the free-standing `constexpr <functor> <monad>` test cases are folded into their monad's case as nested sections. `TEMPLATE_TEST_CASE` is used only where one battery genuinely serves several subjects: `variadic_union` (one battery over the header's five specializations, at less than half the code), `and_then`'s member-callable battery (the `optional` half was a line-for-line type substitution of the `expected` half), and the pack/sum join algebra — the twelve shapes shared by `detail::_join` and the public `operator&` now run through both layers, in both constant and runtime evaluation, which also closed the old `_join` grid's complete absence of runtime assertions. Every restructuring step was verified by comparing per-file assertion counts before and after, on both GCC and Clang.

One change to the test utilities underpins both passes: `util/static_check.hpp` no longer uses the library it is used to test. It was built on `fn::monadic_invocable`, so a bug in `fn` would have sat in both judge and judged; it now asks `std::is_invocable` the same question `operator|` asks, and includes no libfn header — which also closes the long-standing circular dependency from the test utilities back to `include/fn`.

The `noexcept` and `requires` work was treated as a discovery tool rather than a formality, and it surfaced a number of genuine defects in `include/` — the concept probes added one more. Each was reproduced on both GCC and Clang and filed separately; none is fixed here. Where the current behaviour is wrong, the tests assert it as it stands, so the assertions fail when the library is fixed rather than silently passing — the sites carry comments naming the issue they belong to. CI's wider matrix caught a handful of portability mistakes in the new tests themselves (old Clang, AppleClang 15, MSVC); all are fixed, each pinned by a comment at the site that bit.

Assisted-by: Claude:claude-opus-4-8
Assisted-by: Claude:claude-fable-5
