### PR TITLE
Fix ambiguous partial specialization when appending a `sum` to a `pack`

### DIFF
--- a/include/fn/detail/pack_impl.hpp
+++ b/include/fn/detail/pack_impl.hpp
@@ -24,11 +24,14 @@ template <::std::size_t I, typename T> struct _element {
 template <typename, typename... Ts> struct pack_impl;
 
 template <typename... Ts> struct _pack_append;
+// A pack never holds a sum. The specialization is defined but has no `type`, so naming
+// `append_type<sum>` is a substitution failure rather than a use of an incomplete type; and the
+// two specializations must exclude each other, or both match a sum and the choice is ambiguous.
 template <typename T, typename... Ts>
   requires _some_sum<T>
-struct _pack_append<T, Ts...>;
+struct _pack_append<T, Ts...> {};
 template <typename T, typename... Ts>
-  requires(not _some_pack<T>)
+  requires(not _some_pack<T>) && (not _some_sum<T>)
 struct _pack_append<T, Ts...> {
   using impl = pack_impl<::std::index_sequence_for<Ts..., T>, Ts..., T>;
   using type = ::fn::pack<Ts..., T>;
@@ -98,11 +101,6 @@ struct pack_impl<::std::index_sequence<Is...>, Ts...> : _element<Is, Ts>... {
       return type{static_cast<apply_const_lvalue_t<Self, Ts &&>>(FWD(self)._element<Is, Ts>::v)..., FWD(args)...};
     });
   }
-
-  template <typename T, typename Self>
-  static constexpr auto _append(Self &&self, auto &&...args) noexcept
-    requires _some_sum<T>
-  = delete;
 };
 
 } // namespace fn::detail

--- a/include/fn/pack.hpp
+++ b/include/fn/pack.hpp
@@ -106,7 +106,8 @@ template <typename... Ts> struct pack : detail::pack_impl<::std::index_sequence_
    */
   template <typename Arg>
   [[nodiscard]] constexpr auto append(Arg &&arg) & noexcept -> append_type<Arg>
-    requires requires { append_type<Arg>{_impl::template _append<Arg>(*this, FWD(arg))}; }
+    requires(not some_in_place_type<Arg>)
+            && requires { append_type<Arg>{_impl::template _append<Arg>(*this, FWD(arg))}; }
   {
     return {_impl::template _append<Arg>(*this, FWD(arg))};
   }
@@ -120,7 +121,8 @@ template <typename... Ts> struct pack : detail::pack_impl<::std::index_sequence_
    */
   template <typename Arg>
   [[nodiscard]] constexpr auto append(Arg &&arg) const & noexcept -> append_type<Arg>
-    requires requires { append_type<Arg>{_impl::template _append<Arg>(*this, FWD(arg))}; }
+    requires(not some_in_place_type<Arg>)
+            && requires { append_type<Arg>{_impl::template _append<Arg>(*this, FWD(arg))}; }
   {
     return {_impl::template _append<Arg>(*this, FWD(arg))};
   }
@@ -134,7 +136,8 @@ template <typename... Ts> struct pack : detail::pack_impl<::std::index_sequence_
    */
   template <typename Arg>
   [[nodiscard]] constexpr auto append(Arg &&arg) && noexcept -> append_type<Arg>
-    requires requires { append_type<Arg>{_impl::template _append<Arg>(::std::move(*this), FWD(arg))}; }
+    requires(not some_in_place_type<Arg>)
+            && requires { append_type<Arg>{_impl::template _append<Arg>(::std::move(*this), FWD(arg))}; }
   {
     return {_impl::template _append<Arg>(::std::move(*this), FWD(arg))};
   }
@@ -148,7 +151,8 @@ template <typename... Ts> struct pack : detail::pack_impl<::std::index_sequence_
    */
   template <typename Arg>
   [[nodiscard]] constexpr auto append(Arg &&arg) const && noexcept -> append_type<Arg>
-    requires requires { append_type<Arg>{_impl::template _append<Arg>(::std::move(*this), FWD(arg))}; }
+    requires(not some_in_place_type<Arg>)
+            && requires { append_type<Arg>{_impl::template _append<Arg>(::std::move(*this), FWD(arg))}; }
   {
     return {_impl::template _append<Arg>(::std::move(*this), FWD(arg))};
   }

--- a/tests/fn/pack.cpp
+++ b/tests/fn/pack.cpp
@@ -27,6 +27,12 @@ template <fn::pack<int, double> P> struct pack_nttp final {};
 template <fn::some_pack auto P> struct some_pack_nttp final {};
 template <fn::some_pack auto P> auto read_nttp() { return fn::get<0>(P); }
 
+template <typename V, typename T, typename... Args>
+concept can_append_in_place = requires(V v, Args... args) { FWD(v).append(std::in_place_type<T>, args...); };
+
+template <typename V, typename Arg>
+concept can_append = requires(V v, Arg arg) { FWD(v).append(FWD(arg)); };
+
 } // namespace
 
 TEST_CASE("pack", "[pack]")
@@ -237,6 +243,21 @@ TEST_CASE("append value categories", "[pack][append]")
     CHECK(c2.invoke([](bool i, int j, B const &b1, C const &c, B const &b2) {
       return i && j == 3 && b1.v == 14 && c.v == 30 && b2.v == 20;
     }));
+  }
+
+  WHEN("constraints")
+  {
+    static_assert(can_append_in_place<T &, B, int>);
+    static_assert(can_append_in_place<T &, B, int, int>);
+    static_assert(not can_append_in_place<T &, B, char const *>); // B is not constructible from it
+
+    // A pack never holds a sum, in either spelling - and asking must answer, not hard-error
+    static_assert(not can_append<T &, fn::sum<int>>);
+    static_assert(not can_append<T &, fn::sum<int> &>);
+    static_assert(not can_append_in_place<T &, fn::sum<int>, fn::sum<int>>);
+    static_assert(not can_append_in_place<T &, fn::sum_for<bool, int>, fn::sum_for<bool, int>>);
+
+    SUCCEED();
   }
 }
 

--- a/tests/fn/pack.cpp
+++ b/tests/fn/pack.cpp
@@ -251,6 +251,15 @@ TEST_CASE("append value categories", "[pack][append]")
     static_assert(can_append_in_place<T &, B, int, int>);
     static_assert(not can_append_in_place<T &, B, char const *>); // B is not constructible from it
 
+    // in_place_type selects the element type, it is never itself an element: with no arguments and
+    // no default constructor there is nothing to construct, and the deduced-Arg overload must not
+    // pick the call up and append the tag instead
+    static_assert(not can_append_in_place<T &, B>);
+    static_assert(not can_append<T &, std::in_place_type_t<B> const &>);
+    // C has a default constructor, so the same call still means "construct the element"
+    static_assert(can_append_in_place<T &, C>);
+    static_assert(std::same_as<decltype(std::declval<T &>().append(std::in_place_type<C>)), T::append_type<C>>);
+
     // A pack never holds a sum, in either spelling - and asking must answer, not hard-error
     static_assert(not can_append<T &, fn::sum<int>>);
     static_assert(not can_append<T &, fn::sum<int> &>);


### PR DESCRIPTION
Two defects in the same `pack::append` overload set.

### Fix ambiguous partial specialization when appending a `sum` to a `pack`

`_pack_append`'s two specializations both matched a sum and neither subsumed the other, so naming `append_type<sum>` was ill-formed: gcc hard-errored even inside a requires-expression, while clang answered false. They now exclude each other, and the sum case defines no `type`, making the rejection a clean substitution failure on both compilers. Drops `_append<sum> = delete`, which `append`'s trailing return type made unreachable.

### Reject `in_place_type` as a deduced `pack::append` argument

The tag selects the element type; it is never an element. With a type that has no default constructor the in-place overload dropped out on its `is_constructible_v` conjunct and the deduced-argument overload picked the call up, silently appending the tag itself, so `append(in_place_type<T>)` meant "construct a T" or "append the tag" depending on a property of T. The deduced-argument overloads now carry the guard `as_pack` already had, leaving the in-place overload as the only candidate for a tag.

Closes #282
Closes #283

---
**Stack**: P1 of 13 — the release-0.1 bugfix queue, merging bottom-up into `main`; this PR is the base of the stack. Every stack boundary was validated with a gcc build and the full test suite on top of `main`, and the aggregate branch ran the full CI matrix green (#289).
