### PR TITLE
Constrain `in_place_type` construction of `sum` and `choice` on the argument list

### DIFF
--- a/include/fn/choice.hpp
+++ b/include/fn/choice.hpp
@@ -111,7 +111,7 @@ struct choice<Ts...> : sum<Ts...> {
    */
   template <typename T>
   constexpr explicit choice(::std::in_place_type_t<T> d, auto &&...args) noexcept
-    requires has_type<T>
+    requires has_type<T> && detail::_brace_constructible<T, decltype(args)...>
       : _impl(d, FWD(args)...)
   {
   }

--- a/include/fn/choice.hpp
+++ b/include/fn/choice.hpp
@@ -111,7 +111,7 @@ struct choice<Ts...> : sum<Ts...> {
    */
   template <typename T>
   constexpr explicit choice(::std::in_place_type_t<T> d, auto &&...args) noexcept
-    requires has_type<T> && detail::_brace_constructible<T, decltype(args)...>
+    requires has_type<T> && detail::_initializable<T, decltype(args)...>
       : _impl(d, FWD(args)...)
   {
   }

--- a/include/fn/detail/pack_impl.hpp
+++ b/include/fn/detail/pack_impl.hpp
@@ -21,6 +21,20 @@ template <::std::size_t I, typename T> struct _element {
   T v; // NOSONAR cpp:S6226 MSVC ignores the attribute
 };
 
+// Initializes one element. A reference element is spelled as a cast rather than `T{arg}`: the two
+// are the same thing ([expr.type.conv]/1.3 defines the latter as direct-initializing an invented
+// variable of type T, and [dcl.init.list]/3.9 initializes a reference from a single element whose
+// type is reference-related to it, i.e. binds), but gcc reads the braced form as materializing a
+// temporary and rejects the bind - while accepting the equivalent declaration. The cast keeps both
+// compilers on the binding path.
+template <typename T> [[nodiscard]] constexpr auto _make_element(auto &&...args) -> T
+{
+  if constexpr (::std::is_reference_v<T>)
+    return T(FWD(args)...); // a single argument, so this is a cast expression: it binds
+  else
+    return T{FWD(args)...};
+}
+
 template <typename, typename... Ts> struct pack_impl;
 
 template <typename... Ts> struct _pack_append;
@@ -88,7 +102,8 @@ struct pack_impl<::std::index_sequence<Is...>, Ts...> : _element<Is, Ts>... {
       -> pack_impl<::std::index_sequence<Is..., size>, Ts..., T>
     requires(not _some_sum<T>) && (not _some_pack<T>) && _initializable<T, decltype(args)...>
   {
-    return {static_cast<apply_const_lvalue_t<Self, Ts &&>>(FWD(self)._element<Is, Ts>::v)..., T{FWD(args)...}};
+    return {static_cast<apply_const_lvalue_t<Self, Ts &&>>(FWD(self)._element<Is, Ts>::v)...,
+            _make_element<T>(FWD(args)...)};
   }
 
   template <typename T, typename Self>

--- a/include/fn/detail/pack_impl.hpp
+++ b/include/fn/detail/pack_impl.hpp
@@ -86,7 +86,7 @@ struct pack_impl<::std::index_sequence<Is...>, Ts...> : _element<Is, Ts>... {
   template <typename T, typename Self>
   static constexpr auto _append(Self &&self, auto &&...args) noexcept //
       -> pack_impl<::std::index_sequence<Is..., size>, Ts..., T>
-    requires(not _some_sum<T>) && (not _some_pack<T>) && ::std::is_constructible_v<T, decltype(args)...>
+    requires(not _some_sum<T>) && (not _some_pack<T>) && _initializable<T, decltype(args)...>
   {
     return {static_cast<apply_const_lvalue_t<Self, Ts &&>>(FWD(self)._element<Is, Ts>::v)..., T{FWD(args)...}};
   }

--- a/include/fn/detail/traits.hpp
+++ b/include/fn/detail/traits.hpp
@@ -11,12 +11,16 @@
 
 namespace fn::detail {
 
-// The storage constructs an element as `T{args...}`, so a constraint on that construction must ask
-// the same question: `is_constructible_v` spells parenthesized initialization, which for an
-// aggregate performs no brace elision (`std::array<int, 3>` is not "constructible" from 3 ints) and
-// permits narrowing where brace initialization rejects it.
+// The storage initializes an element as `T{args...}`, so a constraint on it must ask the same
+// question: `is_constructible_v` spells parenthesized initialization, which for an aggregate
+// performs no brace elision (`std::array<int, 3>` is not "constructible" from 3 ints) and permits
+// narrowing where brace initialization rejects it. A reference element is not brace-initialized but
+// bound, and `T{...}` for a reference `T` is not even a portable question to ask (gcc rejects it,
+// clang accepts) - so that leg asks about the binding instead.
 template <typename T, typename... Args>
-concept _brace_constructible = requires { T{::std::declval<Args>()...}; };
+concept _initializable                                                    //
+    = (::std::is_reference_v<T> && ::std::is_constructible_v<T, Args...>) //
+      || ((not ::std::is_reference_v<T>) && requires { T{::std::declval<Args>()...}; });
 
 // Change any rvalue or empty value to prvalue, but leave lvalues unchanged.
 // This is meant to find the type of data members which won't bind to rvalues.

--- a/include/fn/detail/traits.hpp
+++ b/include/fn/detail/traits.hpp
@@ -7,8 +7,16 @@
 #define INCLUDE_FN_DETAIL_TRAITS
 
 #include <type_traits>
+#include <utility>
 
 namespace fn::detail {
+
+// The storage constructs an element as `T{args...}`, so a constraint on that construction must ask
+// the same question: `is_constructible_v` spells parenthesized initialization, which for an
+// aggregate performs no brace elision (`std::array<int, 3>` is not "constructible" from 3 ints) and
+// permits narrowing where brace initialization rejects it.
+template <typename T, typename... Args>
+concept _brace_constructible = requires { T{::std::declval<Args>()...}; };
 
 // Change any rvalue or empty value to prvalue, but leave lvalues unchanged.
 // This is meant to find the type of data members which won't bind to rvalues.

--- a/include/fn/pack.hpp
+++ b/include/fn/pack.hpp
@@ -46,7 +46,7 @@ template <typename... Ts> struct pack : detail::pack_impl<::std::index_sequence_
    */
   template <typename T>
   [[nodiscard]] constexpr auto append(::std::in_place_type_t<T>, auto &&...args) & noexcept -> append_type<T>
-    requires ::std::is_constructible_v<T, decltype(args)...>
+    requires detail::_initializable<T, decltype(args)...>
              && requires { append_type<T>{_impl::template _append<T>(*this, FWD(args)...)}; }
   {
     return {_impl::template _append<T>(*this, FWD(args)...)};
@@ -61,7 +61,7 @@ template <typename... Ts> struct pack : detail::pack_impl<::std::index_sequence_
    */
   template <typename T>
   [[nodiscard]] constexpr auto append(::std::in_place_type_t<T>, auto &&...args) const & noexcept -> append_type<T>
-    requires ::std::is_constructible_v<T, decltype(args)...>
+    requires detail::_initializable<T, decltype(args)...>
              && requires { append_type<T>{_impl::template _append<T>(*this, FWD(args)...)}; }
   {
     return {_impl::template _append<T>(*this, FWD(args)...)};
@@ -76,7 +76,7 @@ template <typename... Ts> struct pack : detail::pack_impl<::std::index_sequence_
    */
   template <typename T>
   [[nodiscard]] constexpr auto append(::std::in_place_type_t<T>, auto &&...args) && noexcept -> append_type<T>
-    requires ::std::is_constructible_v<T, decltype(args)...>
+    requires detail::_initializable<T, decltype(args)...>
              && requires { append_type<T>{_impl::template _append<T>(::std::move(*this), FWD(args)...)}; }
   {
     return {_impl::template _append<T>(::std::move(*this), FWD(args)...)};
@@ -91,7 +91,7 @@ template <typename... Ts> struct pack : detail::pack_impl<::std::index_sequence_
    */
   template <typename T>
   [[nodiscard]] constexpr auto append(::std::in_place_type_t<T>, auto &&...args) const && noexcept -> append_type<T>
-    requires ::std::is_constructible_v<T, decltype(args)...>
+    requires detail::_initializable<T, decltype(args)...>
              && requires { append_type<T>{_impl::template _append<T>(::std::move(*this), FWD(args)...)}; }
   {
     return {_impl::template _append<T>(::std::move(*this), FWD(args)...)};

--- a/include/fn/sum.hpp
+++ b/include/fn/sum.hpp
@@ -244,7 +244,7 @@ struct sum<Ts...> {
    */
   template <typename T>
   constexpr explicit sum(::std::in_place_type_t<T>, auto &&...args)
-    requires has_type<T>
+    requires has_type<T> && detail::_brace_constructible<T, decltype(args)...>
       : data(detail::make_variadic_union<T, data_t>(FWD(args)...)), index(detail::type_index<T, Ts...>)
   {
   }
@@ -616,6 +616,7 @@ template <typename T> explicit sum(T) -> sum<::std::remove_cvref_t<T>>;
  * @return TODO
  */
 [[nodiscard]] constexpr auto as_sum(auto &&src) -> decltype(auto)
+  requires(not some_in_place_type<decltype(src)>)
 {
   return sum<::std::remove_cvref_t<decltype(src)>>(FWD(src));
 }
@@ -626,7 +627,9 @@ template <typename T> explicit sum(T) -> sum<::std::remove_cvref_t<T>>;
  * @param src TODO
  * @return TODO
  */
-template <typename T> [[nodiscard]] constexpr auto as_sum(::std::in_place_type_t<T>, auto &&...args) -> decltype(auto)
+template <typename T>
+[[nodiscard]] constexpr auto as_sum(::std::in_place_type_t<T>, auto &&...args) -> decltype(auto)
+  requires detail::_brace_constructible<T, decltype(args)...>
 {
   return sum<T>(::std::in_place_type<T>, FWD(args)...);
 }

--- a/include/fn/sum.hpp
+++ b/include/fn/sum.hpp
@@ -244,7 +244,7 @@ struct sum<Ts...> {
    */
   template <typename T>
   constexpr explicit sum(::std::in_place_type_t<T>, auto &&...args)
-    requires has_type<T> && detail::_brace_constructible<T, decltype(args)...>
+    requires has_type<T> && detail::_initializable<T, decltype(args)...>
       : data(detail::make_variadic_union<T, data_t>(FWD(args)...)), index(detail::type_index<T, Ts...>)
   {
   }
@@ -629,7 +629,7 @@ template <typename T> explicit sum(T) -> sum<::std::remove_cvref_t<T>>;
  */
 template <typename T>
 [[nodiscard]] constexpr auto as_sum(::std::in_place_type_t<T>, auto &&...args) -> decltype(auto)
-  requires detail::_brace_constructible<T, decltype(args)...>
+  requires detail::_initializable<T, decltype(args)...>
 {
   return sum<T>(::std::in_place_type<T>, FWD(args)...);
 }

--- a/tests/fn/choice.cpp
+++ b/tests/fn/choice.cpp
@@ -30,6 +30,9 @@ struct NonCopyable final {
   NonCopyable &operator=(NonCopyable const &) = delete;
 };
 
+template <typename S, typename T, typename... Args>
+concept can_in_place = requires(Args... args) { S{std::in_place_type<T>, args...}; };
+
 } // anonymous namespace
 
 TEST_CASE("choice non-monadic functionality", "[choice]")
@@ -341,6 +344,17 @@ TEST_CASE("choice non-monadic functionality", "[choice]")
 
       auto b = choice{std::in_place_type<NonCopyable>, 42};
       static_assert(std::is_same_v<decltype(b), choice<NonCopyable>>);
+    }
+
+    WHEN("constraints")
+    {
+      static_assert(can_in_place<choice<NonCopyable>, NonCopyable, int>);
+      static_assert(not can_in_place<choice<NonCopyable>, int, int>); // int is not an alternative
+
+      // the constructor forwards to sum's, and rejects what sum rejects
+      static_assert(not can_in_place<choice<NonCopyable>, NonCopyable>);               // no default ctor
+      static_assert(not can_in_place<choice<NonCopyable>, NonCopyable, char const *>); // not constructible from
+      SUCCEED();
     }
   }
 

--- a/tests/fn/pack.cpp
+++ b/tests/fn/pack.cpp
@@ -229,6 +229,37 @@ TEST_CASE("append value categories", "[pack][append]")
     CHECK(std::move(s).append(B{30}).invoke(check));
   }
 
+  WHEN("reference element")
+  {
+    // Evaluated, not merely decltype'd: a reference element must BIND to the argument, and the
+    // element-initializing expression is only instantiated when the call is actually made
+    C c{};
+    auto q = s.append(std::in_place_type<B &>, c);
+    static_assert(std::same_as<decltype(q), T::append_type<B &>>);
+    CHECK(q.invoke([&c](int, std::string_view, A, B &b) { return &b == static_cast<B *>(&c); }));
+
+    auto r = s.append(c); // deduced, so the element type is C &
+    static_assert(std::same_as<decltype(r), T::append_type<C &>>);
+    CHECK(r.invoke([&c](int, std::string_view, A, C &x) { return &x == &c; }));
+
+    c.v = 77; // the same object, observed through both packs
+    CHECK(q.invoke([](int, std::string_view, A, B &b) { return b.v == 77; }));
+    CHECK(r.invoke([](int, std::string_view, A, C &x) { return x.v == 77; }));
+
+    WHEN("constexpr")
+    {
+      static_assert([] {
+        fn::pack<int> p{1};
+        B b{5, 6};
+        auto q = p.append(std::in_place_type<B &>, b);
+        auto r = p.append(b);
+        b.v = 9;
+        return q.invoke([](int, B &x) { return x.v == 9; }) && r.invoke([](int, B &x) { return x.v == 9; });
+      }());
+      SUCCEED();
+    }
+  }
+
   WHEN("pack on the right side, deduced")
   {
     constexpr fn::pack<bool, int, B> a{true, 3, B{14}};

--- a/tests/fn/pack.cpp
+++ b/tests/fn/pack.cpp
@@ -12,6 +12,7 @@
 
 #include <catch2/catch_all.hpp>
 
+#include <array>
 #include <tuple>
 #include <utility>
 
@@ -250,6 +251,12 @@ TEST_CASE("append value categories", "[pack][append]")
     static_assert(can_append_in_place<T &, B, int>);
     static_assert(can_append_in_place<T &, B, int, int>);
     static_assert(not can_append_in_place<T &, B, char const *>); // B is not constructible from it
+
+    // the element is brace-initialized, so an aggregate is appended element-wise, exactly as `sum`
+    // constructs one - a constraint spelled with is_constructible_v would reject this
+    static_assert(can_append_in_place<T &, std::array<int, 3>, int, int, int>);
+    static_assert(not can_append_in_place<T &, std::array<int, 3>, int, int, int, int>); // one too many
+    static_assert(not can_append_in_place<T &, int, double>);                            // narrowing
 
     // in_place_type selects the element type, it is never itself an element: with no arguments and
     // no default constructor there is nothing to construct, and the deduced-Arg overload must not

--- a/tests/fn/sum.cpp
+++ b/tests/fn/sum.cpp
@@ -39,6 +39,15 @@ template <fn::some_sum auto S> auto read_nttp()
 {
   return S.invoke([](auto const &...args) { return (0.0 + ... + static_cast<double>(args)); });
 }
+
+template <typename S, typename T, typename... Args>
+concept can_in_place = requires(Args... args) { S{std::in_place_type<T>, args...}; };
+
+template <typename T, typename... Args>
+concept can_as_sum = requires(Args... args) { fn::as_sum(std::in_place_type<T>, args...); };
+
+template <typename T>
+concept can_as_sum_value = requires(T v) { fn::as_sum(FWD(v)); };
 } // anonymous namespace
 
 TEST_CASE("sum basic functionality tests", "[sum]")
@@ -63,6 +72,20 @@ TEST_CASE("sum basic functionality tests", "[sum]")
     constexpr auto b = fn::as_sum(std::in_place_type<long>, 12);
     static_assert(std::same_as<decltype(b), fn::sum<long> const>);
     static_assert(b == fn::sum{12l});
+
+    WHEN("constraints")
+    {
+      static_assert(can_as_sum<long, int>);
+      static_assert(can_as_sum<std::array<int, 3>, int, int, int>); // an aggregate, brace-initialized
+      static_assert(not can_as_sum<NonCopyable>);                   // no default constructor
+      static_assert(not can_as_sum<NonCopyable, char const *>);     // not constructible from it
+
+      // the tag selects the alternative, it is never itself one: with nothing to construct there is
+      // no viable lift at all, rather than a sum whose alternative is the tag
+      static_assert(not can_as_sum_value<std::in_place_type_t<NonCopyable> const &>);
+      static_assert(can_as_sum_value<long>);
+      SUCCEED();
+    }
   }
 
   WHEN("sum_for")
@@ -207,10 +230,33 @@ TEST_CASE("sum basic functionality tests", "[sum]")
       auto b = sum{std::in_place_type<NonCopyable>, 42};
       static_assert(std::is_same_v<decltype(b), sum<NonCopyable>>);
     }
+
+    WHEN("constraints")
+    {
+      static_assert(can_in_place<sum<NonCopyable>, NonCopyable, int>);
+      static_assert(not can_in_place<sum<NonCopyable>, int, int>); // int is not an alternative
+
+      // an argument list the alternative cannot be constructed from is not viable - viability must
+      // answer here, not fail to compile inside variadic_union, beyond SFINAE's reach
+      static_assert(not can_in_place<sum<NonCopyable>, NonCopyable>);               // no default ctor
+      static_assert(not can_in_place<sum<NonCopyable>, NonCopyable, char const *>); // not constructible from
+      SUCCEED();
+    }
   }
 
   WHEN("forwarding constructors (aggregate)")
   {
+    WHEN("constraints")
+    {
+      using T = std::array<int, 3>;
+      // the element is brace-initialized, which elides braces for an aggregate - a constraint
+      // spelled with is_constructible_v (parenthesized init) would reject this very construction
+      static_assert(can_in_place<sum<T>, T, int, int, int>);
+      static_assert(not can_in_place<sum<T>, T, int, int, int, int>); // one too many
+      static_assert(not can_in_place<sum<int>, int, double>);         // narrowing, rejected by braces
+      SUCCEED();
+    }
+
     WHEN("regular")
     {
       sum<std::array<int, 3>> a{std::in_place_type<std::array<int, 3>>, 1, 2, 3};


### PR DESCRIPTION
Three interdependent fixes to the question "can this element be constructed": the brace-initializability trait is introduced for `sum` and `choice`, adopted and renamed for `pack`, and `pack`'s reference elements are bound to match.

### Constrain `in_place_type` construction of `sum` and `choice` on the argument list

The constructors checked only `has_type<T>`, so any argument list was reported viable and a bad one then failed to compile inside `variadic_union`, outside the immediate context. They now also require that the alternative can be constructed from the arguments, as `pack::append` already did; `choice`'s constructor forwards to `sum`'s and shared the gap.

The conjunct is brace-initializability, not `is_constructible_v`: the storage constructs the element as `T{args...}`, which elides braces for an aggregate (`std::array<int, 3>` is not `is_constructible_v` from three ints, yet its forwarding construction is supported and tested) and rejects narrowing.

`as_sum` gets the same conjunct on its `in_place_type` overload, and the guard `as_pack` already carried on its value lift - without it, a tag whose type is not default-constructible fell through to the value overload and was wrapped as an alternative.

### Ask of a `pack` element the same question its initialization answers

`append` constrained on `is_constructible_v` while `_append` brace-initializes the element, so an aggregate could not be appended element-wise (`std::array<int, 3>` is not `is_constructible_v` from three ints) though `sum` constructs exactly that, and a narrowing argument list was admitted for the body to reject. Both now use the constraint introduced for `sum`, which asks about the initialization actually performed.

That constraint grows a reference leg in the process: a reference element is bound, not brace-initialized, and `T{...}` for a reference `T` is not a portable question - gcc rejects it, clang accepts - so it must be spelled as the binding it is. Renamed `_brace_constructible` to `_initializable` accordingly.

### Bind a reference `pack` element instead of brace-initializing it

`_append` built every element as `T{FWD(args)...}`. For a reference `T` that is a bind ([expr.type.conv]/1.3 defines it as direct-initializing an invented variable of type T, and [dcl.init.list]/3.9 initializes a reference from a single element whose type is reference-related to it), but gcc reads the braced functional-cast form as materializing a temporary and rejects the binding - while accepting the equivalent declaration. So appending an lvalue, which deduces a reference element, did not compile on gcc at all.

It went unnoticed because every test of such an append only took `decltype(...)` of the call, never instantiating the body. The new tests evaluate it, and assert the element binds - address identity, and mutation observed through the pack - with a constexpr twin.

Closes #284
Closes #287

---
**Stack**: P2 of 13 — the release-0.1 bugfix queue, merging bottom-up into `main`. Based on #295 and to be retargeted to `main` once it merges; the diff shows only this PR's commits. Every stack boundary was validated with a gcc build and the full test suite on top of `main`, and the aggregate branch ran the full CI matrix green (#289).
