### PR TITLE
Give `sum_value` and `sum_error` a `noexcept` specification

### DIFF
--- a/include/fn/expected.hpp
+++ b/include/fn/expected.hpp
@@ -634,9 +634,9 @@ public:
 
   // Convert to graded monad. A lifting overload wraps one side in a sum and relocates the other
   // untouched, so it weighs both; the ones whose side already is a sum only return *this.
-  auto sum_error() const & noexcept(::std::is_nothrow_constructible_v<value_type, value_type const &>
-                                    && ::std::is_nothrow_constructible_v<sum<error_type>, error_type const &>
-                                    && ::std::is_nothrow_move_constructible_v<sum<error_type>>) // extension
+  constexpr auto sum_error() const & noexcept(::std::is_nothrow_constructible_v<value_type, value_type const &>
+                                              && ::std::is_nothrow_constructible_v<sum<error_type>, error_type const &>
+                                              && ::std::is_nothrow_move_constructible_v<sum<error_type>>) // extension
       -> expected<value_type, sum<error_type>>
     requires(not some_sum<error_type>)
   {
@@ -646,9 +646,9 @@ public:
     else
       return type{::fn::unexpect, sum<error_type>(this->error())};
   }
-  auto sum_error() && noexcept(::std::is_nothrow_constructible_v<value_type, value_type>
-                               && ::std::is_nothrow_constructible_v<sum<error_type>, error_type>
-                               && ::std::is_nothrow_move_constructible_v<sum<error_type>>) // extension
+  constexpr auto sum_error() && noexcept(::std::is_nothrow_constructible_v<value_type, value_type>
+                                         && ::std::is_nothrow_constructible_v<sum<error_type>, error_type>
+                                         && ::std::is_nothrow_move_constructible_v<sum<error_type>>) // extension
       -> expected<value_type, sum<error_type>>
     requires(not some_sum<error_type>)
   {
@@ -658,30 +658,31 @@ public:
     else
       return type{::fn::unexpect, sum<error_type>(::std::move(*this).error())};
   }
-  auto sum_error() & noexcept -> decltype(auto)
+  constexpr auto sum_error() & noexcept -> decltype(auto)
     requires(some_sum<error_type>)
   {
     return *this;
   }
-  auto sum_error() const & noexcept -> decltype(auto)
+  constexpr auto sum_error() const & noexcept -> decltype(auto)
     requires(some_sum<error_type>)
   {
     return *this;
   }
-  auto sum_error() && noexcept -> decltype(auto)
+  constexpr auto sum_error() && noexcept -> decltype(auto)
     requires(some_sum<error_type>)
   {
     return ::std::move(*this);
   }
-  auto sum_error() const && noexcept -> decltype(auto)
+  constexpr auto sum_error() const && noexcept -> decltype(auto)
     requires(some_sum<error_type>)
   {
     return ::std::move(*this);
   }
 
-  auto sum_value() const & noexcept(::std::is_nothrow_constructible_v<sum<value_type>, value_type const &>
-                                    && ::std::is_nothrow_move_constructible_v<sum<value_type>>
-                                    && ::std::is_nothrow_constructible_v<error_type, error_type const &>) // extension
+  constexpr auto
+  sum_value() const & noexcept(::std::is_nothrow_constructible_v<sum<value_type>, value_type const &>
+                               && ::std::is_nothrow_move_constructible_v<sum<value_type>>
+                               && ::std::is_nothrow_constructible_v<error_type, error_type const &>) // extension
       -> expected<sum<value_type>, error_type>
     requires(not some_sum<value_type>)
   {
@@ -691,9 +692,9 @@ public:
     else
       return type{::fn::unexpect, this->error()};
   }
-  auto sum_value() && noexcept(::std::is_nothrow_constructible_v<sum<value_type>, value_type>
-                               && ::std::is_nothrow_move_constructible_v<sum<value_type>>
-                               && ::std::is_nothrow_constructible_v<error_type, error_type>) // extension
+  constexpr auto sum_value() && noexcept(::std::is_nothrow_constructible_v<sum<value_type>, value_type>
+                                         && ::std::is_nothrow_move_constructible_v<sum<value_type>>
+                                         && ::std::is_nothrow_constructible_v<error_type, error_type>) // extension
       -> expected<sum<value_type>, error_type>
     requires(not some_sum<value_type>)
   {
@@ -703,22 +704,22 @@ public:
     else
       return type{::fn::unexpect, ::std::move(*this).error()};
   }
-  auto sum_value() & noexcept -> decltype(auto)
+  constexpr auto sum_value() & noexcept -> decltype(auto)
     requires(some_sum<value_type>)
   {
     return *this;
   }
-  auto sum_value() const & noexcept -> decltype(auto)
+  constexpr auto sum_value() const & noexcept -> decltype(auto)
     requires(some_sum<value_type>)
   {
     return *this;
   }
-  auto sum_value() && noexcept -> decltype(auto)
+  constexpr auto sum_value() && noexcept -> decltype(auto)
     requires(some_sum<value_type>)
   {
     return ::std::move(*this);
   }
-  auto sum_value() const && noexcept -> decltype(auto)
+  constexpr auto sum_value() const && noexcept -> decltype(auto)
     requires(some_sum<value_type>)
   {
     return ::std::move(*this);
@@ -985,8 +986,8 @@ public:
   }
 
   // Convert to graded monad. There is no value to relocate here, so only the error's lift weighs.
-  auto sum_error() const & noexcept(::std::is_nothrow_constructible_v<sum<error_type>, error_type const &>
-                                    && ::std::is_nothrow_move_constructible_v<sum<error_type>>) // extension
+  constexpr auto sum_error() const & noexcept(::std::is_nothrow_constructible_v<sum<error_type>, error_type const &>
+                                              && ::std::is_nothrow_move_constructible_v<sum<error_type>>) // extension
       -> expected<value_type, sum<error_type>>
     requires(not some_sum<error_type>)
   {
@@ -996,8 +997,8 @@ public:
     else
       return type{::fn::unexpect, sum<error_type>(this->error())};
   }
-  auto sum_error() && noexcept(::std::is_nothrow_constructible_v<sum<error_type>, error_type>
-                               && ::std::is_nothrow_move_constructible_v<sum<error_type>>) // extension
+  constexpr auto sum_error() && noexcept(::std::is_nothrow_constructible_v<sum<error_type>, error_type>
+                                         && ::std::is_nothrow_move_constructible_v<sum<error_type>>) // extension
       -> expected<value_type, sum<error_type>>
     requires(not some_sum<error_type>)
   {
@@ -1007,22 +1008,22 @@ public:
     else
       return type{::fn::unexpect, sum<error_type>(::std::move(*this).error())};
   }
-  auto sum_error() & noexcept -> decltype(auto)
+  constexpr auto sum_error() & noexcept -> decltype(auto)
     requires(some_sum<error_type>)
   {
     return *this;
   }
-  auto sum_error() const & noexcept -> decltype(auto)
+  constexpr auto sum_error() const & noexcept -> decltype(auto)
     requires(some_sum<error_type>)
   {
     return *this;
   }
-  auto sum_error() && noexcept -> decltype(auto)
+  constexpr auto sum_error() && noexcept -> decltype(auto)
     requires(some_sum<error_type>)
   {
     return ::std::move(*this);
   }
-  auto sum_error() const && noexcept -> decltype(auto)
+  constexpr auto sum_error() const && noexcept -> decltype(auto)
     requires(some_sum<error_type>)
   {
     return ::std::move(*this);

--- a/include/fn/expected.hpp
+++ b/include/fn/expected.hpp
@@ -632,8 +632,12 @@ public:
     return _base::_transform_error(::std::move(*this), FWD(f));
   }
 
-  // Convert to graded monad
-  auto sum_error() const & -> expected<value_type, sum<error_type>>
+  // Convert to graded monad. A lifting overload wraps one side in a sum and relocates the other
+  // untouched, so it weighs both; the ones whose side already is a sum only return *this.
+  auto sum_error() const & noexcept(::std::is_nothrow_constructible_v<value_type, value_type const &>
+                                    && ::std::is_nothrow_constructible_v<sum<error_type>, error_type const &>
+                                    && ::std::is_nothrow_move_constructible_v<sum<error_type>>) // extension
+      -> expected<value_type, sum<error_type>>
     requires(not some_sum<error_type>)
   {
     using type = expected<value_type, sum<error_type>>;
@@ -642,7 +646,10 @@ public:
     else
       return type{::fn::unexpect, sum<error_type>(this->error())};
   }
-  auto sum_error() && -> expected<value_type, sum<error_type>>
+  auto sum_error() && noexcept(::std::is_nothrow_constructible_v<value_type, value_type>
+                               && ::std::is_nothrow_constructible_v<sum<error_type>, error_type>
+                               && ::std::is_nothrow_move_constructible_v<sum<error_type>>) // extension
+      -> expected<value_type, sum<error_type>>
     requires(not some_sum<error_type>)
   {
     using type = expected<value_type, sum<error_type>>;
@@ -651,28 +658,31 @@ public:
     else
       return type{::fn::unexpect, sum<error_type>(::std::move(*this).error())};
   }
-  auto sum_error() & -> decltype(auto)
+  auto sum_error() & noexcept -> decltype(auto)
     requires(some_sum<error_type>)
   {
     return *this;
   }
-  auto sum_error() const & -> decltype(auto)
+  auto sum_error() const & noexcept -> decltype(auto)
     requires(some_sum<error_type>)
   {
     return *this;
   }
-  auto sum_error() && -> decltype(auto)
+  auto sum_error() && noexcept -> decltype(auto)
     requires(some_sum<error_type>)
   {
     return ::std::move(*this);
   }
-  auto sum_error() const && -> decltype(auto)
+  auto sum_error() const && noexcept -> decltype(auto)
     requires(some_sum<error_type>)
   {
     return ::std::move(*this);
   }
 
-  auto sum_value() const & -> expected<sum<value_type>, error_type>
+  auto sum_value() const & noexcept(::std::is_nothrow_constructible_v<sum<value_type>, value_type const &>
+                                    && ::std::is_nothrow_move_constructible_v<sum<value_type>>
+                                    && ::std::is_nothrow_constructible_v<error_type, error_type const &>) // extension
+      -> expected<sum<value_type>, error_type>
     requires(not some_sum<value_type>)
   {
     using type = expected<sum<value_type>, error_type>;
@@ -681,7 +691,10 @@ public:
     else
       return type{::fn::unexpect, this->error()};
   }
-  auto sum_value() && -> expected<sum<value_type>, error_type>
+  auto sum_value() && noexcept(::std::is_nothrow_constructible_v<sum<value_type>, value_type>
+                               && ::std::is_nothrow_move_constructible_v<sum<value_type>>
+                               && ::std::is_nothrow_constructible_v<error_type, error_type>) // extension
+      -> expected<sum<value_type>, error_type>
     requires(not some_sum<value_type>)
   {
     using type = expected<sum<value_type>, error_type>;
@@ -690,22 +703,22 @@ public:
     else
       return type{::fn::unexpect, ::std::move(*this).error()};
   }
-  auto sum_value() & -> decltype(auto)
+  auto sum_value() & noexcept -> decltype(auto)
     requires(some_sum<value_type>)
   {
     return *this;
   }
-  auto sum_value() const & -> decltype(auto)
+  auto sum_value() const & noexcept -> decltype(auto)
     requires(some_sum<value_type>)
   {
     return *this;
   }
-  auto sum_value() && -> decltype(auto)
+  auto sum_value() && noexcept -> decltype(auto)
     requires(some_sum<value_type>)
   {
     return ::std::move(*this);
   }
-  auto sum_value() const && -> decltype(auto)
+  auto sum_value() const && noexcept -> decltype(auto)
     requires(some_sum<value_type>)
   {
     return ::std::move(*this);
@@ -971,8 +984,10 @@ public:
     return _base::_transform_error(::std::move(*this), FWD(f));
   }
 
-  // Convert to graded monad
-  auto sum_error() const & -> expected<value_type, sum<error_type>>
+  // Convert to graded monad. There is no value to relocate here, so only the error's lift weighs.
+  auto sum_error() const & noexcept(::std::is_nothrow_constructible_v<sum<error_type>, error_type const &>
+                                    && ::std::is_nothrow_move_constructible_v<sum<error_type>>) // extension
+      -> expected<value_type, sum<error_type>>
     requires(not some_sum<error_type>)
   {
     using type = expected<value_type, sum<error_type>>;
@@ -981,7 +996,9 @@ public:
     else
       return type{::fn::unexpect, sum<error_type>(this->error())};
   }
-  auto sum_error() && -> expected<value_type, sum<error_type>>
+  auto sum_error() && noexcept(::std::is_nothrow_constructible_v<sum<error_type>, error_type>
+                               && ::std::is_nothrow_move_constructible_v<sum<error_type>>) // extension
+      -> expected<value_type, sum<error_type>>
     requires(not some_sum<error_type>)
   {
     using type = expected<value_type, sum<error_type>>;
@@ -990,22 +1007,22 @@ public:
     else
       return type{::fn::unexpect, sum<error_type>(::std::move(*this).error())};
   }
-  auto sum_error() & -> decltype(auto)
+  auto sum_error() & noexcept -> decltype(auto)
     requires(some_sum<error_type>)
   {
     return *this;
   }
-  auto sum_error() const & -> decltype(auto)
+  auto sum_error() const & noexcept -> decltype(auto)
     requires(some_sum<error_type>)
   {
     return *this;
   }
-  auto sum_error() && -> decltype(auto)
+  auto sum_error() && noexcept -> decltype(auto)
     requires(some_sum<error_type>)
   {
     return ::std::move(*this);
   }
-  auto sum_error() const && -> decltype(auto)
+  auto sum_error() const && noexcept -> decltype(auto)
     requires(some_sum<error_type>)
   {
     return ::std::move(*this);
@@ -1022,11 +1039,16 @@ private:
   }
 };
 // Lifts for sum transformation functions
-[[nodiscard]] constexpr auto sum_value(some_expected_non_void auto &&src) -> decltype(auto)
+[[nodiscard]] constexpr auto sum_value(some_expected_non_void auto &&src) noexcept(noexcept(FWD(src).sum_value()))
+    -> decltype(auto)
 {
   return FWD(src).sum_value();
 }
-[[nodiscard]] constexpr auto sum_error(some_expected auto &&src) -> decltype(auto) { return FWD(src).sum_error(); }
+[[nodiscard]] constexpr auto sum_error(some_expected auto &&src) noexcept(noexcept(FWD(src).sum_error()))
+    -> decltype(auto)
+{
+  return FWD(src).sum_error();
+}
 
 // When any of the sides is expected<void, ...>, we do not produce expected<pack<...>, ...>
 // Instead just elide void and carry non-void (or elide both voids if that's what we get)

--- a/include/fn/optional.hpp
+++ b/include/fn/optional.hpp
@@ -477,8 +477,11 @@ public:
     return _base::_transform(::std::move(*this), FWD(f));
   }
 
-  // Convert to graded monad
-  auto sum_value() const & -> optional<sum<value_type>>
+  // Convert to graded monad. The lifting overloads wrap the value in a sum and that sum in the
+  // result, so they weigh both; the ones whose value type already is a sum only return *this.
+  auto sum_value() const & noexcept(::std::is_nothrow_constructible_v<sum<value_type>, value_type const &>
+                                    && ::std::is_nothrow_move_constructible_v<sum<value_type>>) // extension
+      -> optional<sum<value_type>>
     requires(not some_sum<value_type>)
   {
     using type = optional<sum<value_type>>;
@@ -487,7 +490,9 @@ public:
     else
       return type{::std::nullopt};
   }
-  auto sum_value() && -> optional<sum<value_type>>
+  auto sum_value() && noexcept(::std::is_nothrow_constructible_v<sum<value_type>, value_type>
+                               && ::std::is_nothrow_move_constructible_v<sum<value_type>>) // extension
+      -> optional<sum<value_type>>
     requires(not some_sum<value_type>)
   {
     using type = optional<sum<value_type>>;
@@ -496,22 +501,22 @@ public:
     else
       return type{::std::nullopt};
   }
-  auto sum_value() & -> decltype(auto)
+  auto sum_value() & noexcept -> decltype(auto)
     requires(some_sum<value_type>)
   {
     return *this;
   }
-  auto sum_value() const & -> decltype(auto)
+  auto sum_value() const & noexcept -> decltype(auto)
     requires(some_sum<value_type>)
   {
     return *this;
   }
-  auto sum_value() && -> decltype(auto)
+  auto sum_value() && noexcept -> decltype(auto)
     requires(some_sum<value_type>)
   {
     return ::std::move(*this);
   }
-  auto sum_value() const && -> decltype(auto)
+  auto sum_value() const && noexcept -> decltype(auto)
     requires(some_sum<value_type>)
   {
     return ::std::move(*this);
@@ -880,7 +885,11 @@ constexpr optional<T> make_optional(::std::initializer_list<U> il, Args &&...arg
 }
 
 // Lifts for sum transformation functions
-[[nodiscard]] constexpr auto sum_value(some_optional auto &&src) -> decltype(auto) { return FWD(src).sum_value(); }
+[[nodiscard]] constexpr auto sum_value(some_optional auto &&src) noexcept(noexcept(FWD(src).sum_value()))
+    -> decltype(auto)
+{
+  return FWD(src).sum_value();
+}
 
 template <some_optional Lh, some_optional Rh> [[nodiscard]] constexpr auto operator&(Lh &&lh, Rh &&rh) noexcept
 {

--- a/include/fn/optional.hpp
+++ b/include/fn/optional.hpp
@@ -479,8 +479,8 @@ public:
 
   // Convert to graded monad. The lifting overloads wrap the value in a sum and that sum in the
   // result, so they weigh both; the ones whose value type already is a sum only return *this.
-  auto sum_value() const & noexcept(::std::is_nothrow_constructible_v<sum<value_type>, value_type const &>
-                                    && ::std::is_nothrow_move_constructible_v<sum<value_type>>) // extension
+  constexpr auto sum_value() const & noexcept(::std::is_nothrow_constructible_v<sum<value_type>, value_type const &>
+                                              && ::std::is_nothrow_move_constructible_v<sum<value_type>>) // extension
       -> optional<sum<value_type>>
     requires(not some_sum<value_type>)
   {
@@ -490,8 +490,8 @@ public:
     else
       return type{::std::nullopt};
   }
-  auto sum_value() && noexcept(::std::is_nothrow_constructible_v<sum<value_type>, value_type>
-                               && ::std::is_nothrow_move_constructible_v<sum<value_type>>) // extension
+  constexpr auto sum_value() && noexcept(::std::is_nothrow_constructible_v<sum<value_type>, value_type>
+                                         && ::std::is_nothrow_move_constructible_v<sum<value_type>>) // extension
       -> optional<sum<value_type>>
     requires(not some_sum<value_type>)
   {
@@ -501,22 +501,22 @@ public:
     else
       return type{::std::nullopt};
   }
-  auto sum_value() & noexcept -> decltype(auto)
+  constexpr auto sum_value() & noexcept -> decltype(auto)
     requires(some_sum<value_type>)
   {
     return *this;
   }
-  auto sum_value() const & noexcept -> decltype(auto)
+  constexpr auto sum_value() const & noexcept -> decltype(auto)
     requires(some_sum<value_type>)
   {
     return *this;
   }
-  auto sum_value() && noexcept -> decltype(auto)
+  constexpr auto sum_value() && noexcept -> decltype(auto)
     requires(some_sum<value_type>)
   {
     return ::std::move(*this);
   }
-  auto sum_value() const && noexcept -> decltype(auto)
+  constexpr auto sum_value() const && noexcept -> decltype(auto)
     requires(some_sum<value_type>)
   {
     return ::std::move(*this);

--- a/tests/fn/expected.cpp
+++ b/tests/fn/expected.cpp
@@ -232,6 +232,25 @@ TEST_CASE("graded monad", "[expected][sum][graded][and_then][or_else][sum_value]
     static_assert(std::is_same_v<decltype(fn::sum_error(s)), T &>);
   }
 
+  WHEN("constexpr")
+  {
+    static_assert([] {
+      fn::expected<int, Error> const a{::fn::unexpect, Unknown};
+      return a.sum_error().error() == fn::sum{Unknown};
+    }());
+    static_assert([] { return fn::expected<int, Error>{12}.sum_error().value() == 12; }());
+    static_assert([] { return fn::expected<int, Error>{12}.sum_value().value() == fn::sum{12}; }());
+    static_assert([] {
+      fn::expected<void, Error> const a{::fn::unexpect, Unknown};
+      return a.sum_error().error() == fn::sum{Unknown};
+    }());
+    static_assert([] {
+      fn::expected<int, Error> a{12};
+      return fn::sum_value(a).value() == fn::sum{12};
+    }());
+    SUCCEED();
+  }
+
   WHEN("noexcept")
   {
     using S = fn::expected<int, fn::sum<Error>>; // error already a sum

--- a/tests/fn/expected.cpp
+++ b/tests/fn/expected.cpp
@@ -232,6 +232,29 @@ TEST_CASE("graded monad", "[expected][sum][graded][and_then][or_else][sum_value]
     static_assert(std::is_same_v<decltype(fn::sum_error(s)), T &>);
   }
 
+  WHEN("noexcept")
+  {
+    using S = fn::expected<int, fn::sum<Error>>; // error already a sum
+    using V = fn::expected<fn::sum<int>, Error>; // value already a sum
+
+    // the overloads whose side already is a sum only return *this
+    static_assert(noexcept(std::declval<S &>().sum_error()));
+    static_assert(noexcept(std::declval<S const &&>().sum_error()));
+    static_assert(noexcept(std::declval<V &>().sum_value()));
+    static_assert(noexcept(std::declval<V const &&>().sum_value()));
+    static_assert(noexcept(fn::sum_error(std::declval<S &>())));
+    static_assert(noexcept(fn::sum_value(std::declval<V &>())));
+
+    // a lifting overload wraps one side in a sum and relocates the other, so it weighs both. sum's
+    // own value constructor carries no noexcept specifier yet (#280), so these are conservatively
+    // false, and sharpen when it does
+    static_assert(not noexcept(std::declval<fn::expected<int, Error> &>().sum_error()));
+    static_assert(not noexcept(std::declval<fn::expected<int, Error> &&>().sum_value()));
+    static_assert(not noexcept(std::declval<fn::expected<void, Error> &>().sum_error()));
+    static_assert(not noexcept(fn::sum_error(std::declval<fn::expected<int, Error> &>())));
+    SUCCEED();
+  }
+
   WHEN("sum_value from sum")
   {
     using T = fn::expected<fn::sum<int>, Error>;

--- a/tests/fn/optional.cpp
+++ b/tests/fn/optional.cpp
@@ -81,6 +81,27 @@ TEST_CASE("optional graded monad", "[optional][sum][graded][or_else][sum_value]"
     static_assert(std::is_same_v<decltype(fn::sum_value(s)), fn::optional<fn::sum<int>>>);
   }
 
+  WHEN("noexcept")
+  {
+    using T = fn::optional<int>;
+    using S = fn::optional<fn::sum<int>>;
+
+    // the sum-valued overloads only return *this
+    static_assert(noexcept(std::declval<S &>().sum_value()));
+    static_assert(noexcept(std::declval<S const &>().sum_value()));
+    static_assert(noexcept(std::declval<S &&>().sum_value()));
+    static_assert(noexcept(std::declval<S const &&>().sum_value()));
+    static_assert(noexcept(fn::sum_value(std::declval<S &>())));
+
+    // the lifting overloads wrap the value in a sum, so they weigh that construction: sum's own
+    // value constructor carries no noexcept specifier yet (#280), so they are conservatively false
+    // even for int, and sharpen when it does
+    static_assert(not noexcept(std::declval<T &>().sum_value()));
+    static_assert(not noexcept(std::declval<T &&>().sum_value()));
+    static_assert(not noexcept(fn::sum_value(std::declval<T &>())));
+    SUCCEED();
+  }
+
   WHEN("or_else")
   {
     fn::optional<fn::sum<int>> s{std::nullopt};

--- a/tests/fn/optional.cpp
+++ b/tests/fn/optional.cpp
@@ -79,6 +79,21 @@ TEST_CASE("optional graded monad", "[optional][sum][graded][or_else][sum_value]"
     }
 
     static_assert(std::is_same_v<decltype(fn::sum_value(s)), fn::optional<fn::sum<int>>>);
+
+    WHEN("constexpr")
+    {
+      static_assert([] {
+        fn::optional<int> const a{12};
+        return a.sum_value().value() == fn::sum{12};
+      }());
+      static_assert([] { return fn::optional<int>{12}.sum_value().value() == fn::sum{12}; }());
+      static_assert([] { return not fn::optional<int>{std::nullopt}.sum_value().has_value(); }());
+      static_assert([] {
+        fn::optional<int> a{12};
+        return fn::sum_value(a).value() == fn::sum{12};
+      }());
+      SUCCEED();
+    }
   }
 
   WHEN("noexcept")


### PR DESCRIPTION
Both `sum_value` / `sum_error` gaps: the missing `noexcept` specification, and the missing `constexpr`.

### Give `sum_value` and `sum_error` a `noexcept` specification

No overload had one, so a pipeline crossing them lost `noexcept` unnecessarily. The overloads whose side already is a sum return `*this` by reference and cannot throw, so they are unconditionally `noexcept`; the lifting overloads wrap one side in a sum and relocate the other, so they weigh both constructions, and the free functions propagate whatever the member says.

The lifting overloads still report `noexcept(false)` even for trivial types, because `sum`'s own value constructor carries no specifier to derive from (#280) - conservatively correct, and it sharpens when that lands. The tests assert both halves.

### Make `sum_value` and `sum_error` usable in a constant expression

They were the only monadic members not declared `constexpr`, so a constexpr pipeline could not cross the graded lift - and the free functions, though marked `constexpr` themselves, forwarded to them and were equally unusable.

Closes #276

---
**Stack**: P4 of 13 — the release-0.1 bugfix queue, merging bottom-up into `main`. Based on #297 and to be retargeted to `main` once it merges; the diff shows only this PR's commits. Every stack boundary was validated with a gcc build and the full test suite on top of `main`, and the aggregate branch ran the full CI matrix green (#289).
