### PR TITLE
Let C++20 rewriting synthesize `sum`'s `operator!=`

### DIFF
--- a/include/fn/sum.hpp
+++ b/include/fn/sum.hpp
@@ -657,21 +657,8 @@ template <typename... Ts, typename... Tx>
   });
 }
 
-/**
- * @brief TODO
- *
- * @tparam Ts TODO
- * @tparam Tx TODO
- * @param lh TODO
- * @param rh TODO
- * @return TODO
- */
-template <typename... Ts, typename... Tx>
-[[nodiscard]] constexpr bool operator!=(sum<Ts...> const &lh, sum<Tx...> const &rh) noexcept
-  requires(... && (::std::equality_comparable<Ts> || not detail::type_one_of<Ts, Tx...>))
-{
-  return not(lh == rh);
-}
+// No operator!=: C++20 rewrites `a != b` as `!(a == b)`, so the synthesized candidate inherits
+// operator=='s constraints and the two cannot drift apart.
 
 /**
  * @brief TODO

--- a/tests/fn/sum.cpp
+++ b/tests/fn/sum.cpp
@@ -40,6 +40,13 @@ template <fn::some_sum auto S> auto read_nttp()
   return S.invoke([](auto const &...args) { return (0.0 + ... + static_cast<double>(args)); });
 }
 
+// Comparison probes are type-keyed rather than the file's usual value-taking lambda: sum<> has no
+// values to pass one (its default constructor is deleted, by design).
+template <typename L, typename R>
+concept can_eq = requires { std::declval<L const &>() == std::declval<R const &>(); };
+template <typename L, typename R>
+concept can_ne = requires { std::declval<L const &>() != std::declval<R const &>(); };
+
 template <typename S, typename T, typename... Args>
 concept can_in_place = requires(Args... args) { S{std::in_place_type<T>, args...}; };
 
@@ -312,6 +319,15 @@ TEST_CASE("sum basic functionality tests", "[sum]")
   WHEN("equality comparison")
   {
     using type = sum<bool, int>;
+
+    // != is synthesized by C++20 rewriting from ==, so it cannot claim to be viable where == is not.
+    // Against the uninstantiable sum<> both must drop out of overload resolution together
+    static_assert(can_eq<type, type>);
+    static_assert(can_ne<type, type>);
+    static_assert(not can_eq<sum<int>, sum<>>);
+    static_assert(not can_ne<sum<int>, sum<>>);
+    static_assert(not can_eq<sum<>, sum<int>>);
+    static_assert(not can_ne<sum<>, sum<int>>);
 
     type const a{std::in_place_type<int>, 42};
     static_assert(std::is_same_v<bool, decltype(sum{42} == a)>);


### PR DESCRIPTION
The hand-written `operator!=` dropped the arity conjuncts `operator==` carries, so against a `sum<>` operand its constraint was satisfied while `==`'s was not: the call reported itself viable and then failed to compile in its own body, where `not(lh == rh)` found no `operator==`. A constraint that lies.

Deleting it makes `a != b` a rewritten `!(a == b)`, which inherits `operator==`'s constraints by construction, so the two cannot drift apart again.

Closes #281

---
**Stack**: P5 of 13 — the release-0.1 bugfix queue, merging bottom-up into `main`. Based on #298 and to be retargeted to `main` once it merges; the diff shows only this PR's commits. Every stack boundary was validated with a gcc build and the full test suite on top of `main`, and the aggregate branch ran the full CI matrix green (#289).
