### PR TITLE
Compute a real `noexcept` for the `sum`, `pack` and `choice` surface

### DIFF
--- a/include/fn/choice.hpp
+++ b/include/fn/choice.hpp
@@ -57,7 +57,9 @@ struct choice<Ts...> : sum<Ts...> {
    * @tparam Ret TODO
    * @param fn TODO
    */
-  template <typename Ret> [[nodiscard]] constexpr auto _invoke(auto &&fn) const & noexcept
+  template <typename Ret>
+  [[nodiscard]] constexpr auto
+  _invoke(auto &&fn) const & noexcept(detail::_is_nothrow_rtst_invocable<Ret, decltype(fn), choice const &>)
   {
     return detail::invoke_type_variadic_union<Ret, typename _impl::data_t>(this->data, this->index, FWD(fn));
   }
@@ -68,7 +70,9 @@ struct choice<Ts...> : sum<Ts...> {
    * @tparam Ret TODO
    * @param fn TODO
    */
-  template <typename Ret> [[nodiscard]] constexpr auto _invoke(auto &&fn) && noexcept
+  template <typename Ret>
+  [[nodiscard]] constexpr auto
+  _invoke(auto &&fn) && noexcept(detail::_is_nothrow_rtst_invocable<Ret, decltype(fn), choice &&>)
   {
     return detail::invoke_type_variadic_union<Ret, typename _impl::data_t>( //
         ::std::move(*this).data, ::std::move(*this).index, FWD(fn));
@@ -82,6 +86,7 @@ struct choice<Ts...> : sum<Ts...> {
    */
   template <typename T>
   constexpr choice(T &&v) // NOSONAR cpp:S1709,S6458 implicit arm of the explicit pair; has_type excludes self
+      noexcept(detail::_nothrow_initializable<::std::remove_cvref_t<T>, decltype(v)>)
     requires has_type<::std::remove_cvref_t<T>> && (::std::is_constructible_v<::std::remove_cvref_t<T>, decltype(v)>)
              && (::std::is_convertible_v<decltype(v), ::std::remove_cvref_t<T>>)
       : _impl(::std::in_place_type<::std::remove_cvref_t<T>>, FWD(v))
@@ -96,6 +101,7 @@ struct choice<Ts...> : sum<Ts...> {
    */
   template <typename T>
   constexpr explicit choice(T &&v) // NOSONAR cpp:S6458 has_type excludes self
+      noexcept(detail::_nothrow_initializable<::std::remove_cvref_t<T>, decltype(v)>)
     requires has_type<::std::remove_cvref_t<T>> && (::std::is_constructible_v<::std::remove_cvref_t<T>, decltype(v)>)
              && (not ::std::is_convertible_v<decltype(v), ::std::remove_cvref_t<T>>)
       : _impl(::std::in_place_type<::std::remove_cvref_t<T>>, FWD(v))
@@ -110,7 +116,8 @@ struct choice<Ts...> : sum<Ts...> {
    * @param v TODO
    */
   template <typename T>
-  constexpr explicit choice(::std::in_place_type_t<T> d, auto &&...args) noexcept
+  constexpr explicit choice(::std::in_place_type_t<T> d, auto &&...args) //
+      noexcept(detail::_nothrow_initializable<T, decltype(args)...>)
     requires has_type<T> && detail::_initializable<T, decltype(args)...>
       : _impl(d, FWD(args)...)
   {
@@ -123,7 +130,8 @@ struct choice<Ts...> : sum<Ts...> {
    * @param v TODO
    */
   template <typename... Tx>
-  constexpr choice(sum<Tx...> const &v) noexcept // NOSONAR cpp:S1709 implicit widening by design
+  constexpr choice(sum<Tx...> const &v) // NOSONAR cpp:S1709 implicit widening by design
+      noexcept((... && ::std::is_nothrow_copy_constructible_v<Tx>))
     requires detail::is_superset_of<choice, choice<Tx...>> && (... && ::std::is_copy_constructible_v<Tx>)
       : _impl(::std::in_place_type<sum<Tx...>>, FWD(v))
   {
@@ -136,7 +144,8 @@ struct choice<Ts...> : sum<Ts...> {
    * @param v TODO
    */
   template <typename... Tx>
-  constexpr choice(sum<Tx...> &&v) noexcept // NOSONAR cpp:S1709 implicit widening by design
+  constexpr choice(sum<Tx...> &&v) // NOSONAR cpp:S1709 implicit widening by design
+      noexcept((... && ::std::is_nothrow_move_constructible_v<Tx>))
     requires detail::is_superset_of<choice, choice<Tx...>> && (... && ::std::is_move_constructible_v<Tx>)
       : _impl(::std::in_place_type<sum<Tx...>>, FWD(v))
   {
@@ -149,15 +158,16 @@ struct choice<Ts...> : sum<Ts...> {
    * @param v TODO
    */
   template <typename... Tx>
-  constexpr choice(::std::in_place_type_t<sum<Tx...>>, some_sum auto &&v) noexcept
+  constexpr choice(::std::in_place_type_t<sum<Tx...>>, some_sum auto &&v) //
+      noexcept((... && ::std::is_nothrow_constructible_v<Tx, apply_const_lvalue_t<decltype(v), Tx &&>>))
     requires ::std::is_same_v<::std::remove_cvref_t<decltype(v)>, sum<Tx...>>
              && detail::is_superset_of<choice, choice<Tx...>>
       : _impl(::std::in_place_type<sum<Tx...>>, FWD(v))
   {
   }
 
-  constexpr choice(choice const &other) noexcept = default;
-  constexpr choice(choice &&other) noexcept = default;
+  constexpr choice(choice const &other) = default;
+  constexpr choice(choice &&other) = default;
   constexpr ~choice() = default;
 
   /**
@@ -196,7 +206,10 @@ struct choice<Ts...> : sum<Ts...> {
    * @return TODO
    */
   template <typename Fn>
-  [[nodiscard]] constexpr auto invoke(Fn &&fn) & noexcept
+  [[nodiscard]] constexpr auto invoke(Fn &&fn) & noexcept(
+      detail::_is_nothrow_rts_invocable<
+          typename detail::_sum_invoke_result<detail::_invoke_autodetect_tag, decltype(fn), choice &>::type, Fn &&,
+          choice &>)
     requires typelist_invocable<Fn, choice &>
   {
     using type = detail::_sum_invoke_result<detail::_invoke_autodetect_tag, decltype(fn), choice &>::type;
@@ -211,7 +224,10 @@ struct choice<Ts...> : sum<Ts...> {
    * @return TODO
    */
   template <typename Fn>
-  [[nodiscard]] constexpr auto invoke(Fn &&fn) const & noexcept
+  [[nodiscard]] constexpr auto invoke(Fn &&fn) const & noexcept(
+      detail::_is_nothrow_rts_invocable<
+          typename detail::_sum_invoke_result<detail::_invoke_autodetect_tag, decltype(fn), choice const &>::type,
+          Fn &&, choice const &>)
     requires typelist_invocable<Fn, choice const &>
   {
     using type = detail::_sum_invoke_result<detail::_invoke_autodetect_tag, decltype(fn), choice const &>::type;
@@ -226,7 +242,10 @@ struct choice<Ts...> : sum<Ts...> {
    * @return TODO
    */
   template <typename Fn>
-  [[nodiscard]] constexpr auto invoke(Fn &&fn) && noexcept
+  [[nodiscard]] constexpr auto invoke(Fn &&fn) && noexcept(
+      detail::_is_nothrow_rts_invocable<
+          typename detail::_sum_invoke_result<detail::_invoke_autodetect_tag, decltype(fn), choice &&>::type, Fn &&,
+          choice &&>)
     requires typelist_invocable<Fn, choice &&>
   {
     using type = detail::_sum_invoke_result<detail::_invoke_autodetect_tag, decltype(fn), choice &&>::type;
@@ -241,7 +260,10 @@ struct choice<Ts...> : sum<Ts...> {
    * @return TODO
    */
   template <typename Fn>
-  [[nodiscard]] constexpr auto invoke(Fn &&fn) const && noexcept
+  [[nodiscard]] constexpr auto invoke(Fn &&fn) const && noexcept(
+      detail::_is_nothrow_rts_invocable<
+          typename detail::_sum_invoke_result<detail::_invoke_autodetect_tag, decltype(fn), choice const &&>::type,
+          Fn &&, choice const &&>)
     requires typelist_invocable<Fn, choice const &&>
   {
     using type = detail::_sum_invoke_result<detail::_invoke_autodetect_tag, decltype(fn), choice const &&>::type;
@@ -257,7 +279,9 @@ struct choice<Ts...> : sum<Ts...> {
    * @return TODO
    */
   template <typename T, typename Fn>
-  [[nodiscard]] constexpr auto invoke_r(Fn &&fn) & noexcept
+  [[nodiscard]] constexpr auto invoke_r(Fn &&fn) & noexcept(
+      detail::_is_nothrow_rts_invocable<typename detail::_sum_invoke_result<T, decltype(fn), choice &>::type, Fn &&,
+                                        choice &>)
     requires typelist_invocable<Fn, choice &>
   {
     using type = detail::_sum_invoke_result<T, decltype(fn), choice &>::type;
@@ -273,7 +297,9 @@ struct choice<Ts...> : sum<Ts...> {
    * @return TODO
    */
   template <typename T, typename Fn>
-  [[nodiscard]] constexpr auto invoke_r(Fn &&fn) const & noexcept
+  [[nodiscard]] constexpr auto invoke_r(Fn &&fn) const & noexcept(
+      detail::_is_nothrow_rts_invocable<typename detail::_sum_invoke_result<T, decltype(fn), choice const &>::type,
+                                        Fn &&, choice const &>)
     requires typelist_invocable<Fn, choice const &>
   {
     using type = detail::_sum_invoke_result<T, decltype(fn), choice const &>::type;
@@ -289,7 +315,9 @@ struct choice<Ts...> : sum<Ts...> {
    * @return TODO
    */
   template <typename T, typename Fn>
-  [[nodiscard]] constexpr auto invoke_r(Fn &&fn) && noexcept
+  [[nodiscard]] constexpr auto invoke_r(Fn &&fn) && noexcept(
+      detail::_is_nothrow_rts_invocable<typename detail::_sum_invoke_result<T, decltype(fn), choice &&>::type, Fn &&,
+                                        choice &&>)
     requires typelist_invocable<Fn, choice &&>
   {
     using type = detail::_sum_invoke_result<T, decltype(fn), choice &&>::type;
@@ -305,7 +333,9 @@ struct choice<Ts...> : sum<Ts...> {
    * @return TODO
    */
   template <typename T, typename Fn>
-  [[nodiscard]] constexpr auto invoke_r(Fn &&fn) const && noexcept
+  [[nodiscard]] constexpr auto invoke_r(Fn &&fn) const && noexcept(
+      detail::_is_nothrow_rts_invocable<typename detail::_sum_invoke_result<T, decltype(fn), choice const &&>::type,
+                                        Fn &&, choice const &&>)
     requires typelist_invocable<Fn, choice const &&>
   {
     using type = detail::_sum_invoke_result<T, decltype(fn), choice const &&>::type;
@@ -321,7 +351,10 @@ struct choice<Ts...> : sum<Ts...> {
    * @return TODO
    */
   template <typename Fn>
-  [[nodiscard]] constexpr auto transform(Fn &&fn) & noexcept
+  [[nodiscard]] constexpr auto transform(Fn &&fn) & noexcept(
+      detail::_is_nothrow_rts_invocable<
+          typename detail::_sum_invoke_result<detail::_collapsing_sum_tag, decltype(fn), choice &>::type, Fn &&,
+          choice &>)
     requires typelist_invocable<Fn, choice &>
   {
     using type = detail::_sum_invoke_result<detail::_collapsing_sum_tag, decltype(fn), choice &>::type;
@@ -336,7 +369,10 @@ struct choice<Ts...> : sum<Ts...> {
    * @return TODO
    */
   template <typename Fn>
-  [[nodiscard]] constexpr auto transform(Fn &&fn) const & noexcept
+  [[nodiscard]] constexpr auto transform(Fn &&fn) const & noexcept(
+      detail::_is_nothrow_rts_invocable<
+          typename detail::_sum_invoke_result<detail::_collapsing_sum_tag, decltype(fn), choice const &>::type, Fn &&,
+          choice const &>)
     requires typelist_invocable<Fn, choice const &>
   {
     using type = detail::_sum_invoke_result<detail::_collapsing_sum_tag, decltype(fn), choice const &>::type;
@@ -351,7 +387,10 @@ struct choice<Ts...> : sum<Ts...> {
    * @return TODO
    */
   template <typename Fn>
-  [[nodiscard]] constexpr auto transform(Fn &&fn) && noexcept
+  [[nodiscard]] constexpr auto transform(Fn &&fn) && noexcept(
+      detail::_is_nothrow_rts_invocable<
+          typename detail::_sum_invoke_result<detail::_collapsing_sum_tag, decltype(fn), choice &&>::type, Fn &&,
+          choice &&>)
     requires typelist_invocable<Fn, choice &&>
   {
     using type = detail::_sum_invoke_result<detail::_collapsing_sum_tag, decltype(fn), choice &&>::type;
@@ -366,7 +405,10 @@ struct choice<Ts...> : sum<Ts...> {
    * @return TODO
    */
   template <typename Fn>
-  [[nodiscard]] constexpr auto transform(Fn &&fn) const && noexcept
+  [[nodiscard]] constexpr auto transform(Fn &&fn) const && noexcept(
+      detail::_is_nothrow_rts_invocable<
+          typename detail::_sum_invoke_result<detail::_collapsing_sum_tag, decltype(fn), choice const &&>::type, Fn &&,
+          choice const &&>)
     requires typelist_invocable<Fn, choice const &&>
   {
     using type = detail::_sum_invoke_result<detail::_collapsing_sum_tag, decltype(fn), choice const &&>::type;
@@ -380,7 +422,8 @@ struct choice<Ts...> : sum<Ts...> {
    * @param fn TODO
    * @return TODO
    */
-  template <typename Fn> constexpr auto and_then(Fn &&fn) & noexcept -> decltype(this->invoke(FWD(fn)))
+  template <typename Fn>
+  constexpr auto and_then(Fn &&fn) & noexcept(noexcept(this->invoke(FWD(fn)))) -> decltype(this->invoke(FWD(fn)))
   {
     static_assert(some_choice<decltype(this->invoke(FWD(fn)))>);
     return this->invoke(FWD(fn));
@@ -393,7 +436,8 @@ struct choice<Ts...> : sum<Ts...> {
    * @param fn TODO
    * @return TODO
    */
-  template <typename Fn> constexpr auto and_then(Fn &&fn) const & noexcept -> decltype(this->invoke(FWD(fn)))
+  template <typename Fn>
+  constexpr auto and_then(Fn &&fn) const & noexcept(noexcept(this->invoke(FWD(fn)))) -> decltype(this->invoke(FWD(fn)))
   {
     static_assert(some_choice<decltype(this->invoke(FWD(fn)))>);
     return this->invoke(FWD(fn));
@@ -406,7 +450,9 @@ struct choice<Ts...> : sum<Ts...> {
    * @param fn TODO
    * @return TODO
    */
-  template <typename Fn> constexpr auto and_then(Fn &&fn) && noexcept -> decltype(::std::move(*this).invoke(FWD(fn)))
+  template <typename Fn>
+  constexpr auto and_then(Fn &&fn) && noexcept(noexcept(::std::move(*this).invoke(FWD(fn))))
+      -> decltype(::std::move(*this).invoke(FWD(fn)))
   {
     static_assert(some_choice<decltype(::std::move(*this).invoke(FWD(fn)))>);
     return ::std::move(*this).invoke(FWD(fn));
@@ -420,7 +466,8 @@ struct choice<Ts...> : sum<Ts...> {
    * @return TODO
    */
   template <typename Fn>
-  constexpr auto and_then(Fn &&fn) const && noexcept -> decltype(::std::move(*this).invoke(FWD(fn)))
+  constexpr auto and_then(Fn &&fn) const && noexcept(noexcept(::std::move(*this).invoke(FWD(fn))))
+      -> decltype(::std::move(*this).invoke(FWD(fn)))
   {
     static_assert(some_choice<decltype(::std::move(*this).invoke(FWD(fn)))>);
     return ::std::move(*this).invoke(FWD(fn));

--- a/include/fn/detail/functional.hpp
+++ b/include/fn/detail/functional.hpp
@@ -67,9 +67,14 @@ template <typename Lh, typename Rh>
 } // namespace _fold_detail
 
 namespace _invoke_detail {
+// Each overload's noexcept is the noexcept of what it does: `std::invoke` at the bottom, the pack's
+// or sum's own `invoke` when dispatching into one, and folding-then-recursing when several operands
+// must be joined first (that fold constructs a pack, which can throw). The chain terminates because
+// every step strictly reduces the number of pack/sum operands.
 template <typename Fn, typename... Args>
   requires(not(... || (_some_pack<Args> || _some_sum<Args>))) && ::std::is_invocable_v<Fn, Args...>
-[[nodiscard]] constexpr auto invoke(Fn &&fn, Args &&...args) -> DEDUCED_RETURN(::std::invoke(FWD(fn), FWD(args)...))
+[[nodiscard]] constexpr auto invoke(Fn &&fn, Args &&...args) noexcept(::std::is_nothrow_invocable_v<Fn, Args...>)
+    -> DEDUCED_RETURN(::std::invoke(FWD(fn), FWD(args)...))
 {
   return ::std::invoke(FWD(fn), FWD(args)...);
 }
@@ -78,8 +83,8 @@ template <typename Fn, typename Arg, typename... Args>
   requires(_some_pack<Arg> || _some_sum<Arg>)
           && ((sizeof...(Args) == 0) || (not(... || (_some_pack<Args> || _some_sum<Args>))))
           && requires(Fn &&fn, Arg &&arg, Args &&...args) { FWD(arg).invoke(FWD(fn), FWD(args)...); }
-[[nodiscard]] constexpr auto invoke(Fn &&fn, Arg &&arg, Args &&...args)
-    -> DEDUCED_RETURN(FWD(arg).invoke(FWD(fn), FWD(args)...))
+[[nodiscard]] constexpr auto invoke(Fn &&fn, Arg &&arg, Args &&...args) //
+    noexcept(noexcept(FWD(arg).invoke(FWD(fn), FWD(args)...))) -> DEDUCED_RETURN(FWD(arg).invoke(FWD(fn), FWD(args)...))
 {
   return FWD(arg).invoke(FWD(fn), FWD(args)...);
 }
@@ -93,7 +98,9 @@ template <typename Fn, typename Arg, typename Arg0, typename... Args>
 // Deduced return: a trailing return type is substituted before constraints are checked, so an
 // explicit one would instantiate `fold` for non-viable candidates and static_assert (a `pack` of
 // rvalue refs). The body's `using type` alias is inlined only to dodge MSVC's body-local-alias leak.
-[[nodiscard]] constexpr auto invoke(Fn &&fn, Arg &&arg, Arg0 &&arg0, Args &&...args) -> decltype(auto)
+[[nodiscard]] constexpr auto invoke(Fn &&fn, Arg &&arg, Arg0 &&arg0, Args &&...args) //
+    noexcept(noexcept(invoke<Fn, decltype(::fn::detail::_fold_detail::fold<Arg, Arg0>(FWD(arg), FWD(arg0))), Args...>(
+        FWD(fn), ::fn::detail::_fold_detail::fold<Arg, Arg0>(FWD(arg), FWD(arg0)), FWD(args)...))) -> decltype(auto)
 {
   return invoke<Fn, decltype(::fn::detail::_fold_detail::fold<Arg, Arg0>(FWD(arg), FWD(arg0))), Args...>(
       FWD(fn), ::fn::detail::_fold_detail::fold<Arg, Arg0>(FWD(arg), FWD(arg0)), FWD(args)...);
@@ -101,8 +108,9 @@ template <typename Fn, typename Arg, typename Arg0, typename... Args>
 
 template <typename Ret, typename Fn, typename... Args>
   requires(not(... || (_some_pack<Args> || _some_sum<Args>))) && ::std::is_invocable_r_v<Ret, Fn, Args...>
-[[nodiscard]] constexpr auto invoke_r(Fn &&fn, Args &&...args)
-    -> DEDUCED_RETURN(::pfn::invoke_r<Ret>(FWD(fn), FWD(args)...))
+[[nodiscard]] constexpr auto invoke_r(Fn &&fn, Args &&...args) //
+    noexcept(::std::is_nothrow_invocable_r_v<Ret, Fn, Args...>)
+        -> DEDUCED_RETURN(::pfn::invoke_r<Ret>(FWD(fn), FWD(args)...))
 {
   return ::pfn::invoke_r<Ret>(FWD(fn), FWD(args)...);
 }
@@ -111,8 +119,9 @@ template <typename Ret, typename Fn, typename Arg, typename... Args>
   requires(_some_pack<Arg> || _some_sum<Arg>)
           && ((sizeof...(Args) == 0) || (not(... || (_some_pack<Args> || _some_sum<Args>))))
           && requires(Fn &&fn, Arg &&arg, Args &&...args) { FWD(arg).template invoke_r<Ret>(FWD(fn), FWD(args)...); }
-[[nodiscard]] constexpr auto invoke_r(Fn &&fn, Arg &&arg, Args &&...args)
-    -> DEDUCED_RETURN(FWD(arg).template invoke_r<Ret>(FWD(fn), FWD(args)...))
+[[nodiscard]] constexpr auto invoke_r(Fn &&fn, Arg &&arg, Args &&...args) //
+    noexcept(noexcept(FWD(arg).template invoke_r<Ret>(FWD(fn), FWD(args)...)))
+        -> DEDUCED_RETURN(FWD(arg).template invoke_r<Ret>(FWD(fn), FWD(args)...))
 {
   return FWD(arg).template invoke_r<Ret>(FWD(fn), FWD(args)...);
 }
@@ -124,7 +133,10 @@ template <typename Ret, typename Fn, typename Arg, typename Arg0, typename... Ar
                    FWD(fn), ::fn::detail::_fold_detail::fold<Arg, Arg0>(FWD(arg), FWD(arg0)), FWD(args)...);
              }
 // Same as the fold-recursing `invoke` above: deduced return, alias inlined.
-[[nodiscard]] constexpr auto invoke_r(Fn &&fn, Arg &&arg, Arg0 &&arg0, Args &&...args) -> decltype(auto)
+[[nodiscard]] constexpr auto invoke_r(Fn &&fn, Arg &&arg, Arg0 &&arg0, Args &&...args) //
+    noexcept(
+        noexcept(invoke_r<Ret, Fn, decltype(::fn::detail::_fold_detail::fold<Arg, Arg0>(FWD(arg), FWD(arg0))), Args...>(
+            FWD(fn), ::fn::detail::_fold_detail::fold<Arg, Arg0>(FWD(arg), FWD(arg0)), FWD(args)...))) -> decltype(auto)
 {
   return invoke_r<Ret, Fn, decltype(::fn::detail::_fold_detail::fold<Arg, Arg0>(FWD(arg), FWD(arg0))), Args...>(
       FWD(fn), ::fn::detail::_fold_detail::fold<Arg, Arg0>(FWD(arg), FWD(arg0)), FWD(args)...);
@@ -173,17 +185,29 @@ template <typename Ret, typename Fn, typename... Args> struct _is_invocable_r {
       = decltype(_is_invocable_r_result<Ret, Fn, Args...>(::std::declval<Fn>(), ::std::declval<Args>()...))::value;
 };
 
-// is_nothrow_invocable and is_nothrow_invocable_v
-template <typename Fn, typename... Args> struct _is_nothrow_invocable {
-  // TODO https://github.com/libfn/functional/issues/45
-  static constexpr bool value = false;
-};
+// is_nothrow_invocable and is_nothrow_invocable_v. The invoke chain above carries its own spec, so
+// the question is asked of the call itself and composes through pack and sum dispatch: the answer
+// for a sum operand is that every alternative's call is nothrow, and for a pack that the call over
+// its elements is. The bool parameter keeps the noexcept operand out of reach when the call is not
+// viable at all, where it would be ill-formed rather than false.
+template <bool Enable, typename Fn, typename... Args> struct _is_nothrow_invocable_impl : ::std::false_type {};
+template <typename Fn, typename... Args>
+struct _is_nothrow_invocable_impl<true, Fn, Args...>
+    : ::std::bool_constant<noexcept(_invoke_detail::invoke(::std::declval<Fn>(), ::std::declval<Args>()...))> {};
+
+template <typename Fn, typename... Args>
+struct _is_nothrow_invocable : _is_nothrow_invocable_impl<_is_invocable<Fn, Args...>::value, Fn, Args...> {};
 
 // is_nothrow_invocable_r and is_nothrow_invocable_r_v
-template <typename Ret, typename Fn, typename... Args> struct _is_nothrow_invocable_r {
-  // TODO https://github.com/libfn/functional/issues/45
-  static constexpr bool value = false;
-};
+template <bool Enable, typename Ret, typename Fn, typename... Args>
+struct _is_nothrow_invocable_r_impl : ::std::false_type {};
+template <typename Ret, typename Fn, typename... Args>
+struct _is_nothrow_invocable_r_impl<true, Ret, Fn, Args...>
+    : ::std::bool_constant<noexcept(_invoke_detail::invoke_r<Ret>(::std::declval<Fn>(), ::std::declval<Args>()...))> {};
+
+template <typename Ret, typename Fn, typename... Args>
+struct _is_nothrow_invocable_r
+    : _is_nothrow_invocable_r_impl<_is_invocable_r<Ret, Fn, Args...>::value, Ret, Fn, Args...> {};
 
 // invoke
 template <typename Fn, typename... Args>
@@ -231,6 +255,40 @@ constexpr inline bool _is_rts_invocable<R, Fn, Tpl<Ts...> const &&, Tx...>
     = (... && _is_invocable_r<R, Fn, Ts const &&, Tx...>::value);
 template <typename R, typename Fn, typename T, typename... Tx>
 concept _typelist_invocable_r = _is_rts_invocable<R, Fn, T &&, Tx...>;
+
+// Nothrow twins of the two folds above: a dispatch over a typelist can throw unless every
+// alternative's call is nothrow, since which one runs is not known until run time.
+template <typename Fn, typename T, typename... Tx> constexpr inline bool _is_nothrow_ts_invocable = false;
+template <typename Fn, template <typename...> typename Tpl, typename... Ts, typename... Tx>
+constexpr inline bool _is_nothrow_ts_invocable<Fn, Tpl<Ts...> &, Tx...>
+    = (... && _is_nothrow_invocable<Fn, Ts &, Tx...>::value);
+template <typename Fn, template <typename...> typename Tpl, typename... Ts, typename... Tx>
+constexpr inline bool _is_nothrow_ts_invocable<Fn, Tpl<Ts...> const &, Tx...>
+    = (... && _is_nothrow_invocable<Fn, Ts const &, Tx...>::value);
+template <typename Fn, template <typename...> typename Tpl, typename... Ts, typename... Tx>
+constexpr inline bool _is_nothrow_ts_invocable<Fn, Tpl<Ts...> &&, Tx...>
+    = (... && _is_nothrow_invocable<Fn, Ts &&, Tx...>::value);
+template <typename Fn, template <typename...> typename Tpl, typename... Ts, typename... Tx>
+constexpr inline bool _is_nothrow_ts_invocable<Fn, Tpl<Ts...> const &&, Tx...>
+    = (... && _is_nothrow_invocable<Fn, Ts const &&, Tx...>::value);
+template <typename Fn, typename T, typename... Tx>
+concept _typelist_nothrow_invocable = _is_nothrow_ts_invocable<Fn, T &&, Tx...>;
+
+template <typename R, typename Fn, typename T, typename... Tx> constexpr inline bool _is_nothrow_rts_invocable = false;
+template <typename R, typename Fn, template <typename...> typename Tpl, typename... Ts, typename... Tx>
+constexpr inline bool _is_nothrow_rts_invocable<R, Fn, Tpl<Ts...> &, Tx...>
+    = (... && _is_nothrow_invocable_r<R, Fn, Ts &, Tx...>::value);
+template <typename R, typename Fn, template <typename...> typename Tpl, typename... Ts, typename... Tx>
+constexpr inline bool _is_nothrow_rts_invocable<R, Fn, Tpl<Ts...> const &, Tx...>
+    = (... && _is_nothrow_invocable_r<R, Fn, Ts const &, Tx...>::value);
+template <typename R, typename Fn, template <typename...> typename Tpl, typename... Ts, typename... Tx>
+constexpr inline bool _is_nothrow_rts_invocable<R, Fn, Tpl<Ts...> &&, Tx...>
+    = (... && _is_nothrow_invocable_r<R, Fn, Ts &&, Tx...>::value);
+template <typename R, typename Fn, template <typename...> typename Tpl, typename... Ts, typename... Tx>
+constexpr inline bool _is_nothrow_rts_invocable<R, Fn, Tpl<Ts...> const &&, Tx...>
+    = (... && _is_nothrow_invocable_r<R, Fn, Ts const &&, Tx...>::value);
+template <typename R, typename Fn, typename T, typename... Tx>
+concept _typelist_nothrow_invocable_r = _is_nothrow_rts_invocable<R, Fn, T &&, Tx...>;
 
 } // namespace fn::detail
 

--- a/include/fn/detail/pack_impl.hpp
+++ b/include/fn/detail/pack_impl.hpp
@@ -69,8 +69,9 @@ struct pack_impl<::std::index_sequence<Is...>, Ts...> : _element<Is, Ts>... {
 
   template <typename Self, typename Fn, typename... Args>
     requires(not(... || (_some_pack<Args> || _some_sum<Args>)))
-  static constexpr auto _swap_invoke(Self &&self, Fn &&fn, Args &&...args) noexcept
-      -> ::std::invoke_result<Fn &&, Args &&..., apply_const_lvalue_t<Self, Ts &&>...>::type
+  static constexpr auto _swap_invoke(Self &&self, Fn &&fn, Args &&...args) //
+      noexcept(::std::is_nothrow_invocable_v<Fn &&, Args &&..., apply_const_lvalue_t<Self, Ts &&>...>)
+          -> ::std::invoke_result<Fn &&, Args &&..., apply_const_lvalue_t<Self, Ts &&>...>::type
     requires(::std::is_invocable<Fn &&, Args && ..., apply_const_lvalue_t<Self, Ts &&>...>::value)
   {
     return ::std::invoke(FWD(fn), FWD(args)...,
@@ -79,8 +80,9 @@ struct pack_impl<::std::index_sequence<Is...>, Ts...> : _element<Is, Ts>... {
 
   template <typename Self, typename Fn, typename... Args>
     requires(not(... || (_some_pack<Args> || _some_sum<Args>)))
-  static constexpr auto _invoke(Self &&self, Fn &&fn, Args &&...args) noexcept
-      -> _invoke_result<Fn &&, apply_const_lvalue_t<Self, Ts &&>..., Args &&...>::type
+  static constexpr auto _invoke(Self &&self, Fn &&fn, Args &&...args) //
+      noexcept(_is_nothrow_invocable<Fn &&, apply_const_lvalue_t<Self, Ts &&>..., Args &&...>::value)
+          -> _invoke_result<Fn &&, apply_const_lvalue_t<Self, Ts &&>..., Args &&...>::type
     requires(_is_invocable<Fn &&, apply_const_lvalue_t<Self, Ts &&>..., Args && ...>::value)
   {
     return ::fn::detail::_invoke(
@@ -97,9 +99,16 @@ struct pack_impl<::std::index_sequence<Is...>, Ts...> : _element<Is, Ts>... {
 
   template <typename T> using append_type = _pack_append<T, Ts...>::type;
 
+  // Every existing element is relocated into the new pack, so appending weighs that as well as the
+  // construction of the element being appended.
+  template <typename Self>
+  static constexpr bool _nothrow_relocatable
+      = (... && ::std::is_nothrow_constructible_v<Ts, apply_const_lvalue_t<Self, Ts &&>>);
+
   template <typename T, typename Self>
-  static constexpr auto _append(Self &&self, auto &&...args) noexcept //
-      -> pack_impl<::std::index_sequence<Is..., size>, Ts..., T>
+  static constexpr auto _append(Self &&self, auto &&...args) //
+      noexcept(_nothrow_relocatable<Self> && _nothrow_initializable<T, decltype(args)...>)
+          -> pack_impl<::std::index_sequence<Is..., size>, Ts..., T>
     requires(not _some_sum<T>) && (not _some_pack<T>) && _initializable<T, decltype(args)...>
   {
     return {static_cast<apply_const_lvalue_t<Self, Ts &&>>(FWD(self)._element<Is, Ts>::v)...,
@@ -107,7 +116,9 @@ struct pack_impl<::std::index_sequence<Is...>, Ts...> : _element<Is, Ts>... {
   }
 
   template <typename T, typename Self>
-  static constexpr auto _append(Self &&self, auto &&other) noexcept -> //
+  static constexpr auto _append(Self &&self, auto &&other) //
+      noexcept(_nothrow_relocatable<Self>
+               && ::std::remove_cvref_t<T>::_impl::template _nothrow_relocatable<decltype(other)>) -> //
       typename _pack_append<::std::remove_cvref_t<T>, Ts...>::impl
     requires _some_pack<T> && (::std::is_same_v<::std::remove_cvref_t<decltype(other)>, ::std::remove_cvref_t<T>>)
   {

--- a/include/fn/detail/traits.hpp
+++ b/include/fn/detail/traits.hpp
@@ -22,6 +22,17 @@ concept _initializable                                                    //
     = (::std::is_reference_v<T> && ::std::is_constructible_v<T, Args...>) //
       || ((not ::std::is_reference_v<T>) && requires { T{::std::declval<Args>()...}; });
 
+// Whether that same initialization can throw. Only instantiated for an `_initializable` T, and for
+// the same reason it cannot be `is_nothrow_constructible_v`: the question is about `T{args...}`.
+template <typename T, typename... Args>
+struct _nothrow_init : ::std::bool_constant<noexcept(T{::std::declval<Args>()...})> {};
+template <typename T, typename... Args>
+  requires ::std::is_reference_v<T>
+struct _nothrow_init<T, Args...> : ::std::bool_constant<::std::is_nothrow_constructible_v<T, Args...>> {};
+
+template <typename T, typename... Args>
+concept _nothrow_initializable = _initializable<T, Args...> && _nothrow_init<T, Args...>::value;
+
 // Change any rvalue or empty value to prvalue, but leave lvalues unchanged.
 // This is meant to find the type of data members which won't bind to rvalues.
 template <typename T> extern T _as_value;

--- a/include/fn/detail/variadic_union.hpp
+++ b/include/fn/detail/variadic_union.hpp
@@ -98,6 +98,41 @@ constexpr inline bool _is_rtst_invocable<R, Fn, Tpl<Ts...> const &&>
 template <typename R, typename Fn, typename T>
 concept _typelist_type_invocable_r = _is_rtst_invocable<R, Fn, T &&>;
 
+// Nothrow twins: the alternative that runs is a run-time choice, so the dispatch is nothrow only if
+// the call on every alternative is. These pass the type tag through `std::invoke` / `pfn::invoke_r`,
+// so the std traits answer exactly.
+template <typename Fn, typename T> constexpr inline bool _is_nothrow_tst_invocable = false;
+template <typename Fn, template <typename...> typename Tpl, typename... Ts>
+constexpr inline bool _is_nothrow_tst_invocable<Fn, Tpl<Ts...> &>
+    = (... && ::std::is_nothrow_invocable_v<Fn, ::std::in_place_type_t<Ts>, Ts &>);
+template <typename Fn, template <typename...> typename Tpl, typename... Ts>
+constexpr inline bool _is_nothrow_tst_invocable<Fn, Tpl<Ts...> const &>
+    = (... && ::std::is_nothrow_invocable_v<Fn, ::std::in_place_type_t<Ts>, Ts const &>);
+template <typename Fn, template <typename...> typename Tpl, typename... Ts>
+constexpr inline bool _is_nothrow_tst_invocable<Fn, Tpl<Ts...> &&>
+    = (... && ::std::is_nothrow_invocable_v<Fn, ::std::in_place_type_t<Ts>, Ts &&>);
+template <typename Fn, template <typename...> typename Tpl, typename... Ts>
+constexpr inline bool _is_nothrow_tst_invocable<Fn, Tpl<Ts...> const &&>
+    = (... && ::std::is_nothrow_invocable_v<Fn, ::std::in_place_type_t<Ts>, Ts const &&>);
+template <typename Fn, typename T>
+concept _typelist_type_nothrow_invocable = _is_nothrow_tst_invocable<Fn, T &&>;
+
+template <typename R, typename Fn, typename T> constexpr inline bool _is_nothrow_rtst_invocable = false;
+template <typename R, typename Fn, template <typename...> typename Tpl, typename... Ts>
+constexpr inline bool _is_nothrow_rtst_invocable<R, Fn, Tpl<Ts...> &>
+    = (... && ::std::is_nothrow_invocable_r_v<R, Fn, ::std::in_place_type_t<Ts>, Ts &>);
+template <typename R, typename Fn, template <typename...> typename Tpl, typename... Ts>
+constexpr inline bool _is_nothrow_rtst_invocable<R, Fn, Tpl<Ts...> const &>
+    = (... && ::std::is_nothrow_invocable_r_v<R, Fn, ::std::in_place_type_t<Ts>, Ts const &>);
+template <typename R, typename Fn, template <typename...> typename Tpl, typename... Ts>
+constexpr inline bool _is_nothrow_rtst_invocable<R, Fn, Tpl<Ts...> &&>
+    = (... && ::std::is_nothrow_invocable_r_v<R, Fn, ::std::in_place_type_t<Ts>, Ts &&>);
+template <typename R, typename Fn, template <typename...> typename Tpl, typename... Ts>
+constexpr inline bool _is_nothrow_rtst_invocable<R, Fn, Tpl<Ts...> const &&>
+    = (... && ::std::is_nothrow_invocable_r_v<R, Fn, ::std::in_place_type_t<Ts>, Ts const &&>);
+template <typename R, typename Fn, typename T>
+concept _typelist_type_nothrow_invocable_r = _is_nothrow_rtst_invocable<R, Fn, T &&>;
+
 template <typename... Ts> union variadic_union;
 template <> union variadic_union<>; // Intentionally incomplete
 

--- a/include/fn/pack.hpp
+++ b/include/fn/pack.hpp
@@ -45,7 +45,9 @@ template <typename... Ts> struct pack : detail::pack_impl<::std::index_sequence_
    * @return TODO
    */
   template <typename T>
-  [[nodiscard]] constexpr auto append(::std::in_place_type_t<T>, auto &&...args) & noexcept -> append_type<T>
+  [[nodiscard]] constexpr auto append(::std::in_place_type_t<T>, auto &&...args) & //
+      noexcept(_impl::template _nothrow_relocatable<pack &> && detail::_nothrow_initializable<T, decltype(args)...>)
+          -> append_type<T>
     requires detail::_initializable<T, decltype(args)...>
              && requires { append_type<T>{_impl::template _append<T>(*this, FWD(args)...)}; }
   {
@@ -60,7 +62,9 @@ template <typename... Ts> struct pack : detail::pack_impl<::std::index_sequence_
    * @return TODO
    */
   template <typename T>
-  [[nodiscard]] constexpr auto append(::std::in_place_type_t<T>, auto &&...args) const & noexcept -> append_type<T>
+  [[nodiscard]] constexpr auto append(::std::in_place_type_t<T>, auto &&...args) const & //
+      noexcept(_impl::template _nothrow_relocatable<pack const &>
+               && detail::_nothrow_initializable<T, decltype(args)...>) -> append_type<T>
     requires detail::_initializable<T, decltype(args)...>
              && requires { append_type<T>{_impl::template _append<T>(*this, FWD(args)...)}; }
   {
@@ -75,7 +79,9 @@ template <typename... Ts> struct pack : detail::pack_impl<::std::index_sequence_
    * @return TODO
    */
   template <typename T>
-  [[nodiscard]] constexpr auto append(::std::in_place_type_t<T>, auto &&...args) && noexcept -> append_type<T>
+  [[nodiscard]] constexpr auto append(::std::in_place_type_t<T>, auto &&...args) && //
+      noexcept(_impl::template _nothrow_relocatable<pack &&> && detail::_nothrow_initializable<T, decltype(args)...>)
+          -> append_type<T>
     requires detail::_initializable<T, decltype(args)...>
              && requires { append_type<T>{_impl::template _append<T>(::std::move(*this), FWD(args)...)}; }
   {
@@ -90,7 +96,9 @@ template <typename... Ts> struct pack : detail::pack_impl<::std::index_sequence_
    * @return TODO
    */
   template <typename T>
-  [[nodiscard]] constexpr auto append(::std::in_place_type_t<T>, auto &&...args) const && noexcept -> append_type<T>
+  [[nodiscard]] constexpr auto append(::std::in_place_type_t<T>, auto &&...args) const && //
+      noexcept(_impl::template _nothrow_relocatable<pack const &&>
+               && detail::_nothrow_initializable<T, decltype(args)...>) -> append_type<T>
     requires detail::_initializable<T, decltype(args)...>
              && requires { append_type<T>{_impl::template _append<T>(::std::move(*this), FWD(args)...)}; }
   {
@@ -105,7 +113,8 @@ template <typename... Ts> struct pack : detail::pack_impl<::std::index_sequence_
    * @return TODO
    */
   template <typename Arg>
-  [[nodiscard]] constexpr auto append(Arg &&arg) & noexcept -> append_type<Arg>
+  [[nodiscard]] constexpr auto append(Arg &&arg) & //
+      noexcept(noexcept(_impl::template _append<Arg>(::std::declval<pack &>(), FWD(arg)))) -> append_type<Arg>
     requires(not some_in_place_type<Arg>)
             && requires { append_type<Arg>{_impl::template _append<Arg>(*this, FWD(arg))}; }
   {
@@ -120,7 +129,8 @@ template <typename... Ts> struct pack : detail::pack_impl<::std::index_sequence_
    * @return TODO
    */
   template <typename Arg>
-  [[nodiscard]] constexpr auto append(Arg &&arg) const & noexcept -> append_type<Arg>
+  [[nodiscard]] constexpr auto append(Arg &&arg) const & //
+      noexcept(noexcept(_impl::template _append<Arg>(::std::declval<pack const &>(), FWD(arg)))) -> append_type<Arg>
     requires(not some_in_place_type<Arg>)
             && requires { append_type<Arg>{_impl::template _append<Arg>(*this, FWD(arg))}; }
   {
@@ -135,7 +145,8 @@ template <typename... Ts> struct pack : detail::pack_impl<::std::index_sequence_
    * @return TODO
    */
   template <typename Arg>
-  [[nodiscard]] constexpr auto append(Arg &&arg) && noexcept -> append_type<Arg>
+  [[nodiscard]] constexpr auto append(Arg &&arg) && //
+      noexcept(noexcept(_impl::template _append<Arg>(::std::declval<pack &&>(), FWD(arg)))) -> append_type<Arg>
     requires(not some_in_place_type<Arg>)
             && requires { append_type<Arg>{_impl::template _append<Arg>(::std::move(*this), FWD(arg))}; }
   {
@@ -150,7 +161,8 @@ template <typename... Ts> struct pack : detail::pack_impl<::std::index_sequence_
    * @return TODO
    */
   template <typename Arg>
-  [[nodiscard]] constexpr auto append(Arg &&arg) const && noexcept -> append_type<Arg>
+  [[nodiscard]] constexpr auto append(Arg &&arg) const && //
+      noexcept(noexcept(_impl::template _append<Arg>(::std::declval<pack const &&>(), FWD(arg)))) -> append_type<Arg>
     requires(not some_in_place_type<Arg>)
             && requires { append_type<Arg>{_impl::template _append<Arg>(::std::move(*this), FWD(arg))}; }
   {
@@ -166,8 +178,9 @@ template <typename... Ts> struct pack : detail::pack_impl<::std::index_sequence_
    * @return TODO
    */
   template <typename Fn>
-  [[nodiscard]] constexpr auto invoke(Fn &&fn, auto &&...args) & noexcept
-      -> DEDUCED_RETURN(_impl::_invoke(*this, FWD(fn), FWD(args)...))
+  [[nodiscard]] constexpr auto invoke(Fn &&fn, auto &&...args) & //
+      noexcept(noexcept(_impl::_invoke(::std::declval<pack &>(), FWD(fn), FWD(args)...)))
+          -> DEDUCED_RETURN(_impl::_invoke(*this, FWD(fn), FWD(args)...))
     requires requires { _impl::_invoke(*this, FWD(fn), FWD(args)...); }
   {
     return _impl::_invoke(*this, FWD(fn), FWD(args)...);
@@ -182,8 +195,9 @@ template <typename... Ts> struct pack : detail::pack_impl<::std::index_sequence_
    * @return TODO
    */
   template <typename Fn>
-  [[nodiscard]] constexpr auto invoke(Fn &&fn, auto &&...args) const & noexcept
-      -> DEDUCED_RETURN(_impl::_invoke(*this, FWD(fn), FWD(args)...))
+  [[nodiscard]] constexpr auto invoke(Fn &&fn, auto &&...args) const & //
+      noexcept(noexcept(_impl::_invoke(::std::declval<pack const &>(), FWD(fn), FWD(args)...)))
+          -> DEDUCED_RETURN(_impl::_invoke(*this, FWD(fn), FWD(args)...))
     requires requires { _impl::_invoke(*this, FWD(fn), FWD(args)...); }
   {
     return _impl::_invoke(*this, FWD(fn), FWD(args)...);
@@ -198,8 +212,9 @@ template <typename... Ts> struct pack : detail::pack_impl<::std::index_sequence_
    * @return TODO
    */
   template <typename Fn>
-  [[nodiscard]] constexpr auto invoke(Fn &&fn, auto &&...args) && noexcept
-      -> DEDUCED_RETURN(_impl::_invoke(::std::move(*this), FWD(fn), FWD(args)...))
+  [[nodiscard]] constexpr auto invoke(Fn &&fn, auto &&...args) && //
+      noexcept(noexcept(_impl::_invoke(::std::declval<pack &&>(), FWD(fn), FWD(args)...)))
+          -> DEDUCED_RETURN(_impl::_invoke(::std::move(*this), FWD(fn), FWD(args)...))
     requires requires { _impl::_invoke(::std::move(*this), FWD(fn), FWD(args)...); }
   {
     return _impl::_invoke(::std::move(*this), FWD(fn), FWD(args)...);
@@ -214,8 +229,9 @@ template <typename... Ts> struct pack : detail::pack_impl<::std::index_sequence_
    * @return TODO
    */
   template <typename Fn>
-  [[nodiscard]] constexpr auto invoke(Fn &&fn, auto &&...args) const && noexcept
-      -> DEDUCED_RETURN(_impl::_invoke(::std::move(*this), FWD(fn), FWD(args)...))
+  [[nodiscard]] constexpr auto invoke(Fn &&fn, auto &&...args) const && //
+      noexcept(noexcept(_impl::_invoke(::std::declval<pack const &&>(), FWD(fn), FWD(args)...)))
+          -> DEDUCED_RETURN(_impl::_invoke(::std::move(*this), FWD(fn), FWD(args)...))
     requires requires { _impl::_invoke(::std::move(*this), FWD(fn), FWD(args)...); }
   {
     return _impl::_invoke(::std::move(*this), FWD(fn), FWD(args)...);
@@ -231,7 +247,9 @@ template <typename... Ts> struct pack : detail::pack_impl<::std::index_sequence_
    * @return TODO
    */
   template <typename Ret, typename Fn>
-  [[nodiscard]] constexpr auto invoke_r(Fn &&fn, auto &&...args) & noexcept -> Ret
+  [[nodiscard]] constexpr auto invoke_r(Fn &&fn, auto &&...args) & //
+      noexcept(noexcept(_impl::_invoke(::std::declval<pack &>(), FWD(fn), FWD(args)...))
+               && ::std::is_nothrow_constructible_v<Ret, decltype(_impl::_invoke(*this, FWD(fn), FWD(args)...))>) -> Ret
     requires requires { _impl::_invoke(*this, FWD(fn), FWD(args)...); }
              && ::std::is_convertible_v<decltype(_impl::_invoke(*this, FWD(fn), FWD(args)...)), Ret>
   {
@@ -248,7 +266,9 @@ template <typename... Ts> struct pack : detail::pack_impl<::std::index_sequence_
    * @return TODO
    */
   template <typename Ret, typename Fn>
-  [[nodiscard]] constexpr auto invoke_r(Fn &&fn, auto &&...args) const & noexcept -> Ret
+  [[nodiscard]] constexpr auto invoke_r(Fn &&fn, auto &&...args) const & //
+      noexcept(noexcept(_impl::_invoke(::std::declval<pack const &>(), FWD(fn), FWD(args)...))
+               && ::std::is_nothrow_constructible_v<Ret, decltype(_impl::_invoke(*this, FWD(fn), FWD(args)...))>) -> Ret
     requires requires { _impl::_invoke(*this, FWD(fn), FWD(args)...); }
              && ::std::is_convertible_v<decltype(_impl::_invoke(*this, FWD(fn), FWD(args)...)), Ret>
   {
@@ -265,7 +285,10 @@ template <typename... Ts> struct pack : detail::pack_impl<::std::index_sequence_
    * @return TODO
    */
   template <typename Ret, typename Fn>
-  [[nodiscard]] constexpr auto invoke_r(Fn &&fn, auto &&...args) && noexcept -> Ret
+  [[nodiscard]] constexpr auto invoke_r(Fn &&fn, auto &&...args) && //
+      noexcept(noexcept(_impl::_invoke(::std::declval<pack &&>(), FWD(fn), FWD(args)...))
+               && ::std::is_nothrow_constructible_v<Ret, decltype(_impl::_invoke(::std::move(*this), FWD(fn),
+                                                                                 FWD(args)...))>) -> Ret
     requires requires { _impl::_invoke(::std::move(*this), FWD(fn), FWD(args)...); }
              && ::std::is_convertible_v<decltype(_impl::_invoke(::std::move(*this), FWD(fn), FWD(args)...)), Ret>
   {
@@ -282,7 +305,10 @@ template <typename... Ts> struct pack : detail::pack_impl<::std::index_sequence_
    * @return TODO
    */
   template <typename Ret, typename Fn>
-  [[nodiscard]] constexpr auto invoke_r(Fn &&fn, auto &&...args) const && noexcept -> Ret
+  [[nodiscard]] constexpr auto invoke_r(Fn &&fn, auto &&...args) const && //
+      noexcept(noexcept(_impl::_invoke(::std::declval<pack const &&>(), FWD(fn), FWD(args)...))
+               && ::std::is_nothrow_constructible_v<Ret, decltype(_impl::_invoke(::std::move(*this), FWD(fn),
+                                                                                 FWD(args)...))>) -> Ret
     requires requires { _impl::_invoke(::std::move(*this), FWD(fn), FWD(args)...); }
              && ::std::is_convertible_v<decltype(_impl::_invoke(::std::move(*this), FWD(fn), FWD(args)...)), Ret>
   {
@@ -320,10 +346,11 @@ template <::std::size_t I, some_pack P>
  * @param args TODO
  * @return TODO
  */
-[[nodiscard]] constexpr auto as_pack() -> pack<> { return {}; }
+[[nodiscard]] constexpr auto as_pack() noexcept -> pack<> { return {}; }
 template <typename T, typename... Args>
   requires(not some_in_place_type<T>)
-[[nodiscard]] constexpr auto as_pack(T &&src, Args &&...args) -> decltype(auto)
+[[nodiscard]] constexpr auto as_pack(T &&src, Args &&...args) //
+    noexcept(::std::is_nothrow_constructible_v<pack<T, Args...>, T, Args...>) -> decltype(auto)
 {
   return pack<T, Args...>{FWD(src), FWD(args)...};
 }

--- a/include/fn/sum.hpp
+++ b/include/fn/sum.hpp
@@ -44,6 +44,15 @@ static constexpr bool _is_valid_sum_subtype //
 
 struct _invoke_autodetect_tag final {};
 
+// Whether comparing an alternative can throw. An alternative the other side does not have is never
+// compared, so it cannot throw - and need not even be comparable, which is why this is a guarded
+// specialization rather than a disjunction: unlike a requires-clause, a noexcept-specifier is an
+// ordinary constant expression, and every operand of its `||` has to be well-formed.
+template <typename T, typename... Tx> constexpr inline bool _nothrow_eq_with = true;
+template <typename T, typename... Tx>
+  requires type_one_of<T, Tx...>
+constexpr inline bool _nothrow_eq_with<T, Tx...> = noexcept(::std::declval<T const &>() == ::std::declval<T const &>());
+
 template <typename Fn, typename Self, typename T, typename... Args> struct _typelist_select_invoke_result;
 template <typename Fn, typename Self, template <typename...> typename Tpl, typename... Ts, typename... Args>
 struct _typelist_select_invoke_result<Fn, Self, Tpl<Ts...>, Args...> {
@@ -180,18 +189,27 @@ struct sum<Ts...> {
    */
   template <typename T> static constexpr bool has_type = data_t::template has_type<T>;
 
-  template <typename Ret> [[nodiscard]] constexpr auto _invoke(auto &&fn) const & noexcept
+  // Every dispatch below is nothrow exactly when the call on each alternative is: which one runs is
+  // a run-time choice, so one throwing alternative is enough to make the whole dispatch throwing.
+  template <typename Ret>
+  [[nodiscard]] constexpr auto
+  _invoke(auto &&fn) const & noexcept(detail::_is_nothrow_rtst_invocable<Ret, decltype(fn), sum const &>)
   {
     return detail::invoke_type_variadic_union<Ret, data_t>(this->data, this->index, FWD(fn));
   }
 
-  template <typename Ret> [[nodiscard]] constexpr auto _invoke(auto &&fn) && noexcept
+  template <typename Ret>
+  [[nodiscard]] constexpr auto
+  _invoke(auto &&fn) && noexcept(detail::_is_nothrow_rtst_invocable<Ret, decltype(fn), sum &&>)
   {
     return detail::invoke_type_variadic_union<Ret, data_t>(::std::move(*this).data, ::std::move(*this).index, FWD(fn));
   }
 
   template <typename Fn>
-  [[nodiscard]] constexpr auto _transform(Fn &&fn) const & noexcept ->
+  [[nodiscard]] constexpr auto _transform(Fn &&fn) const & noexcept(
+      detail::_is_nothrow_rtst_invocable<
+          typename detail::_sum_invoke_type_result<detail::_collapsing_sum_tag, Fn &&, sum const &>::type, Fn &&,
+          sum const &>) ->
       typename detail::_sum_invoke_type_result<detail::_collapsing_sum_tag, Fn &&, sum const &>::type
   {
     using type = detail::_sum_invoke_type_result<detail::_collapsing_sum_tag, Fn &&, sum const &>::type;
@@ -199,7 +217,9 @@ struct sum<Ts...> {
   }
 
   template <typename Fn>
-  [[nodiscard]] constexpr auto _transform(Fn &&fn) && noexcept ->
+  [[nodiscard]] constexpr auto _transform(Fn &&fn) && noexcept(
+      detail::_is_nothrow_rtst_invocable<
+          typename detail::_sum_invoke_type_result<detail::_collapsing_sum_tag, Fn &&, sum &&>::type, Fn &&, sum &&>) ->
       typename detail::_sum_invoke_type_result<detail::_collapsing_sum_tag, Fn &&, sum &&>::type
   {
     using type = detail::_sum_invoke_type_result<detail::_collapsing_sum_tag, Fn &&, sum &&>::type;
@@ -214,6 +234,7 @@ struct sum<Ts...> {
    */
   template <typename T>
   constexpr sum(T &&v) // NOSONAR cpp:S1709,S6458 implicit arm of the explicit pair; has_type excludes self
+      noexcept(detail::_nothrow_initializable<::std::remove_cvref_t<T>, decltype(v)>)
     requires has_type<::std::remove_cvref_t<T>> && (::std::is_constructible_v<::std::remove_cvref_t<T>, decltype(v)>)
                  && (::std::is_convertible_v<decltype(v), ::std::remove_cvref_t<T>>)
       : data(detail::make_variadic_union<::std::remove_cvref_t<T>, data_t>(FWD(v))),
@@ -229,6 +250,7 @@ struct sum<Ts...> {
    */
   template <typename T>
   constexpr explicit sum(T &&v) // NOSONAR cpp:S6458 has_type excludes self
+      noexcept(detail::_nothrow_initializable<::std::remove_cvref_t<T>, decltype(v)>)
     requires has_type<::std::remove_cvref_t<T>> && (::std::is_constructible_v<::std::remove_cvref_t<T>, decltype(v)>)
                  && (not ::std::is_convertible_v<decltype(v), ::std::remove_cvref_t<T>>)
       : data(detail::make_variadic_union<::std::remove_cvref_t<T>, data_t>(FWD(v))),
@@ -243,7 +265,8 @@ struct sum<Ts...> {
    * @param args TODO
    */
   template <typename T>
-  constexpr explicit sum(::std::in_place_type_t<T>, auto &&...args)
+  constexpr explicit sum(::std::in_place_type_t<T>,
+                         auto &&...args) noexcept(detail::_nothrow_initializable<T, decltype(args)...>)
     requires has_type<T> && detail::_initializable<T, decltype(args)...>
       : data(detail::make_variadic_union<T, data_t>(FWD(args)...)), index(detail::type_index<T, Ts...>)
   {
@@ -256,7 +279,8 @@ struct sum<Ts...> {
    * @param arg TODO
    */
   template <typename... Tx>
-  constexpr sum(sum<Tx...> const &arg) noexcept // NOSONAR cpp:S1709 implicit widening by design
+  constexpr sum(sum<Tx...> const &arg) // NOSONAR cpp:S1709 implicit widening by design
+      noexcept((... && ::std::is_nothrow_copy_constructible_v<Tx>))
     requires detail::is_superset_of<sum, sum<Tx...>> && (not ::std::is_same_v<sum, sum<Tx...>>)
                  && (... && ::std::is_copy_constructible_v<Tx>) && (sizeof...(Tx) > 0)
       : data(FWD(arg).template _invoke<data_t>([]<typename T>(::std::in_place_type_t<T>, auto &&v) {
@@ -275,7 +299,8 @@ struct sum<Ts...> {
    * @param arg TODO
    */
   template <typename... Tx>
-  constexpr sum(sum<Tx...> &&arg) noexcept // NOSONAR cpp:S1709 implicit widening by design
+  constexpr sum(sum<Tx...> &&arg) // NOSONAR cpp:S1709 implicit widening by design
+      noexcept((... && ::std::is_nothrow_move_constructible_v<Tx>))
     requires detail::is_superset_of<sum, sum<Tx...>> && (not ::std::is_same_v<sum, sum<Tx...>>)
                  && (... && ::std::is_move_constructible_v<Tx>) && (sizeof...(Tx) > 0)
       : data(FWD(arg).template _invoke<data_t>([]<typename T>(::std::in_place_type_t<T>, auto &&v) {
@@ -294,7 +319,8 @@ struct sum<Ts...> {
    * @param arg TODO
    */
   template <typename... Tx>
-  constexpr sum(::std::in_place_type_t<sum<Tx...>>, some_sum auto &&arg) noexcept
+  constexpr sum(::std::in_place_type_t<sum<Tx...>>, some_sum auto &&arg) //
+      noexcept((... && ::std::is_nothrow_constructible_v<Tx, apply_const_lvalue_t<decltype(arg), Tx &&>>))
     requires ::std::is_same_v<::std::remove_cvref_t<decltype(arg)>, sum<Tx...>>
                  && detail::is_superset_of<sum, sum<Tx...>> && (sizeof...(Tx) > 0)
       : data(FWD(arg).template _invoke<data_t>([]<typename T>(::std::in_place_type_t<T>, auto &&v) {
@@ -311,7 +337,7 @@ struct sum<Ts...> {
    *
    * @param other TODO
    */
-  constexpr sum(sum const &other) noexcept
+  constexpr sum(sum const &other) noexcept((... && ::std::is_nothrow_copy_constructible_v<Ts>))
     requires(... && ::std::is_copy_constructible_v<Ts>)
       : data(detail::invoke_type_variadic_union<data_t, data_t>(       //
             other.data, other.index,                                   //
@@ -327,7 +353,7 @@ struct sum<Ts...> {
    *
    * @param other TODO
    */
-  constexpr sum(sum &&other) noexcept
+  constexpr sum(sum &&other) noexcept((... && ::std::is_nothrow_move_constructible_v<Ts>))
     requires(... && ::std::is_move_constructible_v<Ts>)
       : data(detail::invoke_type_variadic_union<data_t, data_t>(  //
             ::std::move(other).data, other.index,                 //
@@ -397,7 +423,10 @@ struct sum<Ts...> {
    * @return TODO
    */
   template <typename Fn, typename... Args>
-  [[nodiscard]] constexpr auto invoke(Fn &&fn, Args &&...args) & noexcept ->
+  [[nodiscard]] constexpr auto invoke(Fn &&fn, Args &&...args) & noexcept(
+      detail::_is_nothrow_rts_invocable<
+          typename detail::_sum_invoke_result<detail::_invoke_autodetect_tag, Fn &&, sum &, Args &&...>::type, Fn &&,
+          sum &, Args &&...>) ->
       typename detail::_sum_invoke_result<detail::_invoke_autodetect_tag, Fn &&, sum &, Args &&...>::type
     requires typelist_invocable<Fn, sum &, Args &&...>
   {
@@ -415,7 +444,10 @@ struct sum<Ts...> {
    * @return TODO
    */
   template <typename Fn, typename... Args>
-  [[nodiscard]] constexpr auto invoke(Fn &&fn, Args &&...args) const & noexcept ->
+  [[nodiscard]] constexpr auto invoke(Fn &&fn, Args &&...args) const & noexcept(
+      detail::_is_nothrow_rts_invocable<
+          typename detail::_sum_invoke_result<detail::_invoke_autodetect_tag, Fn &&, sum const &, Args &&...>::type,
+          Fn &&, sum const &, Args &&...>) ->
       typename detail::_sum_invoke_result<detail::_invoke_autodetect_tag, Fn &&, sum const &, Args &&...>::type
     requires typelist_invocable<Fn, sum const &, Args &&...>
   {
@@ -433,7 +465,10 @@ struct sum<Ts...> {
    * @return TODO
    */
   template <typename Fn, typename... Args>
-  [[nodiscard]] constexpr auto invoke(Fn &&fn, Args &&...args) && noexcept ->
+  [[nodiscard]] constexpr auto invoke(Fn &&fn, Args &&...args) && noexcept(
+      detail::_is_nothrow_rts_invocable<
+          typename detail::_sum_invoke_result<detail::_invoke_autodetect_tag, Fn &&, sum &&, Args &&...>::type, Fn &&,
+          sum &&, Args &&...>) ->
       typename detail::_sum_invoke_result<detail::_invoke_autodetect_tag, Fn &&, sum &&, Args &&...>::type
     requires typelist_invocable<Fn, sum &&, Args &&...>
   {
@@ -451,7 +486,10 @@ struct sum<Ts...> {
    * @return TODO
    */
   template <typename Fn, typename... Args>
-  [[nodiscard]] constexpr auto invoke(Fn &&fn, Args &&...args) const && noexcept ->
+  [[nodiscard]] constexpr auto invoke(Fn &&fn, Args &&...args) const && noexcept(
+      detail::_is_nothrow_rts_invocable<
+          typename detail::_sum_invoke_result<detail::_invoke_autodetect_tag, Fn &&, sum const &&, Args &&...>::type,
+          Fn &&, sum const &&, Args &&...>) ->
       typename detail::_sum_invoke_result<detail::_invoke_autodetect_tag, Fn &&, sum const &&, Args &&...>::type
     requires typelist_invocable<Fn, sum const &&, Args &&...>
   {
@@ -470,7 +508,8 @@ struct sum<Ts...> {
    * @return TODO
    */
   template <typename Ret, typename Fn, typename... Args>
-  [[nodiscard]] constexpr auto invoke_r(Fn &&fn, Args &&...args) & noexcept -> Ret
+  [[nodiscard]] constexpr auto
+  invoke_r(Fn &&fn, Args &&...args) & noexcept(detail::_is_nothrow_rts_invocable<Ret, Fn &&, sum &, Args &&...>) -> Ret
     requires typelist_invocable_r<Ret, Fn, sum &, Args &&...>
   {
     using type = detail::_sum_invoke_result<Ret, Fn &&, sum &, Args &&...>::type;
@@ -488,7 +527,8 @@ struct sum<Ts...> {
    * @return TODO
    */
   template <typename Ret, typename Fn, typename... Args>
-  [[nodiscard]] constexpr auto invoke_r(Fn &&fn, Args &&...args) const & noexcept -> Ret
+  [[nodiscard]] constexpr auto invoke_r(Fn &&fn, Args &&...args) const & noexcept(
+      detail::_is_nothrow_rts_invocable<Ret, Fn &&, sum const &, Args &&...>) -> Ret
     requires typelist_invocable_r<Ret, Fn, sum const &, Args &&...>
   {
     using type = detail::_sum_invoke_result<Ret, Fn &&, sum const &, Args &&...>::type;
@@ -506,7 +546,9 @@ struct sum<Ts...> {
    * @return TODO
    */
   template <typename Ret, typename Fn, typename... Args>
-  [[nodiscard]] constexpr auto invoke_r(Fn &&fn, Args &&...args) && noexcept -> Ret
+  [[nodiscard]] constexpr auto
+  invoke_r(Fn &&fn, Args &&...args) && noexcept(detail::_is_nothrow_rts_invocable<Ret, Fn &&, sum &&, Args &&...>)
+      -> Ret
     requires typelist_invocable_r<Ret, Fn, sum &&, Args &&...>
   {
     using type = detail::_sum_invoke_result<Ret, Fn &&, sum &&, Args &&...>::type;
@@ -524,7 +566,8 @@ struct sum<Ts...> {
    * @return TODO
    */
   template <typename Ret, typename Fn, typename... Args>
-  [[nodiscard]] constexpr auto invoke_r(Fn &&fn, Args &&...args) const && noexcept -> Ret
+  [[nodiscard]] constexpr auto invoke_r(Fn &&fn, Args &&...args) const && noexcept(
+      detail::_is_nothrow_rts_invocable<Ret, Fn &&, sum const &&, Args &&...>) -> Ret
     requires typelist_invocable_r<Ret, Fn, sum const &&, Args &&...>
   {
     using type = detail::_sum_invoke_result<Ret, Fn &&, sum const &&, Args &&...>::type;
@@ -541,7 +584,10 @@ struct sum<Ts...> {
    * @return TODO
    */
   template <typename Fn, typename... Args>
-  [[nodiscard]] constexpr auto transform(Fn &&fn, Args &&...args) & noexcept ->
+  [[nodiscard]] constexpr auto transform(Fn &&fn, Args &&...args) & noexcept(
+      detail::_is_nothrow_rts_invocable<
+          typename detail::_sum_invoke_result<detail::_collapsing_sum_tag, Fn &&, sum &, Args &&...>::type, Fn &&,
+          sum &, Args &&...>) ->
       typename detail::_sum_invoke_result<detail::_collapsing_sum_tag, Fn &&, sum &, Args &&...>::type
     requires typelist_invocable<Fn, sum &, Args &&...>
   {
@@ -559,7 +605,10 @@ struct sum<Ts...> {
    * @return TODO
    */
   template <typename Fn, typename... Args>
-  [[nodiscard]] constexpr auto transform(Fn &&fn, Args &&...args) const & noexcept ->
+  [[nodiscard]] constexpr auto transform(Fn &&fn, Args &&...args) const & noexcept(
+      detail::_is_nothrow_rts_invocable<
+          typename detail::_sum_invoke_result<detail::_collapsing_sum_tag, Fn &&, sum const &, Args &&...>::type, Fn &&,
+          sum const &, Args &&...>) ->
       typename detail::_sum_invoke_result<detail::_collapsing_sum_tag, Fn &&, sum const &, Args &&...>::type
     requires typelist_invocable<Fn, sum const &, Args &&...>
   {
@@ -577,7 +626,10 @@ struct sum<Ts...> {
    * @return TODO
    */
   template <typename Fn, typename... Args>
-  [[nodiscard]] constexpr auto transform(Fn &&fn, Args &&...args) && noexcept ->
+  [[nodiscard]] constexpr auto transform(Fn &&fn, Args &&...args) && noexcept(
+      detail::_is_nothrow_rts_invocable<
+          typename detail::_sum_invoke_result<detail::_collapsing_sum_tag, Fn &&, sum &&, Args &&...>::type, Fn &&,
+          sum &&, Args &&...>) ->
       typename detail::_sum_invoke_result<detail::_collapsing_sum_tag, Fn &&, sum &&, Args &&...>::type
     requires typelist_invocable<Fn, sum &&, Args &&...>
   {
@@ -595,7 +647,10 @@ struct sum<Ts...> {
    * @return TODO
    */
   template <typename Fn, typename... Args>
-  [[nodiscard]] constexpr auto transform(Fn &&fn, Args &&...args) const && noexcept ->
+  [[nodiscard]] constexpr auto transform(Fn &&fn, Args &&...args) const && noexcept(
+      detail::_is_nothrow_rts_invocable<
+          typename detail::_sum_invoke_result<detail::_collapsing_sum_tag, Fn &&, sum const &&, Args &&...>::type,
+          Fn &&, sum const &&, Args &&...>) ->
       typename detail::_sum_invoke_result<detail::_collapsing_sum_tag, Fn &&, sum const &&, Args &&...>::type
     requires typelist_invocable<Fn, sum const &&, Args &&...>
   {
@@ -615,7 +670,8 @@ template <typename T> explicit sum(T) -> sum<::std::remove_cvref_t<T>>;
  * @param src TODO
  * @return TODO
  */
-[[nodiscard]] constexpr auto as_sum(auto &&src) -> decltype(auto)
+[[nodiscard]] constexpr auto as_sum(auto &&src) //
+    noexcept(detail::_nothrow_initializable<::std::remove_cvref_t<decltype(src)>, decltype(src)>) -> decltype(auto)
   requires(not some_in_place_type<decltype(src)>)
 {
   return sum<::std::remove_cvref_t<decltype(src)>>(FWD(src));
@@ -628,7 +684,8 @@ template <typename T> explicit sum(T) -> sum<::std::remove_cvref_t<T>>;
  * @return TODO
  */
 template <typename T>
-[[nodiscard]] constexpr auto as_sum(::std::in_place_type_t<T>, auto &&...args) -> decltype(auto)
+[[nodiscard]] constexpr auto as_sum(::std::in_place_type_t<T>, auto &&...args) //
+    noexcept(detail::_nothrow_initializable<T, decltype(args)...>) -> decltype(auto)
   requires detail::_initializable<T, decltype(args)...>
 {
   return sum<T>(::std::in_place_type<T>, FWD(args)...);
@@ -644,11 +701,12 @@ template <typename T>
  * @return TODO
  */
 template <typename... Ts, typename... Tx>
-[[nodiscard]] constexpr bool operator==(sum<Ts...> const &lh, sum<Tx...> const &rh) noexcept
+[[nodiscard]] constexpr bool operator==(sum<Ts...> const &lh, sum<Tx...> const &rh) //
+    noexcept((... && detail::_nothrow_eq_with<Ts, Tx...>))
   requires(... && (::std::equality_comparable<Ts> || not detail::type_one_of<Ts, Tx...>)) //
           && ((sizeof...(Ts)) > 0) && ((sizeof...(Tx)) > 0)
 {
-  return lh.template _invoke<bool>([&rh]<typename T>(::std::in_place_type_t<T> d, auto const &lh) noexcept {
+  return lh.template _invoke<bool>([&rh]<typename T>(::std::in_place_type_t<T> d, auto const &lh) {
     if constexpr (::std::remove_cvref_t<decltype(rh)>::template has_type<T>) {
       return rh.has_value(d) && lh == *rh.get_ptr(d);
     } else {

--- a/tests/fn/choice.cpp
+++ b/tests/fn/choice.cpp
@@ -556,6 +556,29 @@ TEST_CASE("choice non-monadic functionality", "[choice]")
   }
 }
 
+TEST_CASE("choice noexcept", "[choice][noexcept]")
+{
+  using fn::choice;
+  using C = choice<int>;
+
+  // the same monadic operation must carry the same exception promise whichever monad it is written
+  // against - choice's answers are pinned here to match optional's and expected's
+  constexpr auto nothrow_fn = [](auto i) noexcept -> choice<int> { return {i}; };
+  constexpr auto throwing_fn = [](auto i) -> choice<int> { return {i}; };
+
+  static_assert(noexcept(std::declval<C &>().and_then(nothrow_fn)));
+  static_assert(not noexcept(std::declval<C &>().and_then(throwing_fn)));
+  static_assert(not noexcept(std::declval<C &&>().and_then(throwing_fn)));
+
+  constexpr auto nothrow_t = [](auto) noexcept { return 0; };
+  constexpr auto throwing_t = [](auto) { return 0; };
+  static_assert(noexcept(std::declval<C &>().transform(nothrow_t)));
+  static_assert(not noexcept(std::declval<C &>().transform(throwing_t)));
+  static_assert(noexcept(std::declval<C &>().invoke(nothrow_t)));
+  static_assert(not noexcept(std::declval<C &>().invoke(throwing_t)));
+  SUCCEED();
+}
+
 TEST_CASE("choice and_then", "[choice][and_then]")
 {
   using type = fn::choice<bool, int>;

--- a/tests/fn/detail/functional.cpp
+++ b/tests/fn/detail/functional.cpp
@@ -5,6 +5,7 @@
 
 #include <fn/detail/functional.hpp>
 #include <fn/pack.hpp>
+#include <fn/utility.hpp>
 
 #include <catch2/catch_all.hpp>
 
@@ -58,19 +59,38 @@ TEST_CASE("_is_invocable_r", "[functional][is_invocable_r]")
 
 TEST_CASE("_is_nothrow_invocable", "[functional][is_nothrow_invocable]")
 {
-  // Hardcoded to false pending https://github.com/libfn/functional/issues/45
   using fn::detail::_is_nothrow_invocable;
-  static_assert(not _is_nothrow_invocable<decltype(sum_two), int, double>::value);
-  static_assert(not _is_nothrow_invocable<decltype([]() noexcept { return 0; })>::value);
+  static_assert(not _is_nothrow_invocable<decltype(sum_two), int, double>::value); // sum_two can throw
+  static_assert(_is_nothrow_invocable<decltype([]() noexcept { return 0; })>::value);
+  static_assert(not _is_nothrow_invocable<decltype([]() { return 0; })>::value);
+  static_assert(not _is_nothrow_invocable<decltype([](int) noexcept { return 0; })>::value); // not invocable at all
+
+  // it composes through the dispatch: a pack answers for the call over its elements, a sum for the
+  // call over every alternative, since which one runs is only known at run time
+  constexpr auto nothrow_generic = [](auto &&...) noexcept { return 0; };
+  constexpr auto throwing_generic = [](auto &&...) { return 0; };
+  static_assert(_is_nothrow_invocable<decltype(nothrow_generic), fn::pack<int, bool> &>::value);
+  static_assert(not _is_nothrow_invocable<decltype(throwing_generic), fn::pack<int, bool> &>::value);
+  static_assert(_is_nothrow_invocable<decltype(nothrow_generic), fn::sum<bool, int> &>::value);
+  static_assert(not _is_nothrow_invocable<decltype(throwing_generic), fn::sum<bool, int> &>::value);
+
+  // one throwing alternative is enough
+  constexpr auto mixed = fn::overload{[](int &) noexcept { return 0; }, [](bool &) { return 0; }};
+  static_assert(not _is_nothrow_invocable<decltype(mixed), fn::sum<bool, int> &>::value);
   SUCCEED();
 }
 
 TEST_CASE("_is_nothrow_invocable_r", "[functional][is_nothrow_invocable_r]")
 {
-  // Hardcoded to false pending https://github.com/libfn/functional/issues/45
   using fn::detail::_is_nothrow_invocable_r;
   static_assert(not _is_nothrow_invocable_r<double, decltype(sum_two), int, double>::value);
-  static_assert(not _is_nothrow_invocable_r<int, decltype([]() noexcept { return 0; })>::value);
+  static_assert(_is_nothrow_invocable_r<int, decltype([]() noexcept { return 0; })>::value);
+  static_assert(not _is_nothrow_invocable_r<int, decltype([]() { return 0; })>::value);
+  static_assert(not _is_nothrow_invocable_r<int *, decltype([]() noexcept { return 0; })>::value); // not convertible
+
+  constexpr auto nothrow_generic = [](auto &&...) noexcept { return 0; };
+  static_assert(_is_nothrow_invocable_r<int, decltype(nothrow_generic), fn::pack<int, bool> &>::value);
+  static_assert(_is_nothrow_invocable_r<int, decltype(nothrow_generic), fn::sum<bool, int> &>::value);
   SUCCEED();
 }
 

--- a/tests/fn/expected.cpp
+++ b/tests/fn/expected.cpp
@@ -9,6 +9,7 @@
 #include <catch2/catch_all.hpp>
 
 #include <memory>
+#include <string>
 #include <utility>
 #include <variant>
 
@@ -264,13 +265,15 @@ TEST_CASE("graded monad", "[expected][sum][graded][and_then][or_else][sum_value]
     static_assert(noexcept(fn::sum_error(std::declval<S &>())));
     static_assert(noexcept(fn::sum_value(std::declval<V &>())));
 
-    // a lifting overload wraps one side in a sum and relocates the other, so it weighs both. sum's
-    // own value constructor carries no noexcept specifier yet (#280), so these are conservatively
-    // false, and sharpen when it does
-    static_assert(not noexcept(std::declval<fn::expected<int, Error> &>().sum_error()));
-    static_assert(not noexcept(std::declval<fn::expected<int, Error> &&>().sum_value()));
-    static_assert(not noexcept(std::declval<fn::expected<void, Error> &>().sum_error()));
-    static_assert(not noexcept(fn::sum_error(std::declval<fn::expected<int, Error> &>())));
+    // a lifting overload wraps one side in a sum and relocates the other, so it weighs both
+    static_assert(noexcept(std::declval<fn::expected<int, Error> &>().sum_error()));
+    static_assert(noexcept(std::declval<fn::expected<int, Error> &&>().sum_value()));
+    static_assert(noexcept(std::declval<fn::expected<void, Error> &>().sum_error()));
+    static_assert(noexcept(fn::sum_error(std::declval<fn::expected<int, Error> &>())));
+
+    // ... including the side it does not touch: here the value's copy is what can throw
+    static_assert(not noexcept(std::declval<fn::expected<std::string, Error> const &>().sum_error()));
+    static_assert(noexcept(std::declval<fn::expected<std::string, Error> &&>().sum_error()));
     SUCCEED();
   }
 

--- a/tests/fn/optional.cpp
+++ b/tests/fn/optional.cpp
@@ -108,12 +108,20 @@ TEST_CASE("optional graded monad", "[optional][sum][graded][or_else][sum_value]"
     static_assert(noexcept(std::declval<S const &&>().sum_value()));
     static_assert(noexcept(fn::sum_value(std::declval<S &>())));
 
-    // the lifting overloads wrap the value in a sum, so they weigh that construction: sum's own
-    // value constructor carries no noexcept specifier yet (#280), so they are conservatively false
-    // even for int, and sharpen when it does
-    static_assert(not noexcept(std::declval<T &>().sum_value()));
-    static_assert(not noexcept(std::declval<T &&>().sum_value()));
-    static_assert(not noexcept(fn::sum_value(std::declval<T &>())));
+    // the lifting overloads wrap the value in a sum, so they weigh that construction
+    static_assert(noexcept(std::declval<T &>().sum_value()));
+    static_assert(noexcept(std::declval<T &&>().sum_value()));
+    static_assert(noexcept(fn::sum_value(std::declval<T &>())));
+
+    // ... and report it when the value's copy can throw
+    struct throwing_copy {
+      throwing_copy() = default;
+      throwing_copy(throwing_copy const &) noexcept(false);
+      throwing_copy(throwing_copy &&) noexcept;
+    };
+    using W = fn::optional<throwing_copy>;
+    static_assert(not noexcept(std::declval<W const &>().sum_value())); // copies
+    static_assert(noexcept(std::declval<W &&>().sum_value()));          // moves
     SUCCEED();
   }
 

--- a/tests/fn/pack.cpp
+++ b/tests/fn/pack.cpp
@@ -308,6 +308,47 @@ TEST_CASE("append value categories", "[pack][append]")
   }
 }
 
+TEST_CASE("pack noexcept", "[pack][noexcept]")
+{
+  using fn::pack;
+
+  struct Throwy {
+    Throwy() = default;
+    Throwy(Throwy const &) noexcept(false) {}
+    Throwy(Throwy &&) noexcept(false) {}
+  };
+  struct Quiet {
+    Quiet() = default;
+    Quiet(Quiet const &) noexcept {}
+    Quiet(Quiet &&) noexcept {}
+  };
+
+  WHEN("append")
+  {
+    static_assert(noexcept(std::declval<pack<int> &>().append(std::in_place_type<int>, 1)));
+    static_assert(noexcept(std::declval<pack<Quiet> &>().append(std::in_place_type<int>, 1)));
+
+    // the element being appended can throw on construction ...
+    static_assert(
+        not noexcept(std::declval<pack<int> &>().append(std::in_place_type<Throwy>, std::declval<Throwy const &>())));
+    // ... and so can relocating an element the pack already holds, even where the new one cannot
+    static_assert(not noexcept(std::declval<pack<Throwy> &>().append(std::in_place_type<int>, 1)));
+    static_assert(not noexcept(std::declval<pack<Throwy> &>().append(1))); // deduced form
+    SUCCEED();
+  }
+
+  WHEN("invoke")
+  {
+    constexpr auto nothrow_fn = [](auto &&...) noexcept { return 0; };
+    constexpr auto throwing_fn = [](auto &&...) { return 0; };
+    static_assert(noexcept(std::declval<pack<int, bool> &>().invoke(nothrow_fn)));
+    static_assert(not noexcept(std::declval<pack<int, bool> &>().invoke(throwing_fn)));
+    static_assert(noexcept(std::declval<pack<int, bool> &>().template invoke_r<int>(nothrow_fn)));
+    static_assert(not noexcept(std::declval<pack<int, bool> &>().template invoke_r<int>(throwing_fn)));
+    SUCCEED();
+  }
+}
+
 TEST_CASE("pack with immovable data", "[pack][immovable]")
 {
   using fn::pack;

--- a/tests/fn/sum.cpp
+++ b/tests/fn/sum.cpp
@@ -654,6 +654,70 @@ struct PassThrough {
 };
 } // namespace
 
+TEST_CASE("sum noexcept", "[sum][noexcept]")
+{
+  using fn::sum;
+
+  struct Throwy {
+    Throwy() = default;
+    Throwy(Throwy const &) noexcept(false) {}
+    Throwy(Throwy &&) noexcept(false) {}
+    bool operator==(Throwy const &) const noexcept(false) { return true; }
+  };
+  struct Quiet {
+    Quiet() = default;
+    Quiet(Quiet const &) noexcept {}
+    Quiet(Quiet &&) noexcept {}
+    bool operator==(Quiet const &) const noexcept { return true; }
+  };
+
+  WHEN("constructors")
+  {
+    static_assert(noexcept(sum<int>{42}));
+    static_assert(noexcept(sum<int>{std::in_place_type<int>, 42}));
+    static_assert(noexcept(fn::as_sum(42)));
+    static_assert(not noexcept(sum<Throwy>{std::declval<Throwy const &>()}));
+
+    static_assert(std::is_nothrow_copy_constructible_v<sum<int>>);
+    static_assert(std::is_nothrow_copy_constructible_v<sum<Quiet>>);
+    static_assert(not std::is_nothrow_copy_constructible_v<sum<Throwy>>);
+    static_assert(not std::is_nothrow_move_constructible_v<sum<Throwy>>);
+    SUCCEED();
+  }
+
+  WHEN("dispatch")
+  {
+    using S = sum<bool, int>;
+    constexpr auto nothrow_fn = [](auto) noexcept { return 0; };
+    constexpr auto throwing_fn = [](auto) { return 0; };
+
+    static_assert(noexcept(std::declval<S &>().invoke(nothrow_fn)));
+    static_assert(not noexcept(std::declval<S &>().invoke(throwing_fn)));
+    static_assert(noexcept(std::declval<S &>().template invoke_r<int>(nothrow_fn)));
+    static_assert(not noexcept(std::declval<S &>().template invoke_r<int>(throwing_fn)));
+    static_assert(noexcept(std::declval<S &>().transform(nothrow_fn)));
+    static_assert(not noexcept(std::declval<S &>().transform(throwing_fn)));
+
+    // which alternative runs is a run-time choice, so one throwing handler makes the whole
+    // dispatch throwing
+    constexpr auto mixed = fn::overload{[](int) noexcept { return 0; }, [](bool) { return 0; }};
+    static_assert(not noexcept(std::declval<S &>().invoke(mixed)));
+    SUCCEED();
+  }
+
+  WHEN("comparison")
+  {
+    static_assert(noexcept(std::declval<sum<int> const &>() == std::declval<sum<int> const &>()));
+    static_assert(noexcept(std::declval<sum<Quiet> const &>() == std::declval<sum<Quiet> const &>()));
+    static_assert(not noexcept(std::declval<sum<Throwy> const &>() == std::declval<sum<Throwy> const &>()));
+
+    // the rewritten != inherits it
+    static_assert(noexcept(std::declval<sum<int> const &>() != std::declval<sum<int> const &>()));
+    static_assert(not noexcept(std::declval<sum<Throwy> const &>() != std::declval<sum<Throwy> const &>()));
+    SUCCEED();
+  }
+}
+
 TEST_CASE("sum type collapsing", "[sum][transform][normalized]")
 {
   using ::fn::overload;


### PR DESCRIPTION
The dispatch machinery promised `noexcept` unconditionally while invoking user callbacks and constructing user types, so a throwing callback or a throwing copy called `std::terminate` - and since the specification also read `noexcept == true`, callers could not even detect the hazard by asking. The constructors were wrong the other way: carrying no specifier at all, they under-promised, so `sum<int>{42}` was `noexcept(false)`.

`is_nothrow_invocable` / `is_nothrow_invocable_r` (stubbed `false` until now) are the foundation, and are computed by asking the invoke chain itself, which grows the specification it was missing. That composes: a pack answers for the call over its elements, a sum for the call over every alternative - one throwing alternative makes the whole dispatch throwing, since which one runs is a run-time choice. The recursion terminates because each step strictly reduces the number of pack/sum operands.

On top of that: the constructors weigh what they construct and relocate, `append` weighs the element built and every element moved into the new pack, `operator==` weighs the alternatives' own comparisons, and `choice` stops over-promising where `optional` and `expected` never did.

Two traps worth naming. A `noexcept`-specifier is an ordinary constant expression, not a requires-clause: both operands of its `||` must be well-formed, so "this alternative is not compared, and need not be comparable" has to be a guarded trait rather than a disjunction. And an explicit `noexcept` on a defaulted copy/move that disagrees with the implicit specification deletes it - `choice`'s had to drop theirs once `sum`'s became conditional.

Closes #45
Closes #280

---
**Stack**: P6 of 13 — the release-0.1 bugfix queue, merging bottom-up into `main`. Based on #299 and to be retargeted to `main` once it merges; the diff shows only this PR's commits. Every stack boundary was validated with a gcc build and the full test suite on top of `main`, and the aggregate branch ran the full CI matrix green (#289).
