### PR TITLE
Propagate `noexcept` through the verbs and `operator|`

### DIFF
--- a/include/fn/and_then.hpp
+++ b/include/fn/and_then.hpp
@@ -63,7 +63,8 @@ constexpr inline struct and_then_t final {
    * @param fn The function to execute on the value
    * @return A functor that will execute the function on the value
    */
-  [[nodiscard]] constexpr auto operator()(auto &&fn) const noexcept -> functor<and_then_t, decltype(fn)> //
+  [[nodiscard]] constexpr auto operator()(auto &&fn) const
+      noexcept(noexcept(functor<and_then_t, decltype(fn)>{FWD(fn)})) -> functor<and_then_t, decltype(fn)> //
   {
     return {FWD(fn)};
   }
@@ -79,7 +80,8 @@ struct and_then_t::apply final {
    * @param fn The function to apply
    */
   template <some_monadic_type V, typename Fn>
-  [[nodiscard]] constexpr auto operator()(V &&v, Fn &&fn) const noexcept //
+  [[nodiscard]] constexpr auto operator()(V &&v, Fn &&fn) const //
+      noexcept(noexcept(FWD(v).and_then(FWD(fn))))              //
       -> same_kind<V &&> auto
     requires invocable_and_then<Fn &&, V &&>
   {

--- a/include/fn/fail.hpp
+++ b/include/fn/fail.hpp
@@ -37,7 +37,8 @@ concept invocable_fail //
  * @brief TODO
  */
 constexpr inline struct fail_t final {
-  [[nodiscard]] constexpr auto operator()(auto &&fn) const noexcept -> functor<fail_t, decltype(fn)> //
+  [[nodiscard]] constexpr auto operator()(auto &&fn) const noexcept(noexcept(functor<fail_t, decltype(fn)>{FWD(fn)}))
+      -> functor<fail_t, decltype(fn)> //
   {
     return {FWD(fn)};
   }
@@ -57,7 +58,13 @@ struct fail_t::apply final {
    * @return TODO
    */
   template <some_expected_non_void V, typename Fn>
-  [[nodiscard]] constexpr auto operator()(V &&v, Fn &&fn) const noexcept -> ::std::remove_cvref_t<V>
+  [[nodiscard]] constexpr auto operator()(V &&v, Fn &&fn) const //
+      noexcept(
+          ::fn::is_nothrow_invocable_v<Fn, decltype(FWD(v).value())>
+          && ::std::is_nothrow_constructible_v<::std::remove_cvref_t<V>, ::fn::unexpect_t,
+                                               ::fn::invoke_result_t<Fn, decltype(FWD(v).value())>>
+          && ::std::is_nothrow_constructible_v<::std::remove_cvref_t<V>, ::fn::unexpect_t, decltype(FWD(v).error())>)
+          -> ::std::remove_cvref_t<V>
     requires invocable_fail<Fn &&, V &&>
   {
     using type = ::std::remove_cvref_t<V>;
@@ -75,7 +82,12 @@ struct fail_t::apply final {
    * @return TODO
    */
   template <some_expected_void V, typename Fn>
-  [[nodiscard]] constexpr auto operator()(V &&v, Fn &&fn) const noexcept -> ::std::remove_cvref_t<V>
+  [[nodiscard]] constexpr auto operator()(V &&v, Fn &&fn) const //
+      noexcept(
+          ::fn::is_nothrow_invocable_v<Fn>
+          && ::std::is_nothrow_constructible_v<::std::remove_cvref_t<V>, ::fn::unexpect_t, ::fn::invoke_result_t<Fn>>
+          && ::std::is_nothrow_constructible_v<::std::remove_cvref_t<V>, ::fn::unexpect_t, decltype(FWD(v).error())>)
+          -> ::std::remove_cvref_t<V>
     requires invocable_fail<Fn &&, V &&>
   {
     using type = ::std::remove_cvref_t<V>;
@@ -93,7 +105,10 @@ struct fail_t::apply final {
    * @return TODO
    */
   template <some_optional V, typename Fn>
-  [[nodiscard]] constexpr auto operator()(V &&v, Fn &&fn) const noexcept -> ::std::remove_cvref_t<V>
+  [[nodiscard]] constexpr auto operator()(V &&v, Fn &&fn) const //
+      noexcept(::fn::is_nothrow_invocable_v<Fn, decltype(FWD(v).value())>
+               && ::std::is_nothrow_constructible_v<::std::remove_cvref_t<V>, ::std::nullopt_t>)
+          -> ::std::remove_cvref_t<V>
     requires invocable_fail<Fn &&, V &&>
   {
     using type = ::std::remove_cvref_t<V>;

--- a/include/fn/filter.hpp
+++ b/include/fn/filter.hpp
@@ -50,8 +50,9 @@ constexpr inline struct filter_t final {
    * @param on_err The error handler, takes the value by const reference and returns the error type
    * @return A functor that will filter the value of the monadic type
    */
-  [[nodiscard]] constexpr auto operator()(auto &&pred, auto &&on_err) const noexcept
-      -> functor<filter_t, decltype(pred), decltype(on_err)>
+  [[nodiscard]] constexpr auto operator()(auto &&pred, auto &&on_err) const
+      noexcept(noexcept(functor<filter_t, decltype(pred), decltype(on_err)>{FWD(pred), FWD(on_err)}))
+          -> functor<filter_t, decltype(pred), decltype(on_err)>
   {
     return {FWD(pred), FWD(on_err)};
   }
@@ -61,7 +62,8 @@ constexpr inline struct filter_t final {
    * @param pred The predicate to filter the value, takes the value by const reference and returns bool
    * @return A functor that will filter the value of the monadic type
    */
-  [[nodiscard]] constexpr auto operator()(auto &&pred) const noexcept -> functor<filter_t, decltype(pred)>
+  [[nodiscard]] constexpr auto operator()(auto &&pred) const
+      noexcept(noexcept(functor<filter_t, decltype(pred)>{FWD(pred)})) -> functor<filter_t, decltype(pred)>
   {
     return {FWD(pred)};
   }
@@ -82,7 +84,14 @@ struct filter_t::apply final {
    * @return TODO
    */
   template <some_expected_non_void V, typename Pred, typename OnErr>
-  [[nodiscard]] constexpr auto operator()(V &&v, Pred &&pred, OnErr &&on_err) const noexcept -> ::std::remove_cvref_t<V>
+  [[nodiscard]] constexpr auto operator()(V &&v, Pred &&pred, OnErr &&on_err) const //
+      noexcept(
+          ::fn::is_nothrow_invocable_v<Pred, decltype(::std::as_const(v).value())>
+          && ::fn::is_nothrow_invocable_v<OnErr, decltype(FWD(v).value())>
+          && ::std::is_nothrow_constructible_v<::std::remove_cvref_t<V>, ::std::in_place_t, decltype(FWD(v).value())>
+          && ::std::is_nothrow_constructible_v<::std::remove_cvref_t<V>, ::fn::unexpect_t,
+                                               ::fn::invoke_result_t<OnErr, decltype(FWD(v).value())>>
+          && ::std::is_nothrow_constructible_v<::std::remove_cvref_t<V>, V>) -> ::std::remove_cvref_t<V>
     requires invocable_filter<Pred &&, OnErr &&, V &&>
   {
     using type = ::std::remove_cvref_t<V>;
@@ -103,7 +112,12 @@ struct filter_t::apply final {
    * @return TODO
    */
   template <some_expected_void V, typename Pred, typename OnErr>
-  [[nodiscard]] constexpr auto operator()(V &&v, Pred &&pred, OnErr &&on_err) const noexcept -> ::std::remove_cvref_t<V>
+  [[nodiscard]] constexpr auto operator()(V &&v, Pred &&pred, OnErr &&on_err) const //
+      noexcept(
+          ::fn::is_nothrow_invocable_v<Pred> && ::fn::is_nothrow_invocable_v<OnErr>
+          && ::std::is_nothrow_constructible_v<::std::remove_cvref_t<V>, ::std::in_place_t>
+          && ::std::is_nothrow_constructible_v<::std::remove_cvref_t<V>, ::fn::unexpect_t, ::fn::invoke_result_t<OnErr>>
+          && ::std::is_nothrow_constructible_v<::std::remove_cvref_t<V>, V>) -> ::std::remove_cvref_t<V>
     requires invocable_filter<Pred &&, OnErr &&, V &&>
   {
     using type = ::std::remove_cvref_t<V>;
@@ -123,7 +137,12 @@ struct filter_t::apply final {
    * @return TODO
    */
   template <some_optional V, typename Pred>
-  [[nodiscard]] constexpr auto operator()(V &&v, Pred &&pred) const noexcept -> ::std::remove_cvref_t<V>
+  [[nodiscard]] constexpr auto operator()(V &&v, Pred &&pred) const //
+      noexcept(
+          ::fn::is_nothrow_invocable_v<Pred, decltype(::std::as_const(v).value())>
+          && ::std::is_nothrow_constructible_v<::std::remove_cvref_t<V>, ::std::in_place_t, decltype(FWD(v).value())>
+          && ::std::is_nothrow_constructible_v<::std::remove_cvref_t<V>, ::std::nullopt_t>
+          && ::std::is_nothrow_constructible_v<::std::remove_cvref_t<V>, V>) -> ::std::remove_cvref_t<V>
     requires invocable_filter<Pred &&, void, V &&>
   {
     using type = ::std::remove_cvref_t<V>;

--- a/include/fn/functor.hpp
+++ b/include/fn/functor.hpp
@@ -38,7 +38,11 @@ template <typename Functor, typename... Args> struct functor final {
    * @param self TODO
    * @return TODO
    */
-  [[nodiscard]] constexpr friend auto operator|(some_monadic_type auto &&v, auto &&self) noexcept -> decltype(auto)
+  // The pipeline propagates what the operation itself promises: the verb's `apply` knows, and
+  // `_swap_invoke` carries that answer up. Promising `noexcept` here regardless would turn an
+  // exception the monad's own member would propagate into a call to std::terminate.
+  [[nodiscard]] constexpr friend auto operator|(some_monadic_type auto &&v, auto &&self) //
+      noexcept(noexcept(data_t::_swap_invoke(FWD(self).data, functor_apply{}, FWD(v)))) -> decltype(auto)
     requires ::std::same_as<::std::remove_cvref_t<decltype(self)>, functor>
              && monadic_invocable<functor_type, decltype(v), Args...>
   {

--- a/include/fn/inspect.hpp
+++ b/include/fn/inspect.hpp
@@ -42,7 +42,8 @@ constexpr inline struct inspect_t final {
    * @param fn TODO
    * @return TODO
    */
-  [[nodiscard]] constexpr auto operator()(auto &&fn) const noexcept -> functor<inspect_t, decltype(fn)>
+  [[nodiscard]] constexpr auto operator()(auto &&fn) const noexcept(noexcept(functor<inspect_t, decltype(fn)>{FWD(fn)}))
+      -> functor<inspect_t, decltype(fn)>
   {
     return {FWD(fn)};
   }
@@ -59,7 +60,8 @@ struct inspect_t::apply final {
    * @return TODO
    */
   template <some_expected_non_void V, typename Fn>
-  [[nodiscard]] constexpr auto operator()(V &&v, Fn &&fn) const noexcept -> V &&
+  [[nodiscard]] constexpr auto operator()(V &&v, Fn &&fn) const
+      noexcept(::fn::is_nothrow_invocable_v<Fn, decltype(::std::as_const(v).value())>) -> V &&
     requires invocable_inspect<Fn &&, V &&>
   {
     if (v.has_value()) {
@@ -76,7 +78,7 @@ struct inspect_t::apply final {
    * @return TODO
    */
   template <some_expected_void V, typename Fn>
-  [[nodiscard]] constexpr auto operator()(V &&v, Fn &&fn) const noexcept -> V &&
+  [[nodiscard]] constexpr auto operator()(V &&v, Fn &&fn) const noexcept(::fn::is_nothrow_invocable_v<Fn>) -> V &&
     requires invocable_inspect<Fn &&, V &&>
   {
     if (v.has_value()) {
@@ -93,7 +95,8 @@ struct inspect_t::apply final {
    * @return TODO
    */
   template <some_optional V, typename Fn>
-  [[nodiscard]] constexpr auto operator()(V &&v, Fn &&fn) const noexcept -> V &&
+  [[nodiscard]] constexpr auto operator()(V &&v, Fn &&fn) const
+      noexcept(::fn::is_nothrow_invocable_v<Fn, decltype(::std::as_const(v).value())>) -> V &&
     requires invocable_inspect<Fn &&, V &&>
   {
     if (v.has_value()) {
@@ -110,7 +113,8 @@ struct inspect_t::apply final {
    * @return TODO
    */
   template <some_choice V, typename Fn>
-  [[nodiscard]] constexpr auto operator()(V &&v, Fn &&fn) const noexcept -> V &&
+  [[nodiscard]] constexpr auto operator()(V &&v, Fn &&fn) const
+      noexcept(::fn::is_nothrow_invocable_v<Fn, decltype(::std::as_const(v).value())>) -> V &&
     requires invocable_inspect<Fn &&, V &&>
   {
     ::fn::invoke(FWD(fn), ::std::as_const(v).value()); // side-effects only

--- a/include/fn/inspect_error.hpp
+++ b/include/fn/inspect_error.hpp
@@ -37,7 +37,8 @@ constexpr inline struct inspect_error_t final {
    * @param fn TODO
    * @return TODO
    */
-  [[nodiscard]] constexpr auto operator()(auto &&fn) const noexcept -> functor<inspect_error_t, decltype(fn)> //
+  [[nodiscard]] constexpr auto operator()(auto &&fn) const
+      noexcept(noexcept(functor<inspect_error_t, decltype(fn)>{FWD(fn)})) -> functor<inspect_error_t, decltype(fn)> //
   {
     return {FWD(fn)};
   }
@@ -57,7 +58,8 @@ struct inspect_error_t::apply final {
    * @return TODO
    */
   template <some_expected V, typename Fn>
-  [[nodiscard]] constexpr auto operator()(V &&v, Fn &&fn) const noexcept -> V &&
+  [[nodiscard]] constexpr auto operator()(V &&v, Fn &&fn) const
+      noexcept(::fn::is_nothrow_invocable_v<Fn, decltype(::std::as_const(v).error())>) -> V &&
     requires invocable_inspect_error<Fn &&, V &&>
   {
     if (not v.has_value()) {
@@ -74,7 +76,7 @@ struct inspect_error_t::apply final {
    * @return TODO
    */
   template <some_optional V, typename Fn>
-  [[nodiscard]] constexpr auto operator()(V &&v, Fn &&fn) const noexcept -> V &&
+  [[nodiscard]] constexpr auto operator()(V &&v, Fn &&fn) const noexcept(::fn::is_nothrow_invocable_v<Fn>) -> V &&
     requires invocable_inspect_error<Fn &&, V &&>
   {
     if (not v.has_value()) {

--- a/include/fn/or_else.hpp
+++ b/include/fn/or_else.hpp
@@ -49,7 +49,8 @@ constexpr inline struct or_else_t final {
    * @param fn TODO
    * @return TODO
    */
-  [[nodiscard]] constexpr auto operator()(auto &&fn) const noexcept -> functor<or_else_t, decltype(fn)> //
+  [[nodiscard]] constexpr auto operator()(auto &&fn) const noexcept(noexcept(functor<or_else_t, decltype(fn)>{FWD(fn)}))
+      -> functor<or_else_t, decltype(fn)> //
   {
     return {FWD(fn)};
   }
@@ -69,7 +70,8 @@ struct or_else_t::apply final {
    * @return TODO
    */
   template <some_monadic_type V, typename Fn>
-  [[nodiscard]] constexpr auto operator()(V &&v, Fn &&fn) const noexcept //
+  [[nodiscard]] constexpr auto operator()(V &&v, Fn &&fn) const //
+      noexcept(noexcept(FWD(v).or_else(FWD(fn))))               //
       -> same_value_kind<V &&> auto
     requires invocable_or_else<Fn &&, V &&>
   {

--- a/include/fn/recover.hpp
+++ b/include/fn/recover.hpp
@@ -42,7 +42,8 @@ constexpr inline struct recover_t final {
    * @param fn TODO
    * @return TODO
    */
-  [[nodiscard]] constexpr auto operator()(auto &&fn) const noexcept -> functor<recover_t, decltype(fn)> //
+  [[nodiscard]] constexpr auto operator()(auto &&fn) const noexcept(noexcept(functor<recover_t, decltype(fn)>{FWD(fn)}))
+      -> functor<recover_t, decltype(fn)> //
   {
     return {FWD(fn)};
   }
@@ -62,7 +63,13 @@ struct recover_t::apply final {
    * @return TODO
    */
   template <some_expected_non_void V, typename Fn>
-  [[nodiscard]] constexpr auto operator()(V &&v, Fn &&fn) const noexcept -> ::std::remove_cvref_t<V>
+  [[nodiscard]] constexpr auto operator()(V &&v, Fn &&fn) const //
+      noexcept(
+          ::fn::is_nothrow_invocable_v<Fn, decltype(FWD(v).error())>
+          && ::std::is_nothrow_constructible_v<::std::remove_cvref_t<V>, ::std::in_place_t, decltype(FWD(v).value())>
+          && ::std::is_nothrow_constructible_v<::std::remove_cvref_t<V>, ::std::in_place_t,
+                                               ::fn::invoke_result_t<Fn, decltype(FWD(v).error())>>)
+          -> ::std::remove_cvref_t<V>
     requires invocable_recover<Fn &&, V &&>
   {
     using type = ::std::remove_cvref_t<V>;
@@ -80,7 +87,10 @@ struct recover_t::apply final {
    * @return TODO
    */
   template <some_expected_void V, typename Fn>
-  [[nodiscard]] constexpr auto operator()(V &&v, Fn &&fn) const noexcept -> ::std::remove_cvref_t<V>
+  [[nodiscard]] constexpr auto operator()(V &&v, Fn &&fn) const //
+      noexcept(::fn::is_nothrow_invocable_v<Fn, decltype(FWD(v).error())>
+               && ::std::is_nothrow_constructible_v<::std::remove_cvref_t<V>, ::std::in_place_t>)
+          -> ::std::remove_cvref_t<V>
     requires invocable_recover<Fn &&, V &&>
   {
     using type = ::std::remove_cvref_t<V>;
@@ -99,7 +109,12 @@ struct recover_t::apply final {
    * @return TODO
    */
   template <some_optional V, typename Fn>
-  [[nodiscard]] constexpr auto operator()(V &&v, Fn &&fn) const noexcept -> ::std::remove_cvref_t<V>
+  [[nodiscard]] constexpr auto operator()(V &&v, Fn &&fn) const //
+      noexcept(
+          ::fn::is_nothrow_invocable_v<Fn>
+          && ::std::is_nothrow_constructible_v<::std::remove_cvref_t<V>, ::std::in_place_t, decltype(FWD(v).value())>
+          && ::std::is_nothrow_constructible_v<::std::remove_cvref_t<V>, ::std::in_place_t, ::fn::invoke_result_t<Fn>>)
+          -> ::std::remove_cvref_t<V>
     requires invocable_recover<Fn &&, V &&>
   {
     using type = ::std::remove_cvref_t<V>;

--- a/include/fn/transform.hpp
+++ b/include/fn/transform.hpp
@@ -63,7 +63,8 @@ constexpr inline struct transform_t final {
    * @param fn TODO
    * @return TODO
    */
-  [[nodiscard]] constexpr auto operator()(auto &&fn) const noexcept -> functor<transform_t, decltype(fn)> //
+  [[nodiscard]] constexpr auto operator()(auto &&fn) const
+      noexcept(noexcept(functor<transform_t, decltype(fn)>{FWD(fn)})) -> functor<transform_t, decltype(fn)> //
   {
     return {FWD(fn)};
   }
@@ -83,7 +84,8 @@ struct transform_t::apply final {
    * @return TODO
    */
   template <some_monadic_type V, typename Fn>
-  [[nodiscard]] constexpr auto operator()(V &&v, Fn &&fn) const noexcept -> same_kind<V &&> auto
+  [[nodiscard]] constexpr auto operator()(V &&v, Fn &&fn) const noexcept(noexcept(FWD(v).transform(FWD(fn))))
+      -> same_kind<V &&> auto
     requires invocable_transform<Fn &&, V &&>
   {
     return FWD(v).transform(FWD(fn));

--- a/include/fn/transform_error.hpp
+++ b/include/fn/transform_error.hpp
@@ -37,7 +37,9 @@ constexpr inline struct transform_error_t final {
    * @param fn TODO
    * @return TODO
    */
-  [[nodiscard]] constexpr auto operator()(auto &&fn) const noexcept -> functor<transform_error_t, decltype(fn)> //
+  [[nodiscard]] constexpr auto operator()(auto &&fn) const
+      noexcept(noexcept(functor<transform_error_t, decltype(fn)>{FWD(fn)}))
+          -> functor<transform_error_t, decltype(fn)> //
   {
     return {FWD(fn)};
   }
@@ -57,7 +59,8 @@ struct transform_error_t::apply final {
    * @return TODO
    */
   template <some_expected V, typename Fn>
-  [[nodiscard]] constexpr auto operator()(V &&v, Fn &&fn) const noexcept -> same_value_kind<V &&> auto
+  [[nodiscard]] constexpr auto operator()(V &&v, Fn &&fn) const noexcept(noexcept(FWD(v).transform_error(FWD(fn))))
+      -> same_value_kind<V &&> auto
     requires invocable_transform_error<Fn &&, V &&>
   {
     return FWD(v).transform_error(FWD(fn));

--- a/include/fn/value_or.hpp
+++ b/include/fn/value_or.hpp
@@ -34,7 +34,8 @@ constexpr inline struct value_or_t final {
    * @return TODO
    */
   template <typename... Args>
-  [[nodiscard]] constexpr auto operator()(Args &&...args) const noexcept -> functor<value_or_t, Args &&...> //
+  [[nodiscard]] constexpr auto operator()(Args &&...args) const
+      noexcept(noexcept(functor<value_or_t, Args &&...>{FWD(args)...})) -> functor<value_or_t, Args &&...> //
   {
     return {FWD(args)...};
   }
@@ -53,9 +54,12 @@ struct value_or_t::apply final {
    * @param args TODO
    * @return TODO
    */
+  // The fallback is built inside, so its construction is weighed here rather than propagated: the
+  // callable or_else receives is a lambda, which cannot be named in this specification.
   template <some_monadic_type V, typename... Args>
-  [[nodiscard]] constexpr auto operator()(V &&v, Args &&...args) const noexcept //
-      -> ::std::remove_cvref_t<V>
+  [[nodiscard]] constexpr auto operator()(V &&v, Args &&...args) const //
+      noexcept(::std::is_nothrow_constructible_v<::std::remove_cvref_t<V>, ::std::in_place_t, Args...>
+               && ::std::is_nothrow_constructible_v<::std::remove_cvref_t<V>, V>) -> ::std::remove_cvref_t<V>
     requires invocable_value_or<V &&, Args...>
   {
     using type = ::std::remove_cvref_t<V>;

--- a/tests/fn/and_then.cpp
+++ b/tests/fn/and_then.cpp
@@ -1047,3 +1047,25 @@ static_assert(invocable_and_then<decltype(fn_int_rvalue<expected<Value, Error>>)
 static_assert(not invocable_and_then<decltype(fn_int_rvalue<expected<Value, Error>>), expected<int, Error> &>); // cannot bind lvalue to rvalue-ref
 // clang-format on
 } // namespace fn
+
+TEST_CASE("and_then noexcept", "[and_then][noexcept]")
+{
+  // the pipeline propagates the member's own spec (the pipeline itself is pinned in functor.cpp)
+  using O = fn::optional<int>;
+  constexpr auto nothrow_fn = [](int i) noexcept -> O { return {i}; };
+  constexpr auto throwing_fn = [](int i) -> O { return {i}; };
+
+  static_assert(noexcept(std::declval<O &>().and_then(nothrow_fn)));
+  static_assert(noexcept(std::declval<O &>() | fn::and_then(nothrow_fn)));
+  static_assert(not noexcept(std::declval<O &>().and_then(throwing_fn)));
+  static_assert(not noexcept(std::declval<O &>() | fn::and_then(throwing_fn)));
+
+  // and_then weighs the untouched ERROR's relocation too: a std::string error cannot be copied
+  // without throwing, so even a noexcept callback yields noexcept(false)
+  using E = fn::expected<int, std::string>;
+  constexpr auto nothrow_e = [](int i) noexcept -> E { return {i}; };
+  static_assert(not noexcept(std::declval<E &>() | fn::and_then(nothrow_e)));
+  static_assert(noexcept(std::declval<fn::expected<int, int> &>()
+                         | fn::and_then([](int i) noexcept -> fn::expected<int, int> { return {i}; })));
+  SUCCEED();
+}

--- a/tests/fn/discard.cpp
+++ b/tests/fn/discard.cpp
@@ -229,3 +229,13 @@ TEST_CASE("constexpr discard optional", "[discard][constexpr][optional]")
 
   SUCCEED();
 }
+
+TEST_CASE("discard noexcept", "[discard][noexcept]")
+{
+  // discard is the one verb whose unconditional noexcept is accurate by construction: it invokes
+  // nothing and returns void. Asserted positively, not as a tripwire.
+  using E = fn::expected<int, int>;
+  static_assert(noexcept(std::declval<E &>() | fn::discard()));
+  static_assert(noexcept(std::declval<fn::optional<std::string> &>() | fn::discard()));
+  SUCCEED();
+}

--- a/tests/fn/fail.cpp
+++ b/tests/fn/fail.cpp
@@ -411,3 +411,14 @@ static_assert(invocable_fail<decltype(fn_int_rvalue<Error>), expected<int, Error
 static_assert(
     not invocable_fail<decltype(fn_int_rvalue<Error>), expected<int, Error> &>); // cannot bind lvalue to rvalue-ref
 } // namespace fn
+
+TEST_CASE("fail noexcept", "[fail][noexcept]")
+{
+  using E = fn::expected<int, int>;
+  using O = fn::optional<int>;
+  static_assert(noexcept(std::declval<E &>() | fn::fail([](int) noexcept { return 0; })));
+  static_assert(not noexcept(std::declval<E &>() | fn::fail([](int) { return 0; })));
+  static_assert(noexcept(std::declval<O &>() | fn::fail([](int) noexcept {})));
+  static_assert(not noexcept(std::declval<O &>() | fn::fail([](int) {})));
+  SUCCEED();
+}

--- a/tests/fn/filter.cpp
+++ b/tests/fn/filter.cpp
@@ -658,3 +658,19 @@ TEST_CASE("constexpr filter optional with sum", "[filter][constexpr][optional][s
 
   SUCCEED();
 }
+
+TEST_CASE("filter noexcept", "[filter][noexcept]")
+{
+  // filter invokes the predicate, may invoke the error handler, and constructs the result
+  using E = fn::expected<int, int>;
+  using O = fn::optional<int>;
+  static_assert(
+      noexcept(std::declval<E &>() | fn::filter([](int) noexcept { return true; }, [](int) noexcept { return 0; })));
+  static_assert(
+      not noexcept(std::declval<E &>() | fn::filter([](int) { return true; }, [](int) noexcept { return 0; })));
+  static_assert(
+      not noexcept(std::declval<E &>() | fn::filter([](int) noexcept { return true; }, [](int) { return 0; })));
+  static_assert(noexcept(std::declval<O &>() | fn::filter([](int) noexcept { return true; })));
+  static_assert(not noexcept(std::declval<O &>() | fn::filter([](int) { return true; })));
+  SUCCEED();
+}

--- a/tests/fn/functor.cpp
+++ b/tests/fn/functor.cpp
@@ -44,8 +44,48 @@ static_assert(is::not_invocable_with_any(fn2)); // arity mismatch
 } // namespace check_optional
 } // namespace
 
+namespace {
+// A second verb whose apply is honestly noexcept(false), to pin what the PIPELINE promises apart
+// from what any real verb promises. Each verb file asserts only its own member's spec.
+constexpr inline struct throwing_t final {
+  auto operator()(auto &&fn) const noexcept -> fn::functor<throwing_t, decltype(fn)> { return {FWD(fn)}; }
+
+  struct apply final {
+    auto operator()(fn::some_monadic_type auto &&v, auto &&fn) const noexcept(false) -> decltype(auto)
+      requires requires { fn(v.value()); }
+    {
+      return FWD(v).transform([&fn](auto &&v) noexcept { return FWD(fn)(FWD(v)); });
+    }
+  };
+} throwing = {};
+
+constexpr inline struct nothrow_t final {
+  auto operator()(auto &&fn) const noexcept -> fn::functor<nothrow_t, decltype(fn)> { return {FWD(fn)}; }
+
+  struct apply final {
+    auto operator()(fn::some_monadic_type auto &&v, auto &&fn) const noexcept -> decltype(auto)
+      requires requires { fn(v.value()); }
+    {
+      return FWD(v).transform([&fn](auto &&v) noexcept { return FWD(fn)(FWD(v)); });
+    }
+  };
+} nothrow_verb = {};
+} // namespace
+
 TEST_CASE("user-defined monadic operation", "[functor]")
 {
   CHECK((fn::expected<int, std::runtime_error>{12} | dummy(fn1)).value() == 13);
   CHECK((fn::optional{42} | dummy(fn1)).value() == 43);
+}
+
+TEST_CASE("pipeline noexcept", "[functor][noexcept]")
+{
+  // operator| propagates what the operation promises, rather than promising noexcept regardless -
+  // which would turn an exception the operation would propagate into a call to std::terminate
+  using O = fn::optional<int>;
+  static_assert(noexcept(std::declval<O &>() | nothrow_verb(fn1)));
+  static_assert(not noexcept(std::declval<O &>() | throwing(fn1)));
+  static_assert(noexcept(std::declval<O &&>() | nothrow_verb(fn1)));
+  static_assert(not noexcept(std::declval<O &&>() | throwing(fn1)));
+  SUCCEED();
 }

--- a/tests/fn/inspect.cpp
+++ b/tests/fn/inspect.cpp
@@ -479,3 +479,19 @@ static_assert(not invocable_inspect<decltype(fn_int_const_rvalue), expected<int,
 // cannot bind lvalue to rvalue-ref
 static_assert(not invocable_inspect<decltype(fn_int_rvalue), expected<int, Error>>);
 } // namespace fn
+
+TEST_CASE("inspect noexcept", "[inspect][noexcept]")
+{
+  // inspect's apply IS the implementation - nothing else computed a spec for it to propagate
+  using E = fn::expected<int, int>;
+  using O = fn::optional<int>;
+  static_assert(noexcept(std::declval<E &>() | fn::inspect([](int) noexcept {})));
+  static_assert(not noexcept(std::declval<E &>() | fn::inspect([](int) {})));
+  static_assert(noexcept(std::declval<O &>() | fn::inspect([](int) noexcept {})));
+  static_assert(not noexcept(std::declval<O &>() | fn::inspect([](int) {})));
+
+  // the operand is returned unchanged, so only the callback can throw - not the accessor, which
+  // the body only reaches when there is a value
+  static_assert(noexcept(std::declval<fn::expected<std::string, int> &>() | fn::inspect([](auto const &) noexcept {})));
+  SUCCEED();
+}

--- a/tests/fn/inspect_error.cpp
+++ b/tests/fn/inspect_error.cpp
@@ -260,3 +260,14 @@ static_assert(not invocable_inspect_error<decltype(fn_int_const_rvalue), expecte
 // cannot bind lvalue to rvalue-ref
 static_assert(not invocable_inspect_error<decltype(fn_int_rvalue), expected<void, int>>);
 } // namespace fn
+
+TEST_CASE("inspect_error noexcept", "[inspect_error][noexcept]")
+{
+  using E = fn::expected<int, int>;
+  using O = fn::optional<int>;
+  static_assert(noexcept(std::declval<E &>() | fn::inspect_error([](int) noexcept {})));
+  static_assert(not noexcept(std::declval<E &>() | fn::inspect_error([](int) {})));
+  static_assert(noexcept(std::declval<O &>() | fn::inspect_error([]() noexcept {})));
+  static_assert(not noexcept(std::declval<O &>() | fn::inspect_error([]() {})));
+  SUCCEED();
+}

--- a/tests/fn/or_else.cpp
+++ b/tests/fn/or_else.cpp
@@ -511,3 +511,21 @@ static_assert(invocable_or_else<decltype(fn_int_rvalue<expected<int, int>>), exp
 static_assert(not invocable_or_else<decltype(fn_int_rvalue<expected<int, int>>), expected<int, int> &>); // cannot bind lvalue to rvalue-ref
 // clang-format on
 } // namespace fn
+
+TEST_CASE("or_else noexcept", "[or_else][noexcept]")
+{
+  using E = fn::expected<int, int>;
+  constexpr auto nothrow_fn = [](int i) noexcept -> E { return {i}; };
+  constexpr auto throwing_fn = [](int i) -> E { return {i}; };
+
+  static_assert(noexcept(std::declval<E const &>().or_else(nothrow_fn)));
+  static_assert(noexcept(std::declval<E const &>() | fn::or_else(nothrow_fn)));
+  static_assert(not noexcept(std::declval<E const &>().or_else(throwing_fn)));
+  static_assert(not noexcept(std::declval<E const &>() | fn::or_else(throwing_fn)));
+
+  // or_else weighs the untouched VALUE's relocation
+  using S = fn::expected<std::string, int>;
+  constexpr auto nothrow_s = [](int) noexcept -> S { return S{std::in_place}; };
+  static_assert(not noexcept(std::declval<S const &>() | fn::or_else(nothrow_s)));
+  SUCCEED();
+}

--- a/tests/fn/recover.cpp
+++ b/tests/fn/recover.cpp
@@ -265,3 +265,19 @@ TEST_CASE("constexpr recover optional", "[recover][constexpr][optional]")
 
   SUCCEED();
 }
+
+TEST_CASE("recover noexcept", "[recover][noexcept]")
+{
+  // recover invokes AND constructs the result, so it weighs both
+  using E = fn::expected<int, int>;
+  using O = fn::optional<int>;
+  static_assert(noexcept(std::declval<E &>() | fn::recover([](int) noexcept { return 0; })));
+  static_assert(not noexcept(std::declval<E &>() | fn::recover([](int) { return 0; })));
+  static_assert(noexcept(std::declval<O &>() | fn::recover([]() noexcept { return 0; })));
+  static_assert(not noexcept(std::declval<O &>() | fn::recover([]() { return 0; })));
+
+  // constructing the result can throw even where the callback cannot
+  using S = fn::expected<std::string, int>;
+  static_assert(not noexcept(std::declval<S const &>() | fn::recover([](int) noexcept { return std::string{}; })));
+  SUCCEED();
+}

--- a/tests/fn/transform.cpp
+++ b/tests/fn/transform.cpp
@@ -560,3 +560,17 @@ TEST_CASE("constexpr transform choice", "[transform][constexpr][choice]")
 
   SUCCEED();
 }
+
+TEST_CASE("transform noexcept", "[transform][noexcept]")
+{
+  using O = fn::optional<int>;
+  static_assert(noexcept(std::declval<O &>() | fn::transform([](int i) noexcept { return i + 1; })));
+  static_assert(not noexcept(std::declval<O &>() | fn::transform([](int i) { return i + 1; })));
+
+  // ... and the untouched error's relocation, as and_then does
+  using E = fn::expected<int, std::string>;
+  static_assert(not noexcept(std::declval<E &>() | fn::transform([](int i) noexcept { return i + 1; })));
+  static_assert(
+      noexcept(std::declval<fn::expected<int, int> &>() | fn::transform([](int i) noexcept { return i + 1; })));
+  SUCCEED();
+}

--- a/tests/fn/transform_error.cpp
+++ b/tests/fn/transform_error.cpp
@@ -196,3 +196,15 @@ TEST_CASE("constexpr transform_error expected with sum", "[transform_error][cons
 
   SUCCEED();
 }
+
+TEST_CASE("transform_error noexcept", "[transform_error][noexcept]")
+{
+  using E = fn::expected<int, int>;
+  static_assert(noexcept(std::declval<E &>() | fn::transform_error([](int i) noexcept { return i + 1; })));
+  static_assert(not noexcept(std::declval<E &>() | fn::transform_error([](int i) { return i + 1; })));
+
+  // the untouched value is relocated into the result, so its copy weighs too
+  using S = fn::expected<std::string, int>;
+  static_assert(not noexcept(std::declval<S const &>() | fn::transform_error([](int i) noexcept { return i + 1; })));
+  SUCCEED();
+}

--- a/tests/fn/value_or.cpp
+++ b/tests/fn/value_or.cpp
@@ -155,3 +155,16 @@ TEST_CASE("constexpr value_or optional", "[value_or][constexpr][optional]")
 
   SUCCEED();
 }
+
+TEST_CASE("value_or noexcept", "[value_or][noexcept]")
+{
+  using E = fn::expected<int, int>;
+  using O = fn::optional<int>;
+  static_assert(noexcept(std::declval<E &>() | fn::value_or(1)));
+  static_assert(noexcept(std::declval<O &>() | fn::value_or(1)));
+
+  // building the fallback value can throw
+  using S = fn::optional<std::string>;
+  static_assert(not noexcept(std::declval<S &>() | fn::value_or("x")));
+  SUCCEED();
+}


### PR DESCRIPTION
`v.and_then(f)` was correctly `noexcept(false)` for a throwing `f`, but `v | fn::and_then(f)` was `noexcept(true)`: the pipeline - the library's headline API, and what the README is written in - turned an exception the member would have propagated into a call to std::terminate. Every step promised `noexcept` unconditionally: the nielbloid (which stores the callable, and that store can throw), `operator|`, `_swap_invoke`, and each verb's `apply`.

The verbs divide by how `apply` is written. The forwarding ones - and_then, or_else, transform, transform_error, value_or - delegate to the monad's member, which already computes a precise spec, so they propagate it. The self-implementing ones - inspect, inspect_error, recover, fail, filter - ARE the implementation: they invoke the callback and construct the result themselves, and nothing anywhere computed an honest answer for them to propagate, so it is computed here, which the real nothrow-invocable traits now make possible. `discard` invokes nothing and returns void, so its unconditional `noexcept` was always accurate; it is asserted positively rather than as a tripwire.

A spec must weigh what the body reaches, not what it writes: `.value()` and `.error()` can throw, but the bodies only call them once has_value() has answered, so the specs ask about the invocation with `decltype` of the accessor, never `noexcept` of a call to it.

Closes #285

---
**Stack**: P7 of 13 — the release-0.1 bugfix queue, merging bottom-up into `main`. Based on #300 and to be retargeted to `main` once it merges; the diff shows only this PR's commits. Every stack boundary was validated with a gcc build and the full test suite on top of `main`, and the aggregate branch ran the full CI matrix green (#289).
