### PR TITLE
Make `operator&` promise only what joining actually promises

### DIFF
--- a/include/fn/detail/functional.hpp
+++ b/include/fn/detail/functional.hpp
@@ -19,7 +19,22 @@
 namespace fn::detail {
 
 namespace _fold_detail {
-template <typename L, typename R> [[nodiscard]] constexpr auto _fold(auto &&l, auto &&r)
+// The branch the fold takes is chosen by `if constexpr`, so a single expression cannot state its
+// specification: the two untaken spellings would be ill-formed. Hence one specialization per branch.
+template <typename L, typename R, typename Lv, typename Rv>
+struct _nothrow_fold : ::std::bool_constant<noexcept(::fn::pack<L, R>{::std::declval<Lv>(), ::std::declval<Rv>()})> {};
+template <typename L, typename R, typename Lv, typename Rv>
+  requires _some_pack<L>
+struct _nothrow_fold<L, R, Lv, Rv>
+    : ::std::bool_constant<noexcept(::std::declval<Lv>().append(::std::in_place_type_t<R>{}, ::std::declval<Rv>()))> {};
+template <typename L, typename R, typename Lv, typename Rv>
+  requires(not _some_pack<L>) && _some_pack<R>
+struct _nothrow_fold<L, R, Lv, Rv> : ::std::bool_constant<noexcept(::fn::pack<L>{::std::declval<Lv>()}.append(
+                                         ::std::in_place_type_t<R>{}, ::std::declval<Rv>()))> {};
+
+template <typename L, typename R>
+[[nodiscard]] constexpr auto _fold(auto &&l, auto &&r) //
+    noexcept(_nothrow_fold<L, R, decltype(l), decltype(r)>::value)
 {
   if constexpr (_some_pack<L>) {
     return FWD(l).append(::std::in_place_type_t<R>{}, FWD(r));
@@ -32,35 +47,70 @@ template <typename L, typename R> [[nodiscard]] constexpr auto _fold(auto &&l, a
   }
 }
 
+// Named types, not lambdas: `fold` and everything above it specify themselves in terms of what
+// dispatching through these promises, and a lambda can be named neither in a noexcept-specifier nor
+// (before clang 17) in any unevaluated operand at all.
+template <typename R, typename Rv> struct _fold_rh final {
+  Rv rv;
+
+  template <typename L>
+  [[nodiscard]] constexpr auto operator()(::std::in_place_type_t<L>, auto &&l) const
+      noexcept(noexcept(_fold<L, R>(FWD(l), ::std::declval<Rv>())))
+  {
+    return _fold<L, R>(FWD(l), static_cast<Rv &&>(rv));
+  }
+};
+
+template <typename L, typename Lv> struct _fold_lh final {
+  Lv lv;
+
+  template <typename R>
+  [[nodiscard]] constexpr auto operator()(::std::in_place_type_t<R>, auto &&r) const
+      noexcept(noexcept(_fold<L, R>(::std::declval<Lv>(), FWD(r))))
+  {
+    return _fold<L, R>(static_cast<Lv &&>(lv), FWD(r));
+  }
+};
+
+template <typename Rv> struct _fold_rh_sum final {
+  Rv rv;
+
+  template <typename L>
+  [[nodiscard]] constexpr auto operator()(::std::in_place_type_t<L>, auto &&l) const
+      noexcept(noexcept(::std::declval<Rv>()._transform(_fold_lh<L, decltype(l)>{FWD(l)})))
+  {
+    return static_cast<Rv &&>(rv)._transform(_fold_lh<L, decltype(l)>{FWD(l)});
+  }
+};
+
 template <typename Lh, typename Rh>
   requires _some_sum<Lh> && _some_sum<Rh>
-[[nodiscard]] constexpr auto fold(auto &&lv, auto &&rv)
+[[nodiscard]] constexpr auto fold(auto &&lv, auto &&rv) //
+    noexcept(noexcept(FWD(lv)._transform(_fold_rh_sum<decltype(rv)>{FWD(rv)})))
 {
-  return FWD(lv)._transform([&rv]<typename L>(::std::in_place_type_t<L>, auto &&l) {
-    return FWD(rv)._transform(
-        [&l]<typename R>(::std::in_place_type_t<R>, auto &&r) { return _fold<L, R>(FWD(l), FWD(r)); });
-  });
+  return FWD(lv)._transform(_fold_rh_sum<decltype(rv)>{FWD(rv)});
 }
 
 template <typename Lh, typename Rh>
   requires _some_sum<Lh> && (not _some_sum<Rh>)
-[[nodiscard]] constexpr auto fold(auto &&lv, auto &&rv)
+[[nodiscard]] constexpr auto fold(auto &&lv, auto &&rv) //
+    noexcept(noexcept(FWD(lv)._transform(_fold_rh<Rh, decltype(rv)>{FWD(rv)})))
 {
-  return FWD(lv)._transform(
-      [&rv]<typename L>(::std::in_place_type_t<L>, auto &&l) { return _fold<L, Rh>(FWD(l), FWD(rv)); });
+  return FWD(lv)._transform(_fold_rh<Rh, decltype(rv)>{FWD(rv)});
 }
 
 template <typename Lh, typename Rh>
   requires(not _some_sum<Lh>) && _some_sum<Rh>
-[[nodiscard]] constexpr auto fold(auto &&lv, auto &&rv)
+[[nodiscard]] constexpr auto fold(auto &&lv, auto &&rv) //
+    noexcept(noexcept(FWD(rv)._transform(_fold_lh<Lh, decltype(lv)>{FWD(lv)})))
 {
-  return FWD(rv)._transform(
-      [&lv]<typename R>(::std::in_place_type_t<R>, auto &&r) { return _fold<Lh, R>(FWD(lv), FWD(r)); });
+  return FWD(rv)._transform(_fold_lh<Lh, decltype(lv)>{FWD(lv)});
 }
 
 template <typename Lh, typename Rh>
   requires(not _some_sum<Lh>) && (not _some_sum<Rh>)
-[[nodiscard]] constexpr auto fold(auto &&lv, auto &&rv)
+[[nodiscard]] constexpr auto fold(auto &&lv, auto &&rv) //
+    noexcept(noexcept(_fold<Lh, Rh>(FWD(lv), FWD(rv))))
 {
   return _fold<Lh, Rh>(FWD(lv), FWD(rv));
 }

--- a/include/fn/expected.hpp
+++ b/include/fn/expected.hpp
@@ -57,16 +57,105 @@ template <typename U, typename G> struct _expected_types<::fn::expected<U, G>> {
   using error_type = G;
 };
 
+// A sum<> error is unconstructible, so an expected carrying one can never hold an error: every arm
+// that lifts one is unreachable, and what cannot run cannot throw. Guarded on the SOURCE's error
+// type - the value arms of the same expected still relocate, and still weigh.
+template <typename E, typename Type, typename... Args>
+constexpr inline bool _nothrow_error_arm = _nothrow_initializable<Type, Args...>;
+template <typename E, typename Type, typename... Args>
+  requires ::std::is_same_v<E, sum<>>
+constexpr inline bool _nothrow_error_arm<E, Type, Args...> = true;
+
+// Carrying the callback's value across into a widened result. An expected<void, ...> has no value to
+// carry, and `declval<void>()` is not a thing to ask about.
+template <typename Type, typename Src>
+constexpr inline bool _nothrow_carry_value
+    = _nothrow_initializable<Type, ::std::in_place_t, decltype(::std::declval<Src>().value())>;
+template <typename Type, typename Src>
+  requires ::std::is_void_v<typename ::std::remove_cvref_t<Src>::value_type>
+constexpr inline bool _nothrow_carry_value<Type, Src> = _nothrow_initializable<Type, ::std::in_place_t>;
+
+// `and_then` and `or_else` each have two arms - the callback's own expected is returned, or the two
+// error (value) types are widened into a sum - and `if constexpr` picks between them. A
+// noexcept-specifier is an ordinary constant expression and cannot pick: the untaken arm's spelling
+// would have to be well-formed too. Hence a trait, whose constrained specializations mirror the
+// body's arms. Both lead with `_is_some_expected`, so a callback returning something else leaves the
+// unconstrained primary to answer, and the body's static_assert to diagnose - a specification must
+// not pre-empt that with a hard error.
+template <typename E, typename Fn, typename ErrArg, typename... ValArg> struct _nothrow_and_then : ::std::false_type {};
+
+template <typename E, typename Fn, typename ErrArg, typename... ValArg>
+  requires _is_some_expected<::std::remove_cvref_t<typename _invoke_result<Fn, ValArg...>::type> &>
+           && ::std::is_same_v<typename _expected_types<
+                                   ::std::remove_cvref_t<typename _invoke_result<Fn, ValArg...>::type>>::error_type,
+                               E>
+struct _nothrow_and_then<E, Fn, ErrArg, ValArg...>
+    : ::std::bool_constant<
+          _is_nothrow_invocable<Fn, ValArg...>::value // the callback
+              && ::std::is_nothrow_constructible_v<::std::remove_cvref_t<typename _invoke_result<Fn, ValArg...>::type>,
+                                                   ::fn::unexpect_t, ErrArg>> {}; // lifting self's error
+
+template <typename E, typename Fn, typename ErrArg, typename... ValArg>
+  requires _is_some_expected<::std::remove_cvref_t<typename _invoke_result<Fn, ValArg...>::type> &>
+           && (not ::std::is_same_v<typename _expected_types<::std::remove_cvref_t<
+                                        typename _invoke_result<Fn, ValArg...>::type>>::error_type,
+                                    E>)
+struct _nothrow_and_then<E, Fn, ErrArg, ValArg...> {
+  using type = ::std::remove_cvref_t<typename _invoke_result<Fn, ValArg...>::type>;
+  using new_type = ::fn::expected<typename type::value_type, sum_for<E, typename type::error_type>>;
+
+  static constexpr bool value
+      = _is_nothrow_invocable<Fn, ValArg...>::value // the callback
+        && _nothrow_carry_value<new_type, type>     // carrying its value across
+        && _nothrow_initializable<new_type, ::fn::unexpect_t,
+                                  decltype(::std::declval<type>().error())> // widening its error
+        && _nothrow_error_arm<E, new_type, ::fn::unexpect_t, ErrArg>;       // widening self's error
+};
+
+// or_else's arms, mirrored the same way. ValArg is the type of self's value as the body relocates it
+// (spelled through apply_const_lvalue_t by the caller, since for a void T there is no value to name).
+template <typename T, typename Fn, typename ErrArg, typename ValArg> struct _nothrow_or_else : ::std::false_type {};
+
+template <typename T, typename Fn, typename ErrArg, typename ValArg>
+  requires _is_some_expected<::std::remove_cvref_t<typename _invoke_result<Fn, ErrArg>::type> &>
+           && ::std::is_same_v<
+               typename _expected_types<::std::remove_cvref_t<typename _invoke_result<Fn, ErrArg>::type>>::value_type,
+               T>
+struct _nothrow_or_else<T, Fn, ErrArg, ValArg>
+    : ::std::bool_constant<
+          _is_nothrow_invocable<Fn, ErrArg>::value // the callback
+          && (::std::is_void_v<T>
+              || _nothrow_initializable<::std::remove_cvref_t<typename _invoke_result<Fn, ErrArg>::type>,
+                                        ::std::in_place_t, ValArg>)> {}; // carrying self's value
+
+template <typename T, typename Fn, typename ErrArg, typename ValArg>
+  requires _is_some_expected<::std::remove_cvref_t<typename _invoke_result<Fn, ErrArg>::type> &>
+           && (not ::std::is_same_v<
+               typename _expected_types<::std::remove_cvref_t<typename _invoke_result<Fn, ErrArg>::type>>::value_type,
+               T>)
+struct _nothrow_or_else<T, Fn, ErrArg, ValArg> {
+  using type = ::std::remove_cvref_t<typename _invoke_result<Fn, ErrArg>::type>;
+  using new_type = ::fn::expected<sum_for<T, typename type::value_type>, typename type::error_type>;
+
+  static constexpr bool value
+      = _is_nothrow_invocable<Fn, ErrArg>::value                       // the callback
+        && _nothrow_initializable<new_type, ::std::in_place_t, ValArg> // widening self's value
+        && _nothrow_carry_value<new_type, type>                        // widening its value
+        && _nothrow_initializable<new_type, ::fn::unexpect_t,
+                                  decltype(::std::declval<type>().error())>; // carrying its error
+};
+
 // Storage layer for ::fn::expected. Inherits the standard-conformant base from
 // pfn, then hides the four monadic static helpers with sum-widening variants
 // that materialise their result via `expected_policy::template type<U, G>`.
 // The transform/transform_error helpers hand pfn's _expected_from_invoke constructors a
 // zero-argument thunk, so the result's member is direct-non-list-initialized from fn's own
 // _invoke (or sum::transform) result: no extra move, and immovable result types work.
-// The statics carry the same extension noexcept as pfn's, spelled with the std traits: for
-// the sum/pack dispatch and sum-widening extensions the lead conjunct is false (the callable
-// is not directly invocable, or the result is differently shaped), so those are
-// conservatively noexcept(false).
+// The statics carry the same extension noexcept as pfn's, computed through fn's own machinery: the
+// callback of a sum/pack dispatch is invoked through `_invoke`, not called directly, so it is
+// `_is_nothrow_invocable` - not the std trait, which is false for a callable that is not directly
+// invocable on a sum or a pack - that answers for it, and the widening arms are weighed by the
+// traits above.
 template <typename T, typename E> struct _expected_base : ::pfn::detail::_expected_base<T, E, expected_policy> {
   using _pfn_base = ::pfn::detail::_expected_base<T, E, expected_policy>;
   using _pfn_base::_pfn_base;
@@ -74,11 +163,8 @@ template <typename T, typename E> struct _expected_base : ::pfn::detail::_expect
   // and_then, non-void value type
   template <typename Self, typename Fn>
   static constexpr auto _and_then(Self &&self, Fn &&fn) //
-      noexcept(::std::is_same_v<typename _expected_types<::std::remove_cvref_t<typename ::fn::detail::_invoke_result<
-                                    Fn, decltype(_pfn_base::_value(FWD(self)))>::type>>::error_type,
-                                E>
-               && ::std::is_nothrow_invocable_v<Fn, decltype(_pfn_base::_value(FWD(self)))>
-               && ::std::is_nothrow_constructible_v<E, decltype(_pfn_base::_error(FWD(self)))>) // extension
+      noexcept(::fn::detail::_nothrow_and_then<E, Fn, decltype(_pfn_base::_error(FWD(self))),
+                                               decltype(_pfn_base::_value(FWD(self)))>::value) // extension
     requires(not ::std::is_void_v<T>) && ::fn::detail::_is_invocable<Fn, decltype(_pfn_base::_value(FWD(self)))>::value
             && ::std::is_constructible_v<E, decltype(_pfn_base::_error(FWD(self)))>
   {
@@ -113,12 +199,8 @@ template <typename T, typename E> struct _expected_base : ::pfn::detail::_expect
 
   // and_then, void value type
   template <typename Self, typename Fn>
-  static constexpr auto _and_then(Self &&self, Fn &&fn) //
-      noexcept(::std::is_same_v<typename _expected_types<
-                                    ::std::remove_cvref_t<typename ::fn::detail::_invoke_result<Fn>::type>>::error_type,
-                                E>
-               && ::std::is_nothrow_invocable_v<Fn>
-               && ::std::is_nothrow_constructible_v<E, decltype(_pfn_base::_error(FWD(self)))>) // extension
+  static constexpr auto _and_then(Self &&self, Fn &&fn)                                               //
+      noexcept(::fn::detail::_nothrow_and_then<E, Fn, decltype(_pfn_base::_error(FWD(self)))>::value) // extension
     requires(::std::is_void_v<T>) && ::fn::detail::_is_invocable<Fn>::value
             && ::std::is_constructible_v<E, decltype(_pfn_base::_error(FWD(self)))>
   {
@@ -157,13 +239,8 @@ template <typename T, typename E> struct _expected_base : ::pfn::detail::_expect
   // an ill-formed _value call (constrained away for void) from being a hard error.
   template <typename Self, typename Fn>
   static constexpr auto _or_else(Self &&self, Fn &&fn) //
-      noexcept(::std::is_same_v<typename _expected_types<::std::remove_cvref_t<typename ::fn::detail::_invoke_result<
-                                    Fn, decltype(_pfn_base::_error(FWD(self)))>::type>>::value_type,
-                                T>
-               && ::std::is_nothrow_invocable_v<Fn, decltype(_pfn_base::_error(FWD(self)))>
-               && (::std::is_void_v<T>
-                   || ::std::is_nothrow_constructible_v<
-                       T, ::fn::apply_const_lvalue_t<Self, typename _pfn_base::_value_t &&>>)) // extension
+      noexcept(::fn::detail::_nothrow_or_else<T, Fn, decltype(_pfn_base::_error(FWD(self))),
+                                              ::fn::apply_const_lvalue_t<Self, typename _pfn_base::_value_t &&>>::value)
     requires ::fn::detail::_is_invocable<Fn, decltype(_pfn_base::_error(FWD(self)))>::value
              && (::std::is_void_v<T> || ::std::is_constructible_v<T, decltype(_pfn_base::_value(FWD(self)))>)
   {
@@ -213,7 +290,7 @@ template <typename T, typename E> struct _expected_base : ::pfn::detail::_expect
   // new value/error is direct-non-list-initialized from the thunk's result (guaranteed elision).
   template <typename Self, typename Fn>
   static constexpr auto _transform(Self &&self, Fn &&fn) //
-      noexcept(::std::is_nothrow_invocable_v<Fn, decltype(_pfn_base::_value(FWD(self)))>
+      noexcept(::fn::detail::_is_nothrow_invocable<Fn, decltype(_pfn_base::_value(FWD(self)))>::value
                && ::std::is_nothrow_constructible_v<E, decltype(_pfn_base::_error(FWD(self)))>) // extension
     requires(not ::std::is_void_v<T>) && (not some_sum<T>)
             && ::fn::detail::_is_invocable_if<not some_sum<T>, Fn, decltype(_pfn_base::_value(FWD(self)))>::value
@@ -236,7 +313,9 @@ template <typename T, typename E> struct _expected_base : ::pfn::detail::_expect
   // transform, value type is a sum (delegates to sum::transform). The callback is constrained here,
   // in the immediate context, for the reason given on optional's sum-case _transform.
   template <typename Self, typename Fn>
-  static constexpr auto _transform(Self &&self, Fn &&fn)
+  static constexpr auto _transform(Self &&self, Fn &&fn) //
+      noexcept(noexcept(_pfn_base::_value(FWD(self)).transform(FWD(fn)))
+               && ::std::is_nothrow_constructible_v<E, decltype(_pfn_base::_error(FWD(self)))>) // extension
     requires some_sum<T> && ::fn::detail::_typelist_invocable<Fn, decltype(_pfn_base::_value(FWD(self)))>
              && ::std::is_constructible_v<E, decltype(_pfn_base::_error(FWD(self)))>
   {
@@ -256,7 +335,7 @@ template <typename T, typename E> struct _expected_base : ::pfn::detail::_expect
   // transform, void value type
   template <typename Self, typename Fn>
   static constexpr auto _transform(Self &&self, Fn &&fn) //
-      noexcept(::std::is_nothrow_invocable_v<Fn>
+      noexcept(::fn::detail::_is_nothrow_invocable<Fn>::value
                && ::std::is_nothrow_constructible_v<E, decltype(_pfn_base::_error(FWD(self)))>) // extension
     requires(::std::is_void_v<T>) && ::fn::detail::_is_invocable<Fn>::value
             && ::std::is_constructible_v<E, decltype(_pfn_base::_error(FWD(self)))>
@@ -278,7 +357,7 @@ template <typename T, typename E> struct _expected_base : ::pfn::detail::_expect
   // apply_const_lvalue_t for the same reason as _or_else's above)
   template <typename Self, typename Fn>
   static constexpr auto _transform_error(Self &&self, Fn &&fn) //
-      noexcept(::std::is_nothrow_invocable_v<Fn, decltype(_pfn_base::_error(FWD(self)))>
+      noexcept(::fn::detail::_is_nothrow_invocable<Fn, decltype(_pfn_base::_error(FWD(self)))>::value
                && (::std::is_void_v<T>
                    || ::std::is_nothrow_constructible_v<
                        T, ::fn::apply_const_lvalue_t<Self, typename _pfn_base::_value_t &&>>)) // extension
@@ -302,7 +381,11 @@ template <typename T, typename E> struct _expected_base : ::pfn::detail::_expect
   // transform_error, error type is a sum (delegates to sum::transform). The callback is constrained
   // here, in the immediate context, for the reason given on optional's sum-case _transform.
   template <typename Self, typename Fn>
-  static constexpr auto _transform_error(Self &&self, Fn &&fn)
+  static constexpr auto _transform_error(Self &&self, Fn &&fn) //
+      noexcept(noexcept(_pfn_base::_error(FWD(self)).transform(FWD(fn)))
+               && (::std::is_void_v<T>
+                   || ::std::is_nothrow_constructible_v<
+                       T, ::fn::apply_const_lvalue_t<Self, typename _pfn_base::_value_t &&>>)) // extension
     requires some_sum<E> && ::fn::detail::_typelist_invocable<Fn, decltype(_pfn_base::_error(FWD(self)))>
              && (::std::is_void_v<T> || ::std::is_constructible_v<T, decltype(_pfn_base::_value(FWD(self)))>)
   {
@@ -1065,13 +1148,11 @@ constexpr inline bool _nothrow_join_expected
       && _nothrow_initializable<Type, ::fn::unexpect_t, decltype(::std::declval<Lh>().error())>
       && _nothrow_initializable<Type, ::fn::unexpect_t, decltype(::std::declval<Rh>().error())>;
 
-// Lifting an operand's error into a widened error type. A sum<> operand can never hold an error, so
-// its arm is unreachable - the joins below assert as much - and what cannot run cannot throw.
+// Lifting an operand's error into a widened error type, through the sum<> guard of _nothrow_error_arm
+// (the joins below assert the same unreachability with pfn::unreachable).
 template <typename Src, typename Err>
-constexpr inline bool _nothrow_error_lift = _nothrow_initializable<Err, decltype(::std::declval<Src>().error())>;
-template <typename Src, typename Err>
-  requires ::std::is_same_v<typename ::std::remove_cvref_t<Src>::error_type, sum<>>
-constexpr inline bool _nothrow_error_lift<Src, Err> = true;
+constexpr inline bool _nothrow_error_lift
+    = _nothrow_error_arm<typename ::std::remove_cvref_t<Src>::error_type, Err, decltype(::std::declval<Src>().error())>;
 
 template <typename Type, typename Err, typename Lh, typename Rh, typename... Vs>
 constexpr inline bool _nothrow_join_widened = _nothrow_initializable<Type, ::std::in_place_t, Vs...>

--- a/include/fn/expected.hpp
+++ b/include/fn/expected.hpp
@@ -1051,13 +1051,61 @@ private:
   return FWD(src).sum_error();
 }
 
+namespace detail {
+template <typename E> struct _expected_type {
+  template <typename T> using type = ::fn::expected<T, E>;
+};
+
+// `error()` throws when the expected holds a value, but every arm below is reached only once
+// `has_value()` has answered - so these ask what constructing the result promises, with the accessor
+// spelled as a type rather than as a call which would drag its own throw in.
+template <typename Type, typename Lh, typename Rh, typename... Vs>
+constexpr inline bool _nothrow_join_expected
+    = _nothrow_initializable<Type, ::std::in_place_t, Vs...>
+      && _nothrow_initializable<Type, ::fn::unexpect_t, decltype(::std::declval<Lh>().error())>
+      && _nothrow_initializable<Type, ::fn::unexpect_t, decltype(::std::declval<Rh>().error())>;
+
+// Lifting an operand's error into a widened error type. A sum<> operand can never hold an error, so
+// its arm is unreachable - the joins below assert as much - and what cannot run cannot throw.
+template <typename Src, typename Err>
+constexpr inline bool _nothrow_error_lift = _nothrow_initializable<Err, decltype(::std::declval<Src>().error())>;
+template <typename Src, typename Err>
+  requires ::std::is_same_v<typename ::std::remove_cvref_t<Src>::error_type, sum<>>
+constexpr inline bool _nothrow_error_lift<Src, Err> = true;
+
+template <typename Type, typename Err, typename Lh, typename Rh, typename... Vs>
+constexpr inline bool _nothrow_join_widened = _nothrow_initializable<Type, ::std::in_place_t, Vs...>
+                                              && (_nothrow_error_lift<Lh, Err> && _nothrow_error_lift<Rh, Err>)
+                                              && _nothrow_initializable<Type, ::fn::unexpect_t, Err>;
+
+// A named type, not a lambda: `operator&` specifies itself in terms of what lifting the error
+// promises, and a lambda can be named neither in a noexcept-specifier nor (before clang 17) in any
+// unevaluated operand at all.
+template <typename E> struct _expected_efn final {
+  // Explicit return type: for a sum<> (never-erroring) operand the else branch is the only one
+  // instantiated, and without this it would deduce void - poisoning _join's return-type deduction.
+  [[nodiscard]] constexpr auto operator()(auto &&v) const noexcept(_nothrow_error_lift<decltype(v), unexpected<E>>)
+      -> ::fn::unexpected<E>
+  {
+    if constexpr (not ::std::is_same_v<typename ::std::remove_cvref_t<decltype(v)>::error_type, sum<>>) {
+      return ::fn::unexpected<E>(FWD(v).error());
+    } else {
+      ::pfn::unreachable(); // LCOV_EXCL_LINE
+    }
+  }
+};
+} // namespace detail
+
 // When any of the sides is expected<void, ...>, we do not produce expected<pack<...>, ...>
 // Instead just elide void and carry non-void (or elide both voids if that's what we get)
 template <typename Lh, typename Rh>
   requires some_expected_void<Lh> && (not some_expected_void<Rh>)
            && ::std::is_same_v<typename ::std::remove_cvref_t<Lh>::error_type,
                                typename ::std::remove_cvref_t<Rh>::error_type>
-[[nodiscard]] constexpr auto operator&(Lh &&lh, Rh &&rh) noexcept
+[[nodiscard]] constexpr auto operator&(Lh &&lh, Rh &&rh) //
+    noexcept(detail::_nothrow_join_expected<
+             expected<typename ::std::remove_cvref_t<Rh>::value_type, typename ::std::remove_cvref_t<Lh>::error_type>,
+             Lh, Rh, decltype(FWD(rh).value())>)
 {
   using error_type = ::std::remove_cvref_t<Lh>::error_type;
   using value_type = ::std::remove_cvref_t<Rh>::value_type;
@@ -1076,7 +1124,13 @@ template <typename Lh, typename Rh>
                                     typename ::std::remove_cvref_t<Rh>::error_type>)
            && (some_sum<typename ::std::remove_cvref_t<Lh>::error_type>
                || some_sum<typename ::std::remove_cvref_t<Rh>::error_type>)
-[[nodiscard]] constexpr auto operator&(Lh &&lh, Rh &&rh) noexcept
+[[nodiscard]] constexpr auto operator&(Lh &&lh, Rh &&rh) //
+    noexcept(detail::_nothrow_join_widened<
+             expected<typename ::std::remove_cvref_t<Rh>::value_type,
+                      sum_for<typename ::std::remove_cvref_t<Lh>::error_type,
+                              typename ::std::remove_cvref_t<Rh>::error_type>>,
+             sum_for<typename ::std::remove_cvref_t<Lh>::error_type, typename ::std::remove_cvref_t<Rh>::error_type>,
+             Lh, Rh, decltype(FWD(rh).value())>)
 {
   using new_error_type
       = sum_for<typename ::std::remove_cvref_t<Lh>::error_type, typename ::std::remove_cvref_t<Rh>::error_type>;
@@ -1101,7 +1155,10 @@ template <typename Lh, typename Rh>
   requires(not some_expected_void<Lh>) && some_expected_void<Rh>
           && ::std::is_same_v<typename ::std::remove_cvref_t<Lh>::error_type,
                               typename ::std::remove_cvref_t<Rh>::error_type>
-[[nodiscard]] constexpr auto operator&(Lh &&lh, Rh &&rh) noexcept
+[[nodiscard]] constexpr auto operator&(Lh &&lh, Rh &&rh) //
+    noexcept(detail::_nothrow_join_expected<
+             expected<typename ::std::remove_cvref_t<Lh>::value_type, typename ::std::remove_cvref_t<Lh>::error_type>,
+             Lh, Rh, decltype(FWD(lh).value())>)
 {
   using error_type = ::std::remove_cvref_t<Lh>::error_type;
   using value_type = ::std::remove_cvref_t<Lh>::value_type;
@@ -1120,7 +1177,13 @@ template <typename Lh, typename Rh>
                                    typename ::std::remove_cvref_t<Rh>::error_type>)
           && (some_sum<typename ::std::remove_cvref_t<Lh>::error_type>
               || some_sum<typename ::std::remove_cvref_t<Rh>::error_type>)
-[[nodiscard]] constexpr auto operator&(Lh &&lh, Rh &&rh) noexcept
+[[nodiscard]] constexpr auto operator&(Lh &&lh, Rh &&rh) //
+    noexcept(detail::_nothrow_join_widened<
+             expected<typename ::std::remove_cvref_t<Lh>::value_type,
+                      sum_for<typename ::std::remove_cvref_t<Lh>::error_type,
+                              typename ::std::remove_cvref_t<Rh>::error_type>>,
+             sum_for<typename ::std::remove_cvref_t<Lh>::error_type, typename ::std::remove_cvref_t<Rh>::error_type>,
+             Lh, Rh, decltype(FWD(lh).value())>)
 {
   using new_error_type
       = sum_for<typename ::std::remove_cvref_t<Lh>::error_type, typename ::std::remove_cvref_t<Rh>::error_type>;
@@ -1145,7 +1208,8 @@ template <typename Lh, typename Rh>
   requires some_expected_void<Lh> && some_expected_void<Rh>
            && ::std::is_same_v<typename ::std::remove_cvref_t<Lh>::error_type,
                                typename ::std::remove_cvref_t<Rh>::error_type>
-[[nodiscard]] constexpr auto operator&(Lh &&lh, Rh &&rh) noexcept
+[[nodiscard]] constexpr auto operator&(Lh &&lh, Rh &&rh) //
+    noexcept(detail::_nothrow_join_expected<expected<void, typename ::std::remove_cvref_t<Lh>::error_type>, Lh, Rh>)
 {
   using error_type = ::std::remove_cvref_t<Lh>::error_type;
   using type = expected<void, error_type>;
@@ -1163,7 +1227,12 @@ template <typename Lh, typename Rh>
                                     typename ::std::remove_cvref_t<Rh>::error_type>)
            && (some_sum<typename ::std::remove_cvref_t<Lh>::error_type>
                || some_sum<typename ::std::remove_cvref_t<Rh>::error_type>)
-[[nodiscard]] constexpr auto operator&(Lh &&lh, Rh &&rh) noexcept
+[[nodiscard]] constexpr auto operator&(Lh &&lh, Rh &&rh) //
+    noexcept(detail::_nothrow_join_widened<
+             expected<void, sum_for<typename ::std::remove_cvref_t<Lh>::error_type,
+                                    typename ::std::remove_cvref_t<Rh>::error_type>>,
+             sum_for<typename ::std::remove_cvref_t<Lh>::error_type, typename ::std::remove_cvref_t<Rh>::error_type>,
+             Lh, Rh>)
 {
   using new_error_type
       = sum_for<typename ::std::remove_cvref_t<Lh>::error_type, typename ::std::remove_cvref_t<Rh>::error_type>;
@@ -1185,21 +1254,18 @@ template <typename Lh, typename Rh>
 
 // Overloads when both sides are non-void, producing either of
 // expected<pack<...>, ...> or expected<sum<pack<...>, pack...>, ...>
-namespace detail {
-template <typename E> struct _expected_type {
-  template <typename T> using type = ::fn::expected<T, E>;
-};
-} // namespace detail
-
 template <typename Lh, typename Rh>
   requires(not some_expected_void<Lh>) && (not some_expected_void<Rh>)
           && ::std::is_same_v<typename ::std::remove_cvref_t<Lh>::error_type,
                               typename ::std::remove_cvref_t<Rh>::error_type>
-[[nodiscard]] constexpr auto operator&(Lh &&lh, Rh &&rh) noexcept
+[[nodiscard]] constexpr auto operator&(Lh &&lh, Rh &&rh) //
+    noexcept(noexcept(::fn::detail::_join<
+                      detail::template _expected_type<typename ::std::remove_cvref_t<Lh>::error_type>::template type>(
+        FWD(lh), FWD(rh), detail::_expected_efn<typename ::std::remove_cvref_t<Lh>::error_type>{})))
 {
   using error_type = ::std::remove_cvref_t<Lh>::error_type;
-  constexpr auto efn = [](auto &&v) { return ::fn::unexpected<error_type>(FWD(v).error()); };
-  return ::fn::detail::_join<detail::template _expected_type<error_type>::template type>(FWD(lh), FWD(rh), efn);
+  return ::fn::detail::_join<detail::template _expected_type<error_type>::template type>(
+      FWD(lh), FWD(rh), detail::_expected_efn<error_type>{});
 }
 
 template <typename Lh, typename Rh>
@@ -1208,20 +1274,19 @@ template <typename Lh, typename Rh>
                                    typename ::std::remove_cvref_t<Rh>::error_type>)
           && (some_sum<typename ::std::remove_cvref_t<Lh>::error_type>
               || some_sum<typename ::std::remove_cvref_t<Rh>::error_type>)
-[[nodiscard]] constexpr auto operator&(Lh &&lh, Rh &&rh) noexcept
+[[nodiscard]] constexpr auto operator&(Lh &&lh, Rh &&rh) //
+    noexcept(noexcept(
+        ::fn::detail::_join<
+            detail::template _expected_type<sum_for<typename ::std::remove_cvref_t<Lh>::error_type,
+                                                    typename ::std::remove_cvref_t<Rh>::error_type>>::template type>(
+            FWD(lh), FWD(rh),
+            detail::_expected_efn<sum_for<typename ::std::remove_cvref_t<Lh>::error_type,
+                                          typename ::std::remove_cvref_t<Rh>::error_type>>{})))
 {
   using new_error_type
       = sum_for<typename ::std::remove_cvref_t<Lh>::error_type, typename ::std::remove_cvref_t<Rh>::error_type>;
-  // Explicit return type: for a sum<> (never-erroring) operand the else branch is the only one
-  // instantiated, and without this it would deduce void — poisoning _join's return-type deduction.
-  constexpr auto efn = [](auto &&v) -> ::fn::unexpected<new_error_type> {
-    if constexpr (not ::std::is_same_v<typename ::std::remove_cvref_t<decltype(v)>::error_type, sum<>>) {
-      return ::fn::unexpected<new_error_type>(FWD(v).error());
-    } else {
-      ::pfn::unreachable(); // LCOV_EXCL_LINE
-    }
-  };
-  return ::fn::detail::_join<detail::template _expected_type<new_error_type>::template type>(FWD(lh), FWD(rh), efn);
+  return ::fn::detail::_join<detail::template _expected_type<new_error_type>::template type>(
+      FWD(lh), FWD(rh), detail::_expected_efn<new_error_type>{});
 }
 
 } // namespace fn

--- a/include/fn/optional.hpp
+++ b/include/fn/optional.hpp
@@ -891,10 +891,19 @@ constexpr optional<T> make_optional(::std::initializer_list<U> il, Args &&...arg
   return FWD(src).sum_value();
 }
 
-template <some_optional Lh, some_optional Rh> [[nodiscard]] constexpr auto operator&(Lh &&lh, Rh &&rh) noexcept
+namespace detail {
+// A named type, not a lambda: `operator&`'s specification has to name it, and a lambda cannot be
+// spelled in an unevaluated operand before C++20's P0315, which our floor compilers predate.
+struct _optional_efn final {
+  [[nodiscard]] constexpr auto operator()(auto const &) const noexcept -> ::std::nullopt_t { return ::std::nullopt; }
+};
+} // namespace detail
+
+template <some_optional Lh, some_optional Rh>
+[[nodiscard]] constexpr auto operator&(Lh &&lh, Rh &&rh) //
+    noexcept(noexcept(::fn::detail::_join<fn::optional>(FWD(lh), FWD(rh), detail::_optional_efn{})))
 {
-  constexpr auto efn = [](auto const &) { return ::std::nullopt; };
-  return ::fn::detail::_join<fn::optional>(FWD(lh), FWD(rh), efn);
+  return ::fn::detail::_join<fn::optional>(FWD(lh), FWD(rh), detail::_optional_efn{});
 }
 
 } // namespace fn

--- a/include/fn/optional.hpp
+++ b/include/fn/optional.hpp
@@ -127,23 +127,52 @@ struct optional_policy {
   template <class X> static constexpr bool is_specialization = _is_some_optional<X &>;
 };
 
+// `or_else` has two arms - the callback's own optional is returned, or its value type and T are
+// widened into a sum - and `if constexpr` picks between them. A noexcept-specifier is an ordinary
+// constant expression, so it cannot pick: the untaken arm's spelling would have to be well-formed
+// too, and it is not. Hence a trait, whose constrained specializations mirror the body's arms. The
+// unconstrained primary answers for a callback returning something that is not an optional at all -
+// the body's static_assert is the diagnostic there, and it must not be pre-empted by a hard error
+// in the specification.
+template <typename T, typename Fn, typename ValArg> struct _nothrow_optional_or_else : ::std::false_type {};
+
+template <typename T, typename Fn, typename ValArg>
+  requires ::std::is_same_v<::std::remove_cvref_t<typename _invoke_result<Fn>::type>, ::fn::optional<T>>
+struct _nothrow_optional_or_else<T, Fn, ValArg>
+    : ::std::bool_constant<_is_nothrow_invocable<Fn>::value
+                               && ::std::is_nothrow_constructible_v<::fn::optional<T>, ::std::in_place_t, ValArg>> {};
+
+template <typename T, typename Fn, typename ValArg>
+  requires _is_some_optional<::std::remove_cvref_t<typename _invoke_result<Fn>::type> &>
+           && (not ::std::is_same_v<::std::remove_cvref_t<typename _invoke_result<Fn>::type>, ::fn::optional<T>>)
+struct _nothrow_optional_or_else<T, Fn, ValArg> {
+  using type = ::std::remove_cvref_t<typename _invoke_result<Fn>::type>;
+  using new_type = ::fn::optional<sum_for<T, typename type::value_type>>;
+
+  static constexpr bool value
+      = _is_nothrow_invocable<Fn>::value                               // the callback
+        && _nothrow_initializable<new_type, ::std::in_place_t, ValArg> // self's value
+        && _nothrow_initializable<new_type, ::std::in_place_t, decltype(::std::declval<type>().value())>; // its value
+};
+
 // Storage layer for ::fn::optional. Inherits the standard-conformant base from
 // pfn, then hides the three monadic static helpers with sum-aware variants that
 // materialise their result via `optional_policy::template type<U>`.
 // The transform helpers hand pfn's _optional_from_invoke constructor a zero-argument
 // thunk, so the result's contained value is direct-non-list-initialized from fn's own
 // _invoke (or sum::transform) result: no extra move, and immovable result types work.
-// The statics carry the same extension noexcept as pfn's, spelled with the std traits: for
-// the sum/pack dispatch extensions std::is_nothrow_invocable_v is false (the callable is not
-// directly invocable on a sum or pack), so those are conservatively noexcept(false).
+// The statics carry the same extension noexcept as pfn's, computed through fn's own machinery:
+// the callback of a sum/pack dispatch is invoked through `_invoke`, not called directly, so it is
+// `_is_nothrow_invocable` - not the std trait, which is false for a callable that is not directly
+// invocable on a sum or a pack - that answers for it.
 template <typename T> struct _optional_base : ::pfn::detail::_optional_base<T, optional_policy> {
   using _pfn_base = ::pfn::detail::_optional_base<T, optional_policy>;
   using _pfn_base::_pfn_base;
 
   // and_then
   template <typename Self, typename Fn>
-  static constexpr auto _and_then(Self &&self, Fn &&fn)                 //
-      noexcept(::std::is_nothrow_invocable_v<Fn, decltype(*FWD(self))>) // extension
+  static constexpr auto _and_then(Self &&self, Fn &&fn)                              //
+      noexcept(::fn::detail::_is_nothrow_invocable<Fn, decltype(*FWD(self))>::value) // extension
     requires ::fn::detail::_is_invocable<Fn, decltype(*FWD(self))>::value
   {
     using type = ::std::remove_cvref_t<typename ::fn::detail::_invoke_result<Fn, decltype(*FWD(self))>::type>;
@@ -169,11 +198,8 @@ template <typename T> struct _optional_base : ::pfn::detail::_optional_base<T, o
 
   // or_else (with value-widening into a sum)
   template <typename Self, typename Fn>
-  static constexpr auto _or_else(Self &&self, Fn &&fn) //
-      noexcept(
-          ::std::is_same_v<::std::remove_cvref_t<typename ::fn::detail::_invoke_result<Fn>::type>, ::fn::optional<T>>
-          && ::std::is_nothrow_invocable_v<Fn>
-          && ::std::is_nothrow_constructible_v<::fn::optional<T>, Self>) // extension
+  static constexpr auto _or_else(Self &&self, Fn &&fn)                                      //
+      noexcept(::fn::detail::_nothrow_optional_or_else<T, Fn, decltype(*FWD(self))>::value) // extension
     requires ::fn::detail::_is_invocable<Fn>::value && ::std::is_constructible_v<T, decltype(*FWD(self))>
   {
     using type = ::std::remove_cvref_t<typename ::fn::detail::_invoke_result<Fn>::type>;
@@ -215,8 +241,8 @@ template <typename T> struct _optional_base : ::pfn::detail::_optional_base<T, o
   // transform, value type is not a sum. In the noexcept spec, only the invoke can throw: the
   // result is direct-non-list-initialized from the thunk's result (guaranteed elision).
   template <typename Self, typename Fn>
-  static constexpr auto _transform(Self &&self, Fn &&fn)                //
-      noexcept(::std::is_nothrow_invocable_v<Fn, decltype(*FWD(self))>) // extension
+  static constexpr auto _transform(Self &&self, Fn &&fn)                             //
+      noexcept(::fn::detail::_is_nothrow_invocable<Fn, decltype(*FWD(self))>::value) // extension
     requires(not some_sum<T>) && ::fn::detail::_is_invocable_if<not some_sum<T>, Fn, decltype(*FWD(self))>::value
   {
     using new_value_type = ::std::remove_cv_t<typename ::fn::detail::_invoke_result<Fn, decltype(*FWD(self))>::type>;
@@ -234,7 +260,8 @@ template <typename T> struct _optional_base : ::pfn::detail::_optional_base<T, o
   // candidate - and would poison overload resolution, since the losing candidates form their
   // signatures too.
   template <typename Self, typename Fn>
-  static constexpr auto _transform(Self &&self, Fn &&fn)
+  static constexpr auto _transform(Self &&self, Fn &&fn)  //
+      noexcept(noexcept((*FWD(self)).transform(FWD(fn)))) // extension
     requires some_sum<T> && ::fn::detail::_typelist_invocable<Fn, decltype(*FWD(self))>
   {
     using new_value_type = decltype((*FWD(self)).transform(FWD(fn)));

--- a/include/fn/pack.hpp
+++ b/include/fn/pack.hpp
@@ -357,16 +357,34 @@ template <typename T, typename... Args>
 
 namespace detail {
 
+// `value()` throws when the monad holds no value, but the join only reaches it once `has_value()`
+// has answered - so the specification below asks what folding and lifting the value promise, with
+// the accessor spelled as a type rather than as a call which would drag its own throw in.
+template <typename Monad> using _value_of_t = decltype(::std::declval<Monad>().value());
+
+template <typename Lh, typename Rh>
+using _joined_t = decltype(::fn::detail::_fold_detail::fold<typename ::std::remove_cvref_t<Lh>::value_type,
+                                                            typename ::std::remove_cvref_t<Rh>::value_type>(
+    ::std::declval<_value_of_t<Lh>>(), ::std::declval<_value_of_t<Rh>>()));
+
+template <template <typename> typename Tpl, typename Lh, typename Rh, typename Efn>
+constexpr inline bool _nothrow_join
+    = noexcept(::fn::detail::_fold_detail::fold<typename ::std::remove_cvref_t<Lh>::value_type,
+                                                typename ::std::remove_cvref_t<Rh>::value_type>(
+          ::std::declval<_value_of_t<Lh>>(), ::std::declval<_value_of_t<Rh>>()))
+      && _nothrow_initializable<Tpl<_joined_t<Lh, Rh>>, ::std::in_place_t, _joined_t<Lh, Rh>>
+      && ::std::is_nothrow_invocable_v<Efn, Lh> && ::std::is_nothrow_invocable_v<Efn, Rh>
+      && _nothrow_initializable<Tpl<_joined_t<Lh, Rh>>, ::std::invoke_result_t<Efn, Lh>>
+      && _nothrow_initializable<Tpl<_joined_t<Lh, Rh>>, ::std::invoke_result_t<Efn, Rh>>;
+
 template <template <typename> typename Tpl>
-[[nodiscard]] constexpr auto _join(auto &&lh, auto &&rh, auto &&efn)
-    -> Tpl<decltype(::fn::detail::_fold_detail::fold<typename ::std::remove_cvref_t<decltype(lh)>::value_type,
-                                                     typename ::std::remove_cvref_t<decltype(rh)>::value_type>(
-        FWD(lh).value(), FWD(rh).value()))>
+[[nodiscard]] constexpr auto _join(auto &&lh, auto &&rh, auto &&efn) //
+    noexcept(_nothrow_join<Tpl, decltype(lh), decltype(rh), decltype(efn)>)
+        -> Tpl<_joined_t<decltype(lh), decltype(rh)>>
 {
   using Lh = ::std::remove_cvref_t<decltype(lh)>::value_type;
   using Rh = ::std::remove_cvref_t<decltype(rh)>::value_type;
-  using value_type = decltype(::fn::detail::_fold_detail::fold<Lh, Rh>(FWD(lh).value(), FWD(rh).value()));
-  using type = Tpl<value_type>;
+  using type = Tpl<_joined_t<decltype(lh), decltype(rh)>>;
   if (lh.has_value() && rh.has_value())
     return type{::std::in_place, ::fn::detail::_fold_detail::fold<Lh, Rh>(FWD(lh).value(), FWD(rh).value())};
   else if (not lh.has_value())
@@ -384,7 +402,9 @@ template <template <typename> typename Tpl>
  * @param rh TODO
  * @return TODO
  */
-[[nodiscard]] constexpr auto operator&(auto &&lh, auto &&rh)
+[[nodiscard]] constexpr auto operator&(auto &&lh, auto &&rh) //
+    noexcept(noexcept(::fn::detail::_fold_detail::fold<::std::remove_cvref_t<decltype(lh)>,
+                                                       ::std::remove_cvref_t<decltype(rh)>>(FWD(lh), FWD(rh))))
   requires(some_sum<decltype(lh)> || some_pack<decltype(lh)>)
 {
   using Lh = ::std::remove_cvref_t<decltype(lh)>;

--- a/include/fn/pack.hpp
+++ b/include/fn/pack.hpp
@@ -367,15 +367,17 @@ using _joined_t = decltype(::fn::detail::_fold_detail::fold<typename ::std::remo
                                                             typename ::std::remove_cvref_t<Rh>::value_type>(
     ::std::declval<_value_of_t<Lh>>(), ::std::declval<_value_of_t<Rh>>()));
 
+// `_join` invokes `efn` as an lvalue - a named parameter - so the `Efn &` questions ask about the
+// call the body performs; the reference collapses to it whatever category the callable arrived in.
 template <template <typename> typename Tpl, typename Lh, typename Rh, typename Efn>
 constexpr inline bool _nothrow_join
     = noexcept(::fn::detail::_fold_detail::fold<typename ::std::remove_cvref_t<Lh>::value_type,
                                                 typename ::std::remove_cvref_t<Rh>::value_type>(
           ::std::declval<_value_of_t<Lh>>(), ::std::declval<_value_of_t<Rh>>()))
       && _nothrow_initializable<Tpl<_joined_t<Lh, Rh>>, ::std::in_place_t, _joined_t<Lh, Rh>>
-      && ::std::is_nothrow_invocable_v<Efn, Lh> && ::std::is_nothrow_invocable_v<Efn, Rh>
-      && _nothrow_initializable<Tpl<_joined_t<Lh, Rh>>, ::std::invoke_result_t<Efn, Lh>>
-      && _nothrow_initializable<Tpl<_joined_t<Lh, Rh>>, ::std::invoke_result_t<Efn, Rh>>;
+      && ::std::is_nothrow_invocable_v<Efn &, Lh> && ::std::is_nothrow_invocable_v<Efn &, Rh>
+      && _nothrow_initializable<Tpl<_joined_t<Lh, Rh>>, ::std::invoke_result_t<Efn &, Lh>>
+      && _nothrow_initializable<Tpl<_joined_t<Lh, Rh>>, ::std::invoke_result_t<Efn &, Rh>>;
 
 template <template <typename> typename Tpl>
 [[nodiscard]] constexpr auto _join(auto &&lh, auto &&rh, auto &&efn) //

--- a/tests/fn/expected.cpp
+++ b/tests/fn/expected.cpp
@@ -623,6 +623,47 @@ TEST_CASE("graded monad", "[expected][sum][graded][and_then][or_else][sum_value]
       CHECK(r.has_value());
     }
   }
+
+  WHEN("noexcept")
+  {
+    // the widening arms relocate BOTH sides into the summed result - self's, and the callback's -
+    // and weigh both, rather than reporting potentially-throwing merely because the shape changed
+    WHEN("and_then widens the error")
+    {
+      using T = fn::expected<int, fn::sum<Error>>;
+      constexpr auto widen = [](int) noexcept -> fn::expected<bool, bool> { return {true}; };
+      static_assert(
+          std::is_same_v<decltype(std::declval<T &>().and_then(widen)), fn::expected<bool, fn::sum_for<Error, bool>>>);
+      static_assert(noexcept(std::declval<T &>().and_then(widen)));
+      static_assert(not noexcept(std::declval<T &>().and_then([](int) -> fn::expected<bool, bool> { return {true}; })));
+
+      using W = fn::expected<int, fn::sum_for<MoveNothrow, Error>>;
+      static_assert(not noexcept(std::declval<W &>().and_then(widen))); // copies self's error
+      static_assert(noexcept(std::declval<W &&>().and_then(widen)));    // moves it
+    }
+
+    WHEN("or_else widens the value")
+    {
+      using T = fn::expected<fn::sum<int>, Error>;
+      constexpr auto widen = [](Error) noexcept -> fn::expected<bool, bool> { return {true}; };
+      static_assert(noexcept(std::declval<T &>().or_else(widen)));
+      static_assert(
+          not noexcept(std::declval<T &>().or_else([](Error) -> fn::expected<bool, bool> { return {true}; })));
+
+      using W = fn::expected<fn::sum_for<MoveNothrow, int>, Error>;
+      static_assert(not noexcept(std::declval<W &>().or_else(widen))); // copies self's value
+      static_assert(noexcept(std::declval<W &&>().or_else(widen)));    // moves it
+    }
+
+    WHEN("the unit error grade")
+    {
+      // sum<> can hold no error, so the arm lifting self's error is unreachable, and cannot throw
+      using T = fn::expected<int, fn::sum<>>;
+      static_assert(
+          noexcept(std::declval<T &>().and_then([](int) noexcept -> fn::expected<bool, Error> { return {true}; })));
+    }
+    SUCCEED();
+  }
 }
 
 TEST_CASE("graded monad constexpr and runtime", "[constexpr][and_then][or_else][expected][graded][sum]")
@@ -828,6 +869,18 @@ TEST_CASE("expected pack support", "[expected][pack][and_then][transform][operat
                 .error()
             == FileNotFound);
     }
+
+    WHEN("noexcept")
+    {
+      // a pack's callback is invoked through fn's own dispatch, taking one argument per element: it
+      // is not directly invocable on the pack, so only fn's nothrow-invocable trait can answer
+      using T = fn::expected<fn::pack<int, double>, Error>;
+      static_assert(noexcept(
+          std::declval<T &>().and_then([](int, double) noexcept -> fn::expected<bool, Error> { return {true}; })));
+      static_assert(
+          not noexcept(std::declval<T &>().and_then([](int, double) -> fn::expected<bool, Error> { return {true}; })));
+      SUCCEED();
+    }
   }
 
   WHEN("transform")
@@ -906,6 +959,14 @@ TEST_CASE("expected pack support", "[expected][pack][and_then][transform][operat
                 .error()
             == FileNotFound);
       CHECK(std::move(std::as_const(s)).transform([](auto...) -> bool { throw 0; }).error() == FileNotFound);
+    }
+
+    WHEN("noexcept")
+    {
+      using T = fn::expected<fn::pack<int, double>, Error>;
+      static_assert(noexcept(std::declval<T &>().transform([](int, double) noexcept -> bool { return true; })));
+      static_assert(not noexcept(std::declval<T &>().transform([](int, double) -> bool { return true; })));
+      SUCCEED();
     }
   }
 
@@ -2393,6 +2454,20 @@ TEST_CASE("expected sum support and_then", "[expected][sum][and_then]")
     static_assert(std::is_same_v<decltype(a.and_then(fn)), fn::expected<bool, Error>>);
     static_assert(a.and_then(fn).value());
   }
+
+  WHEN("noexcept")
+  {
+    // the callback is invoked through fn's own dispatch, so only fn's nothrow-invocable trait can
+    // answer for it - and it is nothrow only if EVERY alternative's call is
+    using T = fn::expected<fn::sum<double, int>, Error>;
+    static_assert(
+        noexcept(std::declval<T &>().and_then([](auto) noexcept -> fn::expected<bool, Error> { return {true}; })));
+    static_assert(not noexcept(std::declval<T &>().and_then([](auto) -> fn::expected<bool, Error> { return {true}; })));
+    static_assert(not noexcept(std::declval<T &>().and_then(
+        fn::overload{[](int) noexcept -> fn::expected<bool, Error> { return {true}; },
+                     [](double) -> fn::expected<bool, Error> { return {true}; }}))); // one throwing arm is enough
+    SUCCEED();
+  }
 }
 
 TEST_CASE("expected sum support or_else", "[expected][sum][or_else]")
@@ -2693,6 +2768,20 @@ TEST_CASE("expected sum support transform", "[expected][sum][transform]")
     T s{fn::sum{12}};
     CHECK(s.transform(lval_only).value() == fn::sum{true});
   }
+
+  WHEN("noexcept")
+  {
+    // the dispatch is nothrow only if every alternative's call is, and only if relocating what each
+    // returns into the result sum is - and, as ever, if lifting the untouched error is
+    using T = fn::expected<fn::sum<double, int>, Error>;
+    static_assert(noexcept(std::declval<T &>().transform([](auto) noexcept -> bool { return true; })));
+    static_assert(not noexcept(std::declval<T &>().transform([](auto) -> bool { return true; })));
+    static_assert(not noexcept(std::declval<fn::expected<fn::sum_for<MoveNothrow, int>, Error> &>().transform(
+        [](auto v) noexcept { return v; })));
+    static_assert(not noexcept(std::declval<fn::expected<fn::sum<double, int>, MoveNothrow> &>().transform(
+        [](auto) noexcept -> bool { return true; }))); // copies the error
+    SUCCEED();
+  }
 }
 
 TEST_CASE("expected sum support transform_error", "[expected][sum][transform_error]")
@@ -2901,6 +2990,17 @@ TEST_CASE("expected sum support transform_error", "[expected][sum][transform_err
     auto r = std::move(n).transform_error([](Error const &) -> bool { throw 0; });
     static_assert(std::is_same_v<decltype(r), fn::expected<std::unique_ptr<int>, bool>>);
     CHECK(*r.value() == 7);
+  }
+
+  WHEN("noexcept")
+  {
+    // the error side dispatches through the sum exactly as the value side does
+    using T = fn::expected<int, fn::sum<double, int>>;
+    static_assert(noexcept(std::declval<T &>().transform_error([](auto) noexcept -> bool { return true; })));
+    static_assert(not noexcept(std::declval<T &>().transform_error([](auto) -> bool { return true; })));
+    static_assert(not noexcept(std::declval<fn::expected<MoveNothrow, fn::sum<double, int>> &>().transform_error(
+        [](auto) noexcept -> bool { return true; }))); // copies the untouched value
+    SUCCEED();
   }
 }
 

--- a/tests/fn/expected.cpp
+++ b/tests/fn/expected.cpp
@@ -21,6 +21,14 @@ struct Xint {
   constexpr bool operator==(Xint const &) const noexcept = default;
 };
 
+// Nothrow move, throwing copy: joining lvalue operands copies the value or error, joining rvalues
+// moves it
+struct MoveNothrow {
+  MoveNothrow() = default;
+  MoveNothrow(MoveNothrow const &) noexcept(false) {}
+  MoveNothrow(MoveNothrow &&) noexcept = default;
+};
+
 // Sums whose alternatives include a non-builtin (Error/Xint/std::string_view/fn::pack — any
 // class/struct/enum) have platform-specific order (see sum.cpp); pure-builtin sums keep `sum<...>`.
 } // namespace
@@ -2246,6 +2254,49 @@ TEST_CASE("expected pack support", "[expected][pack][and_then][transform][operat
         CHECK((Rh{5} & VoidUnit{}).value() == 5);
         CHECK((Rh{::fn::unexpect, FileNotFound} & VoidUnit{}).error() == fn::sum{FileNotFound});
       }
+    }
+
+    WHEN("noexcept")
+    {
+      // the join relocates both operands' values and errors into the result, so it promises only
+      // what relocating them promises
+      using Lh = fn::expected<MoveNothrow, Error>;
+      using Rh = fn::expected<int, Error>;
+      static_assert(noexcept(std::declval<Rh &>() & std::declval<Rh &>()));
+      static_assert(not noexcept(std::declval<Lh &>() & std::declval<Rh &>())); // copies the value
+      static_assert(noexcept(std::declval<Lh &&>() & std::declval<Rh &&>()));   // moves it
+
+      using Eh = fn::expected<int, MoveNothrow>;
+      static_assert(not noexcept(std::declval<Eh &>() & std::declval<Eh &>())); // copies the error
+      static_assert(noexcept(std::declval<Eh &&>() & std::declval<Eh &&>()));
+
+      WHEN("void operand")
+      {
+        using Vh = fn::expected<void, Error>;
+        static_assert(noexcept(std::declval<Vh &>() & std::declval<Rh &>()));
+        static_assert(not noexcept(std::declval<Vh &>() & std::declval<Lh &>())); // carries the value
+        static_assert(noexcept(std::declval<Vh &&>() & std::declval<Lh &&>()));
+        static_assert(noexcept(std::declval<Vh &>() & std::declval<Vh &>()));
+      }
+
+      WHEN("widening the error")
+      {
+        using Wh = fn::expected<int, fn::sum<MoveNothrow>>;
+        static_assert(not noexcept(std::declval<Wh &>() & std::declval<Rh &>())); // copies the error
+        static_assert(noexcept(std::declval<Wh &&>() & std::declval<Rh &&>()));
+      }
+
+      WHEN("unit error operand")
+      {
+        // sum<> can hold no error, so the arm lifting it is unreachable and cannot throw - but the
+        // value is still relocated, and still weighs
+        using Uh = fn::expected<int, fn::sum<>>;
+        using Ut = fn::expected<MoveNothrow, fn::sum<>>;
+        static_assert(noexcept(std::declval<Uh &>() & std::declval<Rh &>()));
+        static_assert(noexcept(std::declval<fn::expected<void, fn::sum<>> &>() & std::declval<Rh &>()));
+        static_assert(not noexcept(std::declval<Ut &>() & std::declval<Rh &>()));
+      }
+      SUCCEED();
     }
   }
 }

--- a/tests/fn/optional.cpp
+++ b/tests/fn/optional.cpp
@@ -183,6 +183,25 @@ TEST_CASE("optional graded monad", "[optional][sum][graded][or_else][sum_value]"
       CHECK(std::move(std::as_const(s)).or_else(fn).value() == fn::sum{12});
       CHECK(std::move(s).or_else(fn).value() == fn::sum{12});
     }
+
+    WHEN("noexcept")
+    {
+      // the widening arm builds a sum from either side's value, and weighs both
+      using T = fn::optional<fn::sum<int>>;
+      constexpr auto widen = []() noexcept -> fn::optional<double> { return {0.5}; };
+      static_assert(std::is_same_v<decltype(std::declval<T &>().or_else(widen)), fn::optional<fn::sum<double, int>>>);
+      static_assert(noexcept(std::declval<T &>().or_else(widen)));
+      static_assert(not noexcept(std::declval<T &>().or_else([]() -> fn::optional<double> { return {0.5}; })));
+
+      // ... including relocating self's value into it
+      using W = fn::optional<fn::sum_for<MoveNothrow, int>>;
+      static_assert(not noexcept(std::declval<W &>().or_else(widen))); // copies
+      static_assert(noexcept(std::declval<W &&>().or_else(widen)));    // moves
+
+      // the same-shape arm, which pfn's own or_else would take
+      static_assert(noexcept(std::declval<T &>().or_else([]() noexcept -> T { return {fn::sum{1}}; })));
+      SUCCEED();
+    }
   }
 }
 
@@ -246,6 +265,18 @@ TEST_CASE("optional pack support", "[optional][pack][and_then][transform][operat
                                      [](int const &&, auto &&...) -> fn::optional<bool> { throw 0; }}) //
                     .has_value());
     }
+
+    WHEN("noexcept")
+    {
+      // a pack's callback is invoked through fn's own dispatch, taking one argument per element: it
+      // is not directly invocable on the pack, so only fn's nothrow-invocable trait can answer
+      using T = fn::optional<fn::pack<int, double>>;
+      static_assert(
+          noexcept(std::declval<T &>().and_then([](int, double) noexcept -> fn::optional<bool> { return {true}; })));
+      static_assert(
+          not noexcept(std::declval<T &>().and_then([](int, double) -> fn::optional<bool> { return {true}; })));
+      SUCCEED();
+    }
   }
 
   WHEN("transform")
@@ -291,6 +322,14 @@ TEST_CASE("optional pack support", "[optional][pack][and_then][transform][operat
       CHECK(not std::as_const(s).transform([](auto...) -> bool { throw 0; }).has_value());
       CHECK(not std::move(std::as_const(s)).transform([](auto...) -> bool { throw 0; }).has_value());
       CHECK(not std::move(s).transform([](auto...) -> bool { throw 0; }).has_value());
+    }
+
+    WHEN("noexcept")
+    {
+      using T = fn::optional<fn::pack<int, double>>;
+      static_assert(noexcept(std::declval<T &>().transform([](int, double) noexcept -> bool { return true; })));
+      static_assert(not noexcept(std::declval<T &>().transform([](int, double) -> bool { return true; })));
+      SUCCEED();
     }
   }
 
@@ -612,6 +651,19 @@ TEST_CASE("optional and_then sum", "[optional][sum][and_then]")
     static_assert(std::is_same_v<decltype(a.and_then(fn)), fn::optional<bool>>);
     static_assert(a.and_then(fn).value());
   }
+
+  WHEN("noexcept")
+  {
+    // the callback is invoked through fn's own dispatch, so only fn's nothrow-invocable trait can
+    // answer for it - and it is nothrow only if EVERY alternative's call is
+    using T = fn::optional<fn::sum<double, int>>;
+    static_assert(noexcept(std::declval<T &>().and_then([](auto) noexcept -> fn::optional<bool> { return {true}; })));
+    static_assert(not noexcept(std::declval<T &>().and_then([](auto) -> fn::optional<bool> { return {true}; })));
+    static_assert(not noexcept(std::declval<T &>().and_then(
+        fn::overload{[](int) noexcept -> fn::optional<bool> { return {true}; },
+                     [](double) -> fn::optional<bool> { return {true}; }}))); // one throwing alternative is enough
+    SUCCEED();
+  }
 }
 
 TEST_CASE("optional transform sum", "[optional][sum][transform]")
@@ -709,5 +761,20 @@ TEST_CASE("optional transform sum", "[optional][sum][transform]")
 
     T s{12};
     CHECK(s.transform(lval_only).value() == fn::sum{true});
+  }
+
+  WHEN("noexcept")
+  {
+    // the dispatch is nothrow only if every alternative's call is, and only if relocating what each
+    // returns into the result sum is
+    using T = fn::optional<fn::sum<double, int>>;
+    static_assert(noexcept(std::declval<T &>().transform([](auto) noexcept -> bool { return true; })));
+    static_assert(not noexcept(std::declval<T &>().transform([](auto) -> bool { return true; })));
+    static_assert(not noexcept(std::declval<T &>().transform(
+        fn::overload{[](double) noexcept -> bool { return true; },
+                     [](int) -> bool { return true; }}))); // one throwing alternative is enough
+    static_assert(not noexcept(
+        std::declval<fn::optional<fn::sum_for<MoveNothrow, int>> &>().transform([](auto v) noexcept { return v; })));
+    SUCCEED();
   }
 }

--- a/tests/fn/optional.cpp
+++ b/tests/fn/optional.cpp
@@ -21,6 +21,13 @@ struct Xint {
   constexpr Xint &operator=(Xint const &) = default;
 };
 
+// Nothrow move, throwing copy: joining lvalue operands copies the value, joining rvalues moves it
+struct MoveNothrow {
+  MoveNothrow() = default;
+  MoveNothrow(MoveNothrow const &) noexcept(false) {}
+  MoveNothrow(MoveNothrow &&) noexcept = default;
+};
+
 // Sums whose alternatives include a non-builtin (Xint/std::string_view/fn::pack — any
 // class/struct/enum) have platform-specific order (see sum.cpp); pure-builtin sums keep sum<...>.
 } // namespace
@@ -484,6 +491,25 @@ TEST_CASE("optional pack support", "[optional][pack][and_then][transform][operat
         CHECK(not(Lh{fn::pack{0.5, 3}} & Rh{std::nullopt}).has_value());
         CHECK(not(Lh{std::nullopt} & Rh{std::nullopt}).has_value());
       }
+    }
+
+    WHEN("noexcept")
+    {
+      // the join relocates both operands' values into the result, so it promises only what
+      // relocating them promises - the nullopt arm is a tag, and cannot throw
+      using Lh = fn::optional<MoveNothrow>;
+      using Rh = fn::optional<int>;
+      static_assert(noexcept(std::declval<Rh &>() & std::declval<Rh &>()));
+      static_assert(not noexcept(std::declval<Lh &>() & std::declval<Rh &>())); // copies
+      static_assert(not noexcept(std::declval<Rh &>() & std::declval<Lh &>()));
+      static_assert(noexcept(std::declval<Lh &&>() & std::declval<Rh &&>())); // moves
+      static_assert(noexcept(std::declval<Rh &&>() & std::declval<Lh &&>()));
+
+      // the same, dispatched through a sum
+      using Sh = fn::optional<fn::sum<MoveNothrow>>;
+      static_assert(not noexcept(std::declval<Sh &>() & std::declval<Rh &>()));
+      static_assert(noexcept(std::declval<Sh &&>() & std::declval<Rh &&>()));
+      SUCCEED();
     }
   }
 }

--- a/tests/fn/optional.cpp
+++ b/tests/fn/optional.cpp
@@ -28,6 +28,23 @@ struct MoveNothrow {
   MoveNothrow(MoveNothrow &&) noexcept = default;
 };
 
+// The join invokes its error-continuation as an lvalue - a named parameter - whatever the value
+// category it was passed in, and its specification must ask about that call. These answer the
+// lvalue and the rvalue question differently, in both directions - and the third offers only the
+// call the body performs. Namespace scope: a local class cannot have member templates.
+struct EfnLvalueNothrow {
+  constexpr auto operator()(auto const &) & noexcept -> std::nullopt_t { return std::nullopt; }
+  auto operator()(auto const &) && noexcept(false) -> std::nullopt_t { throw 0; }
+};
+struct EfnRvalueNothrow {
+  auto operator()(auto const &) & noexcept(false) -> std::nullopt_t { throw 0; }
+  constexpr auto operator()(auto const &) && noexcept -> std::nullopt_t { return std::nullopt; }
+};
+struct EfnLvalueOnly {
+  constexpr auto operator()(auto const &) & noexcept -> std::nullopt_t { return std::nullopt; }
+  auto operator()(auto const &) && -> std::nullopt_t = delete;
+};
+
 // Sums whose alternatives include a non-builtin (Xint/std::string_view/fn::pack — any
 // class/struct/enum) have platform-specific order (see sum.cpp); pure-builtin sums keep sum<...>.
 } // namespace
@@ -548,7 +565,29 @@ TEST_CASE("optional pack support", "[optional][pack][and_then][transform][operat
       using Sh = fn::optional<fn::sum<MoveNothrow>>;
       static_assert(not noexcept(std::declval<Sh &>() & std::declval<Rh &>()));
       static_assert(noexcept(std::declval<Sh &&>() & std::declval<Rh &&>()));
-      SUCCEED();
+
+      WHEN("_join")
+      {
+        // the join invokes its error-continuation as an lvalue, and its specification asks about
+        // that call - whether the callable arrives as a temporary or an lvalue
+        using fn::detail::_join;
+        static_assert(noexcept(_join<fn::optional>(std::declval<Rh &>(), std::declval<Rh &>(), EfnLvalueNothrow{})));
+        static_assert(
+            not noexcept(_join<fn::optional>(std::declval<Rh &>(), std::declval<Rh &>(), EfnRvalueNothrow{})));
+        static_assert(noexcept(_join<fn::optional>(std::declval<Rh &>(), std::declval<Rh &>(), EfnLvalueOnly{})));
+        static_assert(noexcept(
+            _join<fn::optional>(std::declval<Rh &>(), std::declval<Rh &>(), std::declval<EfnLvalueNothrow &>())));
+        static_assert(not noexcept(
+            _join<fn::optional>(std::declval<Rh &>(), std::declval<Rh &>(), std::declval<EfnRvalueNothrow &>())));
+
+        // the body performs the lvalue call: the rvalue overload throws, or does not exist
+        CHECK(not _join<fn::optional>(Rh{std::nullopt}, Rh{12}, EfnLvalueNothrow{}).has_value());
+        CHECK(not _join<fn::optional>(Rh{12}, Rh{std::nullopt}, EfnLvalueOnly{}).has_value());
+        CHECK(_join<fn::optional>(Rh{3}, Rh{4}, EfnLvalueOnly{}).has_value());
+        static_assert(not _join<fn::optional>(Rh{std::nullopt}, Rh{12}, EfnLvalueNothrow{}).has_value());
+        static_assert(not _join<fn::optional>(Rh{12}, Rh{std::nullopt}, EfnLvalueOnly{}).has_value());
+        static_assert(_join<fn::optional>(Rh{3}, Rh{4}, EfnLvalueOnly{}).has_value());
+      }
     }
   }
 }


### PR DESCRIPTION
The `operator&` join and fn's own monadic arms - the same honest-spec derivation, written atop each other.

### Make `operator&` promise only what joining actually promises

All nine `operator&` overloads were unconditionally `noexcept`, yet joining relocates both operands' values - and, for expected, their errors - into the result. A throwing copy or move called std::terminate instead of propagating.

The specification bottoms out in the fold, which had no specification of its own, so an honest answer had to be computed there first. Its four overloads dispatch through `sum::_transform` with a callable, and neither a noexcept-specifier nor (before clang 17, and our floor is 16) any unevaluated operand can name a lambda - so the fold's lambdas, and the error lifts of optional's and expected's joins, become named types.

A sum<> operand can hold no error, so the arm lifting its error is unreachable; what cannot run cannot throw, and the trait says so - otherwise the unit-error grade, which the README leads with, would report noexcept(false) for a join that cannot fail.

The accessors are only reached once has_value() has answered, so the arms are specified with `decltype` of `value()` / `error()` rather than `noexcept` of a call to them, which would drag in a throw the body never risks.

### Compute a real `noexcept` for fn's own monadic arms

fn's monadic extensions - the sum/pack dispatch, and the graded arms that widen an error or a value into a sum - all advertised potentially-throwing, whatever they were given. The specs asked std::is_nothrow_invocable_v, which is false for a callable that is not DIRECTLY invocable: a pack's callback takes one argument per element and a sum's is chosen per alternative, and both are reached through fn's own `_invoke`. The graded arms fared worse: their specs led with a same-shape conjunct, so widening - the whole point of the graded monad - was false by construction. Two of the arms carried no spec at all.

The traits from #45 answer the first: `_is_nothrow_invocable` walks the same dispatch the body does, and agrees with the std trait wherever the callable is directly invocable, so the pfn-shaped paths keep pfn's answer exactly.

The graded arms are chosen by `if constexpr`, and a noexcept-specifier - an ordinary constant expression - cannot choose: the untaken arm's spelling would have to be well-formed too. So a trait chooses, with one constrained specialization per arm, and an unconstrained primary that leaves a bad callback to the body's static_assert rather than pre-empting it with a hard error.

A sum<> error is unconstructible, so an expected carrying one can never hold an error: the arms lifting it are unreachable, and what cannot run cannot throw. The guard is on the error alone - such an expected still has a value, which is still relocated, and still weighs.

Closes #279
Closes #254

---
**Stack**: P8 of 13 — the release-0.1 bugfix queue, merging bottom-up into `main`. Based on #301 and to be retargeted to `main` once it merges; the diff shows only this PR's commits. Every stack boundary was validated with a gcc build and the full test suite on top of `main`, and the aggregate branch ran the full CI matrix green (#289).
