### PR TITLE
Ask of a `sum` alternative the same question its initialization answers

### DIFF
--- a/include/fn/choice.hpp
+++ b/include/fn/choice.hpp
@@ -86,8 +86,9 @@ struct choice<Ts...> : sum<Ts...> {
    */
   template <typename T>
   constexpr choice(T &&v) // NOSONAR cpp:S1709,S6458 implicit arm of the explicit pair; has_type excludes self
-      noexcept(detail::_nothrow_initializable<::std::remove_cvref_t<T>, decltype(v)>)
-    requires has_type<::std::remove_cvref_t<T>> && (detail::_initializable<::std::remove_cvref_t<T>, decltype(v)>)
+      noexcept(::std::is_nothrow_constructible_v<_impl, ::std::in_place_type_t<::std::remove_cvref_t<T>>, decltype(v)>)
+    requires has_type<::std::remove_cvref_t<T>>
+             && (::std::is_constructible_v<_impl, ::std::in_place_type_t<::std::remove_cvref_t<T>>, decltype(v)>)
              && (::std::is_convertible_v<decltype(v), ::std::remove_cvref_t<T>>)
       : _impl(::std::in_place_type<::std::remove_cvref_t<T>>, FWD(v))
   {
@@ -101,8 +102,9 @@ struct choice<Ts...> : sum<Ts...> {
    */
   template <typename T>
   constexpr explicit choice(T &&v) // NOSONAR cpp:S6458 has_type excludes self
-      noexcept(detail::_nothrow_initializable<::std::remove_cvref_t<T>, decltype(v)>)
-    requires has_type<::std::remove_cvref_t<T>> && (detail::_initializable<::std::remove_cvref_t<T>, decltype(v)>)
+      noexcept(::std::is_nothrow_constructible_v<_impl, ::std::in_place_type_t<::std::remove_cvref_t<T>>, decltype(v)>)
+    requires has_type<::std::remove_cvref_t<T>>
+             && (::std::is_constructible_v<_impl, ::std::in_place_type_t<::std::remove_cvref_t<T>>, decltype(v)>)
              && (not ::std::is_convertible_v<decltype(v), ::std::remove_cvref_t<T>>)
       : _impl(::std::in_place_type<::std::remove_cvref_t<T>>, FWD(v))
   {
@@ -117,8 +119,8 @@ struct choice<Ts...> : sum<Ts...> {
    */
   template <typename T>
   constexpr explicit choice(::std::in_place_type_t<T> d, auto &&...args) //
-      noexcept(detail::_nothrow_initializable<T, decltype(args)...>)
-    requires has_type<T> && detail::_initializable<T, decltype(args)...>
+      noexcept(::std::is_nothrow_constructible_v<_impl, ::std::in_place_type_t<T>, decltype(args)...>)
+    requires has_type<T> && ::std::is_constructible_v<_impl, ::std::in_place_type_t<T>, decltype(args)...>
       : _impl(d, FWD(args)...)
   {
   }
@@ -131,8 +133,9 @@ struct choice<Ts...> : sum<Ts...> {
    */
   template <typename... Tx>
   constexpr choice(sum<Tx...> const &v) // NOSONAR cpp:S1709 implicit widening by design
-      noexcept((... && detail::_nothrow_initializable<Tx, Tx const &>))
-    requires detail::is_superset_of<choice, choice<Tx...>> && (... && detail::_initializable<Tx, Tx const &>)
+      noexcept(::std::is_nothrow_constructible_v<_impl, ::std::in_place_type_t<sum<Tx...>>, sum<Tx...> const &>)
+    requires detail::is_superset_of<choice, choice<Tx...>>
+             && (::std::is_constructible_v<_impl, ::std::in_place_type_t<sum<Tx...>>, sum<Tx...> const &>)
       : _impl(::std::in_place_type<sum<Tx...>>, FWD(v))
   {
   }
@@ -145,8 +148,9 @@ struct choice<Ts...> : sum<Ts...> {
    */
   template <typename... Tx>
   constexpr choice(sum<Tx...> &&v) // NOSONAR cpp:S1709 implicit widening by design
-      noexcept((... && detail::_nothrow_initializable<Tx, Tx>))
-    requires detail::is_superset_of<choice, choice<Tx...>> && (... && detail::_initializable<Tx, Tx>)
+      noexcept(::std::is_nothrow_constructible_v<_impl, ::std::in_place_type_t<sum<Tx...>>, sum<Tx...>>)
+    requires detail::is_superset_of<choice, choice<Tx...>>
+             && (::std::is_constructible_v<_impl, ::std::in_place_type_t<sum<Tx...>>, sum<Tx...>>)
       : _impl(::std::in_place_type<sum<Tx...>>, FWD(v))
   {
   }
@@ -159,7 +163,7 @@ struct choice<Ts...> : sum<Ts...> {
    */
   template <typename... Tx>
   constexpr choice(::std::in_place_type_t<sum<Tx...>>, some_sum auto &&v) //
-      noexcept((... && detail::_nothrow_initializable<Tx, apply_const_lvalue_t<decltype(v), Tx &&>>))
+      noexcept(::std::is_nothrow_constructible_v<_impl, ::std::in_place_type_t<sum<Tx...>>, decltype(v)>)
     requires ::std::is_same_v<::std::remove_cvref_t<decltype(v)>, sum<Tx...>>
              && detail::is_superset_of<choice, choice<Tx...>>
       : _impl(::std::in_place_type<sum<Tx...>>, FWD(v))

--- a/include/fn/choice.hpp
+++ b/include/fn/choice.hpp
@@ -87,7 +87,7 @@ struct choice<Ts...> : sum<Ts...> {
   template <typename T>
   constexpr choice(T &&v) // NOSONAR cpp:S1709,S6458 implicit arm of the explicit pair; has_type excludes self
       noexcept(detail::_nothrow_initializable<::std::remove_cvref_t<T>, decltype(v)>)
-    requires has_type<::std::remove_cvref_t<T>> && (::std::is_constructible_v<::std::remove_cvref_t<T>, decltype(v)>)
+    requires has_type<::std::remove_cvref_t<T>> && (detail::_initializable<::std::remove_cvref_t<T>, decltype(v)>)
              && (::std::is_convertible_v<decltype(v), ::std::remove_cvref_t<T>>)
       : _impl(::std::in_place_type<::std::remove_cvref_t<T>>, FWD(v))
   {
@@ -102,7 +102,7 @@ struct choice<Ts...> : sum<Ts...> {
   template <typename T>
   constexpr explicit choice(T &&v) // NOSONAR cpp:S6458 has_type excludes self
       noexcept(detail::_nothrow_initializable<::std::remove_cvref_t<T>, decltype(v)>)
-    requires has_type<::std::remove_cvref_t<T>> && (::std::is_constructible_v<::std::remove_cvref_t<T>, decltype(v)>)
+    requires has_type<::std::remove_cvref_t<T>> && (detail::_initializable<::std::remove_cvref_t<T>, decltype(v)>)
              && (not ::std::is_convertible_v<decltype(v), ::std::remove_cvref_t<T>>)
       : _impl(::std::in_place_type<::std::remove_cvref_t<T>>, FWD(v))
   {
@@ -131,8 +131,8 @@ struct choice<Ts...> : sum<Ts...> {
    */
   template <typename... Tx>
   constexpr choice(sum<Tx...> const &v) // NOSONAR cpp:S1709 implicit widening by design
-      noexcept((... && ::std::is_nothrow_copy_constructible_v<Tx>))
-    requires detail::is_superset_of<choice, choice<Tx...>> && (... && ::std::is_copy_constructible_v<Tx>)
+      noexcept((... && detail::_nothrow_initializable<Tx, Tx const &>))
+    requires detail::is_superset_of<choice, choice<Tx...>> && (... && detail::_initializable<Tx, Tx const &>)
       : _impl(::std::in_place_type<sum<Tx...>>, FWD(v))
   {
   }
@@ -145,8 +145,8 @@ struct choice<Ts...> : sum<Ts...> {
    */
   template <typename... Tx>
   constexpr choice(sum<Tx...> &&v) // NOSONAR cpp:S1709 implicit widening by design
-      noexcept((... && ::std::is_nothrow_move_constructible_v<Tx>))
-    requires detail::is_superset_of<choice, choice<Tx...>> && (... && ::std::is_move_constructible_v<Tx>)
+      noexcept((... && detail::_nothrow_initializable<Tx, Tx>))
+    requires detail::is_superset_of<choice, choice<Tx...>> && (... && detail::_initializable<Tx, Tx>)
       : _impl(::std::in_place_type<sum<Tx...>>, FWD(v))
   {
   }
@@ -159,7 +159,7 @@ struct choice<Ts...> : sum<Ts...> {
    */
   template <typename... Tx>
   constexpr choice(::std::in_place_type_t<sum<Tx...>>, some_sum auto &&v) //
-      noexcept((... && ::std::is_nothrow_constructible_v<Tx, apply_const_lvalue_t<decltype(v), Tx &&>>))
+      noexcept((... && detail::_nothrow_initializable<Tx, apply_const_lvalue_t<decltype(v), Tx &&>>))
     requires ::std::is_same_v<::std::remove_cvref_t<decltype(v)>, sum<Tx...>>
              && detail::is_superset_of<choice, choice<Tx...>>
       : _impl(::std::in_place_type<sum<Tx...>>, FWD(v))

--- a/include/fn/detail/pack_impl.hpp
+++ b/include/fn/detail/pack_impl.hpp
@@ -27,13 +27,34 @@ template <::std::size_t I, typename T> struct _element {
 // type is reference-related to it, i.e. binds), but gcc reads the braced form as materializing a
 // temporary and rejects the bind - while accepting the equivalent declaration. The cast keeps both
 // compilers on the binding path.
-template <typename T> [[nodiscard]] constexpr auto _make_element(auto &&...args) -> T
+template <typename T>
+[[nodiscard]] constexpr auto _make_element(auto &&...args) noexcept(_nothrow_initializable<T, decltype(args)...>) -> T
+  requires _initializable<T, decltype(args)...>
 {
   if constexpr (::std::is_reference_v<T>)
     return T(FWD(args)...); // a single argument, so this is a cast expression: it binds
   else
     return T{FWD(args)...};
 }
+
+// The two questions anyone above may ask about constructing an element, asked OF the function that
+// constructs it rather than restated in terms of a trait - the same discipline as `_makeable` beside
+// `make_variadic_union`, and for the same reason: a restatement can drift from the deed.
+template <typename T, typename... Args>
+concept _makeable_element = requires { _make_element<T>(::std::declval<Args>()...); };
+
+template <typename T, typename... Args>
+concept _nothrow_makeable_element = requires { requires noexcept(_make_element<T>(::std::declval<Args>()...)); };
+
+// One element's relocation into a new pack: the copy-initialization its holder performs
+// ([dcl.init.aggr]/4.3, reached through brace elision), asked of the holder one element at a time -
+// `_element<I, T>{src}` elides into the same member copy-initialization. This excludes explicit
+// constructors, where `is_[nothrow_]constructible_v` would admit them.
+template <typename E, typename Src>
+concept _relocatable_element = requires { E{::std::declval<Src>()}; };
+
+template <typename E, typename Src>
+concept _nothrow_relocatable_element = requires { requires noexcept(E{::std::declval<Src>()}); };
 
 template <typename, typename... Ts> struct pack_impl;
 
@@ -89,6 +110,16 @@ struct pack_impl<::std::index_sequence<Is...>, Ts...> : _element<Is, Ts>... {
         FWD(fn), static_cast<apply_const_lvalue_t<Self, Ts &&>>(FWD(self)._element<Is, Ts>::v)..., FWD(args)...);
   }
 
+  template <typename Ret, typename Self, typename Fn, typename... Args>
+    requires(not(... || (_some_pack<Args> || _some_sum<Args>)))
+  static constexpr auto _invoke_r(Self &&self, Fn &&fn, Args &&...args) //
+      noexcept(_is_nothrow_invocable_r<Ret, Fn &&, apply_const_lvalue_t<Self, Ts &&>..., Args &&...>::value) -> Ret
+    requires(_is_invocable_r<Ret, Fn &&, apply_const_lvalue_t<Self, Ts &&>..., Args && ...>::value)
+  {
+    return ::fn::detail::_invoke_r<Ret>(
+        FWD(fn), static_cast<apply_const_lvalue_t<Self, Ts &&>>(FWD(self)._element<Is, Ts>::v)..., FWD(args)...);
+  }
+
   template <::std::size_t I, typename Self>
   static constexpr decltype(auto) _get(Self &&self) noexcept
     requires(I < size)
@@ -102,14 +133,18 @@ struct pack_impl<::std::index_sequence<Is...>, Ts...> : _element<Is, Ts>... {
   // Every existing element is relocated into the new pack, so appending weighs that as well as the
   // construction of the element being appended.
   template <typename Self>
+  static constexpr bool _relocatable
+      = (... && _relocatable_element<_element<Is, Ts>, apply_const_lvalue_t<Self, Ts &&>>);
+
+  template <typename Self>
   static constexpr bool _nothrow_relocatable
-      = (... && ::std::is_nothrow_constructible_v<Ts, apply_const_lvalue_t<Self, Ts &&>>);
+      = (... && _nothrow_relocatable_element<_element<Is, Ts>, apply_const_lvalue_t<Self, Ts &&>>);
 
   template <typename T, typename Self>
   static constexpr auto _append(Self &&self, auto &&...args) //
-      noexcept(_nothrow_relocatable<Self> && _nothrow_initializable<T, decltype(args)...>)
+      noexcept(_nothrow_relocatable<Self> && _nothrow_makeable_element<T, decltype(args)...>)
           -> pack_impl<::std::index_sequence<Is..., size>, Ts..., T>
-    requires(not _some_sum<T>) && (not _some_pack<T>) && _initializable<T, decltype(args)...>
+    requires(not _some_sum<T>) && (not _some_pack<T>) && _relocatable<Self> && _makeable_element<T, decltype(args)...>
   {
     return {static_cast<apply_const_lvalue_t<Self, Ts &&>>(FWD(self)._element<Is, Ts>::v)...,
             _make_element<T>(FWD(args)...)};
@@ -121,6 +156,8 @@ struct pack_impl<::std::index_sequence<Is...>, Ts...> : _element<Is, Ts>... {
                && ::std::remove_cvref_t<T>::_impl::template _nothrow_relocatable<decltype(other)>) -> //
       typename _pack_append<::std::remove_cvref_t<T>, Ts...>::impl
     requires _some_pack<T> && (::std::is_same_v<::std::remove_cvref_t<decltype(other)>, ::std::remove_cvref_t<T>>)
+             && _relocatable<Self> && ::std::remove_cvref_t<T>::_impl::template
+  _relocatable<decltype(other)>
   {
     using type = _pack_append<::std::remove_cvref_t<T>, Ts...>::impl;
     return FWD(other)._invoke(FWD(other), [&self](auto &&...args) {

--- a/include/fn/detail/variadic_union.hpp
+++ b/include/fn/detail/variadic_union.hpp
@@ -306,39 +306,50 @@ template <typename T, typename U>
 }
 
 template <typename T, typename U>
-[[nodiscard]] constexpr auto make_variadic_union(auto &&...args)
-  requires(U::template has_type<T>) && ::std::is_same_v<T, typename U::t0>
+[[nodiscard]] constexpr U make_variadic_union(auto &&...args) noexcept(noexcept(T{FWD(args)...}))
+  requires(U::template has_type<T>) && ::std::is_same_v<T, typename U::t0> && requires { T{FWD(args)...}; }
 {
   return U{.v0 = T{FWD(args)...}};
 }
 
 template <typename T, typename U>
-[[nodiscard]] constexpr auto make_variadic_union(auto &&...args)
-  requires(U::template has_type<T>) && ::std::is_same_v<T, typename U::t1>
+[[nodiscard]] constexpr U make_variadic_union(auto &&...args) noexcept(noexcept(T{FWD(args)...}))
+  requires(U::template has_type<T>) && ::std::is_same_v<T, typename U::t1> && requires { T{FWD(args)...}; }
 {
   return U{.v1 = T{FWD(args)...}};
 }
 
 template <typename T, typename U>
-[[nodiscard]] constexpr auto make_variadic_union(auto &&...args)
-  requires(U::template has_type<T>) && ::std::is_same_v<T, typename U::t2>
+[[nodiscard]] constexpr U make_variadic_union(auto &&...args) noexcept(noexcept(T{FWD(args)...}))
+  requires(U::template has_type<T>) && ::std::is_same_v<T, typename U::t2> && requires { T{FWD(args)...}; }
 {
   return U{.v2 = T{FWD(args)...}};
 }
 
 template <typename T, typename U>
-[[nodiscard]] constexpr auto make_variadic_union(auto &&...args)
-  requires(U::template has_type<T>) && ::std::is_same_v<T, typename U::t3>
+[[nodiscard]] constexpr U make_variadic_union(auto &&...args) noexcept(noexcept(T{FWD(args)...}))
+  requires(U::template has_type<T>) && ::std::is_same_v<T, typename U::t3> && requires { T{FWD(args)...}; }
 {
   return U{.v3 = T{FWD(args)...}};
 }
 
 template <typename T, typename U>
-[[nodiscard]] constexpr U make_variadic_union(auto &&...args)
-  requires(U::template has_type<T>) && (U::more_t::template has_type<T>)
+[[nodiscard]] constexpr U make_variadic_union(auto &&...args) noexcept(noexcept(T{FWD(args)...}))
+  requires(U::template has_type<T>) && (U::more_t::template has_type<T>) && requires { T{FWD(args)...}; }
 {
   return U{.more = make_variadic_union<T, typename U::more_t>(FWD(args)...)};
 }
+
+// The two questions anyone above may ask about storing an alternative, asked OF the function that
+// stores it rather than restated in terms of a trait. Restating is how the answer drifts from the
+// deed: `make_variadic_union` brace-initializes, and `std::is_[nothrow_]constructible` is a question
+// about parentheses - the two can disagree, and where they do the trait is wrong. Nothing here needs
+// to know that, and nothing above needs to remember it.
+template <typename U, typename T, typename... Args>
+concept _makeable = requires { make_variadic_union<T, U>(::std::declval<Args>()...); };
+
+template <typename U, typename T, typename... Args>
+concept _nothrow_makeable = requires { requires noexcept(make_variadic_union<T, U>(::std::declval<Args>()...)); };
 
 template <typename R, typename U, typename Fn, typename... Args>
 [[nodiscard]] constexpr auto invoke_variadic_union(some_variadic_union auto &&v, ::std::size_t index, Fn &&fn,

--- a/include/fn/pack.hpp
+++ b/include/fn/pack.hpp
@@ -46,10 +46,8 @@ template <typename... Ts> struct pack : detail::pack_impl<::std::index_sequence_
    */
   template <typename T>
   [[nodiscard]] constexpr auto append(::std::in_place_type_t<T>, auto &&...args) & //
-      noexcept(_impl::template _nothrow_relocatable<pack &> && detail::_nothrow_initializable<T, decltype(args)...>)
-          -> append_type<T>
-    requires detail::_initializable<T, decltype(args)...>
-             && requires { append_type<T>{_impl::template _append<T>(*this, FWD(args)...)}; }
+      noexcept(noexcept(_impl::template _append<T>(::std::declval<pack &>(), FWD(args)...))) -> append_type<T>
+    requires requires { append_type<T>{_impl::template _append<T>(*this, FWD(args)...)}; }
   {
     return {_impl::template _append<T>(*this, FWD(args)...)};
   }
@@ -63,10 +61,8 @@ template <typename... Ts> struct pack : detail::pack_impl<::std::index_sequence_
    */
   template <typename T>
   [[nodiscard]] constexpr auto append(::std::in_place_type_t<T>, auto &&...args) const & //
-      noexcept(_impl::template _nothrow_relocatable<pack const &>
-               && detail::_nothrow_initializable<T, decltype(args)...>) -> append_type<T>
-    requires detail::_initializable<T, decltype(args)...>
-             && requires { append_type<T>{_impl::template _append<T>(*this, FWD(args)...)}; }
+      noexcept(noexcept(_impl::template _append<T>(::std::declval<pack const &>(), FWD(args)...))) -> append_type<T>
+    requires requires { append_type<T>{_impl::template _append<T>(*this, FWD(args)...)}; }
   {
     return {_impl::template _append<T>(*this, FWD(args)...)};
   }
@@ -80,10 +76,8 @@ template <typename... Ts> struct pack : detail::pack_impl<::std::index_sequence_
    */
   template <typename T>
   [[nodiscard]] constexpr auto append(::std::in_place_type_t<T>, auto &&...args) && //
-      noexcept(_impl::template _nothrow_relocatable<pack &&> && detail::_nothrow_initializable<T, decltype(args)...>)
-          -> append_type<T>
-    requires detail::_initializable<T, decltype(args)...>
-             && requires { append_type<T>{_impl::template _append<T>(::std::move(*this), FWD(args)...)}; }
+      noexcept(noexcept(_impl::template _append<T>(::std::declval<pack &&>(), FWD(args)...))) -> append_type<T>
+    requires requires { append_type<T>{_impl::template _append<T>(::std::move(*this), FWD(args)...)}; }
   {
     return {_impl::template _append<T>(::std::move(*this), FWD(args)...)};
   }
@@ -97,10 +91,8 @@ template <typename... Ts> struct pack : detail::pack_impl<::std::index_sequence_
    */
   template <typename T>
   [[nodiscard]] constexpr auto append(::std::in_place_type_t<T>, auto &&...args) const && //
-      noexcept(_impl::template _nothrow_relocatable<pack const &&>
-               && detail::_nothrow_initializable<T, decltype(args)...>) -> append_type<T>
-    requires detail::_initializable<T, decltype(args)...>
-             && requires { append_type<T>{_impl::template _append<T>(::std::move(*this), FWD(args)...)}; }
+      noexcept(noexcept(_impl::template _append<T>(::std::declval<pack const &&>(), FWD(args)...))) -> append_type<T>
+    requires requires { append_type<T>{_impl::template _append<T>(::std::move(*this), FWD(args)...)}; }
   {
     return {_impl::template _append<T>(::std::move(*this), FWD(args)...)};
   }
@@ -248,12 +240,10 @@ template <typename... Ts> struct pack : detail::pack_impl<::std::index_sequence_
    */
   template <typename Ret, typename Fn>
   [[nodiscard]] constexpr auto invoke_r(Fn &&fn, auto &&...args) & //
-      noexcept(noexcept(_impl::_invoke(::std::declval<pack &>(), FWD(fn), FWD(args)...))
-               && ::std::is_nothrow_constructible_v<Ret, decltype(_impl::_invoke(*this, FWD(fn), FWD(args)...))>) -> Ret
-    requires requires { _impl::_invoke(*this, FWD(fn), FWD(args)...); }
-             && ::std::is_convertible_v<decltype(_impl::_invoke(*this, FWD(fn), FWD(args)...)), Ret>
+      noexcept(noexcept(_impl::template _invoke_r<Ret>(::std::declval<pack &>(), FWD(fn), FWD(args)...))) -> Ret
+    requires requires { _impl::template _invoke_r<Ret>(*this, FWD(fn), FWD(args)...); }
   {
-    return _impl::_invoke(*this, FWD(fn), FWD(args)...);
+    return _impl::template _invoke_r<Ret>(*this, FWD(fn), FWD(args)...);
   }
 
   /**
@@ -267,12 +257,10 @@ template <typename... Ts> struct pack : detail::pack_impl<::std::index_sequence_
    */
   template <typename Ret, typename Fn>
   [[nodiscard]] constexpr auto invoke_r(Fn &&fn, auto &&...args) const & //
-      noexcept(noexcept(_impl::_invoke(::std::declval<pack const &>(), FWD(fn), FWD(args)...))
-               && ::std::is_nothrow_constructible_v<Ret, decltype(_impl::_invoke(*this, FWD(fn), FWD(args)...))>) -> Ret
-    requires requires { _impl::_invoke(*this, FWD(fn), FWD(args)...); }
-             && ::std::is_convertible_v<decltype(_impl::_invoke(*this, FWD(fn), FWD(args)...)), Ret>
+      noexcept(noexcept(_impl::template _invoke_r<Ret>(::std::declval<pack const &>(), FWD(fn), FWD(args)...))) -> Ret
+    requires requires { _impl::template _invoke_r<Ret>(*this, FWD(fn), FWD(args)...); }
   {
-    return _impl::_invoke(*this, FWD(fn), FWD(args)...);
+    return _impl::template _invoke_r<Ret>(*this, FWD(fn), FWD(args)...);
   }
 
   /**
@@ -286,13 +274,10 @@ template <typename... Ts> struct pack : detail::pack_impl<::std::index_sequence_
    */
   template <typename Ret, typename Fn>
   [[nodiscard]] constexpr auto invoke_r(Fn &&fn, auto &&...args) && //
-      noexcept(noexcept(_impl::_invoke(::std::declval<pack &&>(), FWD(fn), FWD(args)...))
-               && ::std::is_nothrow_constructible_v<Ret, decltype(_impl::_invoke(::std::move(*this), FWD(fn),
-                                                                                 FWD(args)...))>) -> Ret
-    requires requires { _impl::_invoke(::std::move(*this), FWD(fn), FWD(args)...); }
-             && ::std::is_convertible_v<decltype(_impl::_invoke(::std::move(*this), FWD(fn), FWD(args)...)), Ret>
+      noexcept(noexcept(_impl::template _invoke_r<Ret>(::std::declval<pack &&>(), FWD(fn), FWD(args)...))) -> Ret
+    requires requires { _impl::template _invoke_r<Ret>(::std::move(*this), FWD(fn), FWD(args)...); }
   {
-    return _impl::_invoke(::std::move(*this), FWD(fn), FWD(args)...);
+    return _impl::template _invoke_r<Ret>(::std::move(*this), FWD(fn), FWD(args)...);
   }
 
   /**
@@ -306,13 +291,10 @@ template <typename... Ts> struct pack : detail::pack_impl<::std::index_sequence_
    */
   template <typename Ret, typename Fn>
   [[nodiscard]] constexpr auto invoke_r(Fn &&fn, auto &&...args) const && //
-      noexcept(noexcept(_impl::_invoke(::std::declval<pack const &&>(), FWD(fn), FWD(args)...))
-               && ::std::is_nothrow_constructible_v<Ret, decltype(_impl::_invoke(::std::move(*this), FWD(fn),
-                                                                                 FWD(args)...))>) -> Ret
-    requires requires { _impl::_invoke(::std::move(*this), FWD(fn), FWD(args)...); }
-             && ::std::is_convertible_v<decltype(_impl::_invoke(::std::move(*this), FWD(fn), FWD(args)...)), Ret>
+      noexcept(noexcept(_impl::template _invoke_r<Ret>(::std::declval<pack const &&>(), FWD(fn), FWD(args)...))) -> Ret
+    requires requires { _impl::template _invoke_r<Ret>(::std::move(*this), FWD(fn), FWD(args)...); }
   {
-    return _impl::_invoke(::std::move(*this), FWD(fn), FWD(args)...);
+    return _impl::template _invoke_r<Ret>(::std::move(*this), FWD(fn), FWD(args)...);
   }
 };
 
@@ -348,9 +330,9 @@ template <::std::size_t I, some_pack P>
  */
 [[nodiscard]] constexpr auto as_pack() noexcept -> pack<> { return {}; }
 template <typename T, typename... Args>
-  requires(not some_in_place_type<T>)
+  requires(not some_in_place_type<T>) && detail::_initializable<pack<T, Args...>, T, Args...>
 [[nodiscard]] constexpr auto as_pack(T &&src, Args &&...args) //
-    noexcept(::std::is_nothrow_constructible_v<pack<T, Args...>, T, Args...>) -> decltype(auto)
+    noexcept(detail::_nothrow_initializable<pack<T, Args...>, T, Args...>) -> pack<T, Args...>
 {
   return pack<T, Args...>{FWD(src), FWD(args)...};
 }

--- a/include/fn/sum.hpp
+++ b/include/fn/sum.hpp
@@ -176,6 +176,22 @@ struct sum<Ts...> {
 
   static constexpr ::std::size_t size = sizeof...(Ts);
 
+  // What copying and moving a sum cost, asked of the storage that performs them - see the concepts
+  // in detail/variadic_union.hpp. Everything below is specified and constrained in these terms, so
+  // that no declaration has to restate what the storage does, and none can drift from it.
+  static constexpr bool _copyable = (... && detail::_makeable<data_t, Ts, Ts const &>);
+  static constexpr bool _movable = (... && detail::_makeable<data_t, Ts, Ts>);
+  static constexpr bool _nothrow_copyable = (... && detail::_nothrow_makeable<data_t, Ts, Ts const &>);
+  static constexpr bool _nothrow_movable = (... && detail::_nothrow_makeable<data_t, Ts, Ts>);
+
+  // Copy assignment reinitializes ONE alternative, and `_reinit` chooses its arm per alternative - so
+  // the choice belongs INSIDE the fold. Hoisting it out would demand that one arm serve them all, and
+  // would reject a sum whose alternatives simply need different ones.
+  static constexpr bool _copy_assignable
+      = (...
+         && (detail::_makeable<data_t, Ts, Ts const &>
+             && (detail::_nothrow_makeable<data_t, Ts, Ts const &> || detail::_nothrow_makeable<data_t, Ts, Ts>)));
+
   /**
    * @brief TODO
    *
@@ -235,8 +251,8 @@ struct sum<Ts...> {
    */
   template <typename T>
   constexpr sum(T &&v) // NOSONAR cpp:S1709,S6458 implicit arm of the explicit pair; has_type excludes self
-      noexcept(detail::_nothrow_initializable<::std::remove_cvref_t<T>, decltype(v)>)
-    requires has_type<::std::remove_cvref_t<T>> && (detail::_initializable<::std::remove_cvref_t<T>, decltype(v)>)
+      noexcept(detail::_nothrow_makeable<data_t, ::std::remove_cvref_t<T>, decltype(v)>)
+    requires has_type<::std::remove_cvref_t<T>> && (detail::_makeable<data_t, ::std::remove_cvref_t<T>, decltype(v)>)
                  && (::std::is_convertible_v<decltype(v), ::std::remove_cvref_t<T>>)
       : data(detail::make_variadic_union<::std::remove_cvref_t<T>, data_t>(FWD(v))),
         index(detail::type_index<::std::remove_cvref_t<T>, Ts...>)
@@ -251,8 +267,8 @@ struct sum<Ts...> {
    */
   template <typename T>
   constexpr explicit sum(T &&v) // NOSONAR cpp:S6458 has_type excludes self
-      noexcept(detail::_nothrow_initializable<::std::remove_cvref_t<T>, decltype(v)>)
-    requires has_type<::std::remove_cvref_t<T>> && (detail::_initializable<::std::remove_cvref_t<T>, decltype(v)>)
+      noexcept(detail::_nothrow_makeable<data_t, ::std::remove_cvref_t<T>, decltype(v)>)
+    requires has_type<::std::remove_cvref_t<T>> && (detail::_makeable<data_t, ::std::remove_cvref_t<T>, decltype(v)>)
                  && (not ::std::is_convertible_v<decltype(v), ::std::remove_cvref_t<T>>)
       : data(detail::make_variadic_union<::std::remove_cvref_t<T>, data_t>(FWD(v))),
         index(detail::type_index<::std::remove_cvref_t<T>, Ts...>)
@@ -267,8 +283,8 @@ struct sum<Ts...> {
    */
   template <typename T>
   constexpr explicit sum(::std::in_place_type_t<T>,
-                         auto &&...args) noexcept(detail::_nothrow_initializable<T, decltype(args)...>)
-    requires has_type<T> && detail::_initializable<T, decltype(args)...>
+                         auto &&...args) noexcept(detail::_nothrow_makeable<data_t, T, decltype(args)...>)
+    requires has_type<T> && detail::_makeable<data_t, T, decltype(args)...>
       : data(detail::make_variadic_union<T, data_t>(FWD(args)...)), index(detail::type_index<T, Ts...>)
   {
   }
@@ -281,9 +297,9 @@ struct sum<Ts...> {
    */
   template <typename... Tx>
   constexpr sum(sum<Tx...> const &arg) // NOSONAR cpp:S1709 implicit widening by design
-      noexcept((... && detail::_nothrow_initializable<Tx, Tx const &>))
+      noexcept((... && detail::_nothrow_makeable<data_t, Tx, Tx const &>))
     requires detail::is_superset_of<sum, sum<Tx...>> && (not ::std::is_same_v<sum, sum<Tx...>>)
-                 && (... && detail::_initializable<Tx, Tx const &>) && (sizeof...(Tx) > 0)
+                 && (... && detail::_makeable<data_t, Tx, Tx const &>) && (sizeof...(Tx) > 0)
       : data(FWD(arg).template _invoke<data_t>([]<typename T>(::std::in_place_type_t<T>, auto &&v) {
           return detail::make_variadic_union<T, data_t>(FWD(v));
         })),
@@ -301,9 +317,9 @@ struct sum<Ts...> {
    */
   template <typename... Tx>
   constexpr sum(sum<Tx...> &&arg) // NOSONAR cpp:S1709 implicit widening by design
-      noexcept((... && detail::_nothrow_initializable<Tx, Tx>))
+      noexcept((... && detail::_nothrow_makeable<data_t, Tx, Tx>))
     requires detail::is_superset_of<sum, sum<Tx...>> && (not ::std::is_same_v<sum, sum<Tx...>>)
-                 && (... && detail::_initializable<Tx, Tx>) && (sizeof...(Tx) > 0)
+                 && (... && detail::_makeable<data_t, Tx, Tx>) && (sizeof...(Tx) > 0)
       : data(FWD(arg).template _invoke<data_t>([]<typename T>(::std::in_place_type_t<T>, auto &&v) {
           return detail::make_variadic_union<T, data_t>(FWD(v));
         })),
@@ -321,7 +337,7 @@ struct sum<Ts...> {
    */
   template <typename... Tx>
   constexpr sum(::std::in_place_type_t<sum<Tx...>>, some_sum auto &&arg) //
-      noexcept((... && detail::_nothrow_initializable<Tx, apply_const_lvalue_t<decltype(arg), Tx &&>>))
+      noexcept((... && detail::_nothrow_makeable<data_t, Tx, apply_const_lvalue_t<decltype(arg), Tx &&>>))
     requires ::std::is_same_v<::std::remove_cvref_t<decltype(arg)>, sum<Tx...>>
                  && detail::is_superset_of<sum, sum<Tx...>> && (sizeof...(Tx) > 0)
       : data(FWD(arg).template _invoke<data_t>([]<typename T>(::std::in_place_type_t<T>, auto &&v) {
@@ -338,8 +354,8 @@ struct sum<Ts...> {
    *
    * @param other TODO
    */
-  constexpr sum(sum const &other) noexcept((... && detail::_nothrow_initializable<Ts, Ts const &>))
-    requires(... && detail::_initializable<Ts, Ts const &>)
+  constexpr sum(sum const &other) noexcept(_nothrow_copyable)
+    requires _copyable
       : data(detail::invoke_type_variadic_union<data_t, data_t>(       //
             other.data, other.index,                                   //
             []<typename T>(::std::in_place_type_t<T>, auto const &v) { //
@@ -354,8 +370,8 @@ struct sum<Ts...> {
    *
    * @param other TODO
    */
-  constexpr sum(sum &&other) noexcept((... && detail::_nothrow_initializable<Ts, Ts>))
-    requires(... && detail::_initializable<Ts, Ts>)
+  constexpr sum(sum &&other) noexcept(_nothrow_movable)
+    requires _movable
       : data(detail::invoke_type_variadic_union<data_t, data_t>(  //
             ::std::move(other).data, other.index,                 //
             []<typename T>(::std::in_place_type_t<T>, auto &&v) { //
@@ -387,17 +403,17 @@ struct sum<Ts...> {
   // snapshotting that same type would throw in turn. So there is no safe path, and such an
   // alternative is constrained away rather than half-served.
   //
-  // Every question below is asked of BRACE initialization (`_initializable`), because that is what
-  // the storage performs - `std::is_nothrow_move_constructible_v` asks about `T(T&&)` instead, and
-  // the two can disagree: braced initialization considers initializer-list constructors first, so a
-  // type can promise a nothrow move and still throw from `T{std::move(t)}`. Believing the parens
-  // answer here would destroy the old alternative and then fail to replace it.
+  // The arm is chosen by asking the storage what it can do, never by a trait that restates it:
+  // `std::is_nothrow_move_constructible_v` asks about `T(T&&)`, the storage performs `T{...}`, and
+  // the two can disagree - braced initialization considers initializer-list constructors first, so a
+  // type can promise a nothrow move and still throw from `T{std::move(t)}`. Believing that promise
+  // here would destroy the old alternative and then fail to replace it.
   template <typename T, typename... Args>
-  constexpr void _reinit(Args &&...args) noexcept(detail::_nothrow_initializable<T, Args...>)
-    requires has_type<T> && detail::_initializable<T, Args...>
-             && (detail::_nothrow_initializable<T, Args...> || detail::_nothrow_initializable<T, T>)
+  constexpr void _reinit(Args &&...args) noexcept(detail::_nothrow_makeable<data_t, T, Args...>)
+    requires has_type<T> && detail::_makeable<data_t, T, Args...>
+             && (detail::_nothrow_makeable<data_t, T, Args...> || detail::_nothrow_makeable<data_t, T, T>)
   {
-    if constexpr (detail::_nothrow_initializable<T, Args...>) {
+    if constexpr (detail::_nothrow_makeable<data_t, T, Args...>) {
       ::std::destroy_at(this);
       ::std::construct_at(this, ::std::in_place_type<T>, FWD(args)...);
     } else {
@@ -416,10 +432,8 @@ struct sum<Ts...> {
   // The alternative that changes is CONSTRUCTED, never assigned to: assignment asks nothing of `Ts`
   // beyond what construction already asks, so a type with no assignment operator at all is still
   // assignable through the sum.
-  constexpr sum &operator=(sum const &other) noexcept((... && detail::_nothrow_initializable<Ts, Ts const &>))
-    requires(...
-             && (detail::_initializable<Ts, Ts const &>
-                 && (detail::_nothrow_initializable<Ts, Ts const &> || detail::_nothrow_initializable<Ts, Ts>)))
+  constexpr sum &operator=(sum const &other) noexcept(_nothrow_copyable)
+    requires _copy_assignable
   {
     if (this != &other) {
       detail::invoke_type_variadic_union<void, data_t>( //
@@ -438,7 +452,7 @@ struct sum<Ts...> {
   // Moving is offered only where it cannot throw, for the reason given on _reinit - and where it can,
   // a nothrow-copyable sum is still assignable from an rvalue, by copy.
   constexpr sum &operator=(sum &&other) noexcept
-    requires(... && detail::_nothrow_initializable<Ts, Ts>)
+    requires _nothrow_movable
   {
     if (this != &other) {
       detail::invoke_type_variadic_union<void, data_t>( //
@@ -747,7 +761,8 @@ template <typename T> explicit sum(T) -> sum<::std::remove_cvref_t<T>>;
  * @return TODO
  */
 [[nodiscard]] constexpr auto as_sum(auto &&src) //
-    noexcept(detail::_nothrow_initializable<::std::remove_cvref_t<decltype(src)>, decltype(src)>) -> decltype(auto)
+    noexcept(::std::is_nothrow_constructible_v<sum<::std::remove_cvref_t<decltype(src)>>, decltype(src)>)
+        -> decltype(auto)
   requires(not some_in_place_type<decltype(src)>)
 {
   return sum<::std::remove_cvref_t<decltype(src)>>(FWD(src));
@@ -761,8 +776,8 @@ template <typename T> explicit sum(T) -> sum<::std::remove_cvref_t<T>>;
  */
 template <typename T>
 [[nodiscard]] constexpr auto as_sum(::std::in_place_type_t<T>, auto &&...args) //
-    noexcept(detail::_nothrow_initializable<T, decltype(args)...>) -> decltype(auto)
-  requires detail::_initializable<T, decltype(args)...>
+    noexcept(::std::is_nothrow_constructible_v<sum<T>, ::std::in_place_type_t<T>, decltype(args)...>) -> decltype(auto)
+  requires ::std::is_constructible_v<sum<T>, ::std::in_place_type_t<T>, decltype(args)...>
 {
   return sum<T>(::std::in_place_type<T>, FWD(args)...);
 }

--- a/include/fn/sum.hpp
+++ b/include/fn/sum.hpp
@@ -753,6 +753,17 @@ struct sum<Ts...> {
 template <typename T> explicit sum(::std::in_place_type_t<T>, auto &&...) -> sum<T>;
 template <typename T> explicit sum(T) -> sum<::std::remove_cvref_t<T>>;
 
+namespace detail {
+// The value lift builds `sum<remove_cvref_t<Src>>` - a class whose body refuses an in_place tag as
+// an alternative. MSVC (C++20 mode) compiles a candidate's noexcept-specifier once deduction
+// succeeds, BEFORE the constraint rejects the tag, so the specifier must not name that sum unless
+// the guard holds: a guarded specialization, as `_nothrow_eq_with` is, and for the same reason.
+template <typename Src> constexpr inline bool _nothrow_sum_lift = false;
+template <typename Src>
+  requires(not some_in_place_type<Src>)
+constexpr inline bool _nothrow_sum_lift<Src> = ::std::is_nothrow_constructible_v<sum<::std::remove_cvref_t<Src>>, Src>;
+} // namespace detail
+
 // Lifts
 /**
  * @brief TODO
@@ -761,8 +772,7 @@ template <typename T> explicit sum(T) -> sum<::std::remove_cvref_t<T>>;
  * @return TODO
  */
 [[nodiscard]] constexpr auto as_sum(auto &&src) //
-    noexcept(::std::is_nothrow_constructible_v<sum<::std::remove_cvref_t<decltype(src)>>, decltype(src)>)
-        -> decltype(auto)
+    noexcept(detail::_nothrow_sum_lift<decltype(src)>) -> decltype(auto)
   requires(not some_in_place_type<decltype(src)>)
 {
   return sum<::std::remove_cvref_t<decltype(src)>>(FWD(src));

--- a/include/fn/sum.hpp
+++ b/include/fn/sum.hpp
@@ -236,7 +236,7 @@ struct sum<Ts...> {
   template <typename T>
   constexpr sum(T &&v) // NOSONAR cpp:S1709,S6458 implicit arm of the explicit pair; has_type excludes self
       noexcept(detail::_nothrow_initializable<::std::remove_cvref_t<T>, decltype(v)>)
-    requires has_type<::std::remove_cvref_t<T>> && (::std::is_constructible_v<::std::remove_cvref_t<T>, decltype(v)>)
+    requires has_type<::std::remove_cvref_t<T>> && (detail::_initializable<::std::remove_cvref_t<T>, decltype(v)>)
                  && (::std::is_convertible_v<decltype(v), ::std::remove_cvref_t<T>>)
       : data(detail::make_variadic_union<::std::remove_cvref_t<T>, data_t>(FWD(v))),
         index(detail::type_index<::std::remove_cvref_t<T>, Ts...>)
@@ -252,7 +252,7 @@ struct sum<Ts...> {
   template <typename T>
   constexpr explicit sum(T &&v) // NOSONAR cpp:S6458 has_type excludes self
       noexcept(detail::_nothrow_initializable<::std::remove_cvref_t<T>, decltype(v)>)
-    requires has_type<::std::remove_cvref_t<T>> && (::std::is_constructible_v<::std::remove_cvref_t<T>, decltype(v)>)
+    requires has_type<::std::remove_cvref_t<T>> && (detail::_initializable<::std::remove_cvref_t<T>, decltype(v)>)
                  && (not ::std::is_convertible_v<decltype(v), ::std::remove_cvref_t<T>>)
       : data(detail::make_variadic_union<::std::remove_cvref_t<T>, data_t>(FWD(v))),
         index(detail::type_index<::std::remove_cvref_t<T>, Ts...>)
@@ -281,9 +281,9 @@ struct sum<Ts...> {
    */
   template <typename... Tx>
   constexpr sum(sum<Tx...> const &arg) // NOSONAR cpp:S1709 implicit widening by design
-      noexcept((... && ::std::is_nothrow_copy_constructible_v<Tx>))
+      noexcept((... && detail::_nothrow_initializable<Tx, Tx const &>))
     requires detail::is_superset_of<sum, sum<Tx...>> && (not ::std::is_same_v<sum, sum<Tx...>>)
-                 && (... && ::std::is_copy_constructible_v<Tx>) && (sizeof...(Tx) > 0)
+                 && (... && detail::_initializable<Tx, Tx const &>) && (sizeof...(Tx) > 0)
       : data(FWD(arg).template _invoke<data_t>([]<typename T>(::std::in_place_type_t<T>, auto &&v) {
           return detail::make_variadic_union<T, data_t>(FWD(v));
         })),
@@ -301,9 +301,9 @@ struct sum<Ts...> {
    */
   template <typename... Tx>
   constexpr sum(sum<Tx...> &&arg) // NOSONAR cpp:S1709 implicit widening by design
-      noexcept((... && ::std::is_nothrow_move_constructible_v<Tx>))
+      noexcept((... && detail::_nothrow_initializable<Tx, Tx>))
     requires detail::is_superset_of<sum, sum<Tx...>> && (not ::std::is_same_v<sum, sum<Tx...>>)
-                 && (... && ::std::is_move_constructible_v<Tx>) && (sizeof...(Tx) > 0)
+                 && (... && detail::_initializable<Tx, Tx>) && (sizeof...(Tx) > 0)
       : data(FWD(arg).template _invoke<data_t>([]<typename T>(::std::in_place_type_t<T>, auto &&v) {
           return detail::make_variadic_union<T, data_t>(FWD(v));
         })),
@@ -321,7 +321,7 @@ struct sum<Ts...> {
    */
   template <typename... Tx>
   constexpr sum(::std::in_place_type_t<sum<Tx...>>, some_sum auto &&arg) //
-      noexcept((... && ::std::is_nothrow_constructible_v<Tx, apply_const_lvalue_t<decltype(arg), Tx &&>>))
+      noexcept((... && detail::_nothrow_initializable<Tx, apply_const_lvalue_t<decltype(arg), Tx &&>>))
     requires ::std::is_same_v<::std::remove_cvref_t<decltype(arg)>, sum<Tx...>>
                  && detail::is_superset_of<sum, sum<Tx...>> && (sizeof...(Tx) > 0)
       : data(FWD(arg).template _invoke<data_t>([]<typename T>(::std::in_place_type_t<T>, auto &&v) {
@@ -338,8 +338,8 @@ struct sum<Ts...> {
    *
    * @param other TODO
    */
-  constexpr sum(sum const &other) noexcept((... && ::std::is_nothrow_copy_constructible_v<Ts>))
-    requires(... && ::std::is_copy_constructible_v<Ts>)
+  constexpr sum(sum const &other) noexcept((... && detail::_nothrow_initializable<Ts, Ts const &>))
+    requires(... && detail::_initializable<Ts, Ts const &>)
       : data(detail::invoke_type_variadic_union<data_t, data_t>(       //
             other.data, other.index,                                   //
             []<typename T>(::std::in_place_type_t<T>, auto const &v) { //
@@ -354,8 +354,8 @@ struct sum<Ts...> {
    *
    * @param other TODO
    */
-  constexpr sum(sum &&other) noexcept((... && ::std::is_nothrow_move_constructible_v<Ts>))
-    requires(... && ::std::is_move_constructible_v<Ts>)
+  constexpr sum(sum &&other) noexcept((... && detail::_nothrow_initializable<Ts, Ts>))
+    requires(... && detail::_initializable<Ts, Ts>)
       : data(detail::invoke_type_variadic_union<data_t, data_t>(  //
             ::std::move(other).data, other.index,                 //
             []<typename T>(::std::in_place_type_t<T>, auto &&v) { //
@@ -386,10 +386,16 @@ struct sum<Ts...> {
   // a possible OLD alternative (one is assigned over itself whenever the sum already holds it), and
   // snapshotting that same type would throw in turn. So there is no safe path, and such an
   // alternative is constrained away rather than half-served.
+  //
+  // Every question below is asked of BRACE initialization (`_initializable`), because that is what
+  // the storage performs - `std::is_nothrow_move_constructible_v` asks about `T(T&&)` instead, and
+  // the two can disagree: braced initialization considers initializer-list constructors first, so a
+  // type can promise a nothrow move and still throw from `T{std::move(t)}`. Believing the parens
+  // answer here would destroy the old alternative and then fail to replace it.
   template <typename T, typename... Args>
   constexpr void _reinit(Args &&...args) noexcept(detail::_nothrow_initializable<T, Args...>)
     requires has_type<T> && detail::_initializable<T, Args...>
-             && (detail::_nothrow_initializable<T, Args...> || ::std::is_nothrow_move_constructible_v<T>)
+             && (detail::_nothrow_initializable<T, Args...> || detail::_nothrow_initializable<T, T>)
   {
     if constexpr (detail::_nothrow_initializable<T, Args...>) {
       ::std::destroy_at(this);
@@ -397,7 +403,7 @@ struct sum<Ts...> {
     } else {
       T tmp{FWD(args)...}; // may throw, and the storage is untouched until it cannot
       ::std::destroy_at(this);
-      ::std::construct_at(this, ::std::in_place_type<T>, ::std::move(tmp));
+      ::std::construct_at(this, ::std::in_place_type<T>, ::std::move(tmp)); // cannot throw: see above
     }
   }
 
@@ -410,10 +416,10 @@ struct sum<Ts...> {
   // The alternative that changes is CONSTRUCTED, never assigned to: assignment asks nothing of `Ts`
   // beyond what construction already asks, so a type with no assignment operator at all is still
   // assignable through the sum.
-  constexpr sum &operator=(sum const &other) noexcept((... && ::std::is_nothrow_copy_constructible_v<Ts>))
+  constexpr sum &operator=(sum const &other) noexcept((... && detail::_nothrow_initializable<Ts, Ts const &>))
     requires(...
-             && (::std::is_copy_constructible_v<Ts>
-                 && (::std::is_nothrow_copy_constructible_v<Ts> || ::std::is_nothrow_move_constructible_v<Ts>)))
+             && (detail::_initializable<Ts, Ts const &>
+                 && (detail::_nothrow_initializable<Ts, Ts const &> || detail::_nothrow_initializable<Ts, Ts>)))
   {
     if (this != &other) {
       detail::invoke_type_variadic_union<void, data_t>( //
@@ -432,7 +438,7 @@ struct sum<Ts...> {
   // Moving is offered only where it cannot throw, for the reason given on _reinit - and where it can,
   // a nothrow-copyable sum is still assignable from an rvalue, by copy.
   constexpr sum &operator=(sum &&other) noexcept
-    requires(... && ::std::is_nothrow_move_constructible_v<Ts>)
+    requires(... && detail::_nothrow_initializable<Ts, Ts>)
   {
     if (this != &other) {
       detail::invoke_type_variadic_union<void, data_t>( //

--- a/tests/fn/choice.cpp
+++ b/tests/fn/choice.cpp
@@ -35,6 +35,25 @@ struct NonCopyable final {
 template <typename S, typename T, typename... Args>
 concept can_in_place = requires(Args... args) { S{std::in_place_type<T>, args...}; };
 
+// Every special member of choice is defaulted, and choice adds no state to sum - so each must behave
+// exactly as sum's, down to its noexcept and its constraints.
+template <typename... Ts> consteval bool special_members_follow_sum()
+{
+  using C = fn::choice<Ts...>;
+  using S = fn::sum<Ts...>;
+  return std::is_copy_constructible_v<C> == std::is_copy_constructible_v<S>                    //
+         && std::is_nothrow_copy_constructible_v<C> == std::is_nothrow_copy_constructible_v<S> //
+         && std::is_move_constructible_v<C> == std::is_move_constructible_v<S>                 //
+         && std::is_nothrow_move_constructible_v<C> == std::is_nothrow_move_constructible_v<S> //
+         && std::is_copy_assignable_v<C> == std::is_copy_assignable_v<S>                       //
+         && std::is_nothrow_copy_assignable_v<C> == std::is_nothrow_copy_assignable_v<S>       //
+         && std::is_move_assignable_v<C> == std::is_move_assignable_v<S>                       //
+         && std::is_nothrow_move_assignable_v<C> == std::is_nothrow_move_assignable_v<S>       //
+         && std::is_destructible_v<C> == std::is_destructible_v<S>                             //
+         && std::is_nothrow_destructible_v<C> == std::is_nothrow_destructible_v<S>             //
+         && std::is_trivially_destructible_v<C> == std::is_trivially_destructible_v<S>;
+}
+
 } // anonymous namespace
 
 TEST_CASE("choice non-monadic functionality", "[choice]")
@@ -820,4 +839,47 @@ TEST_CASE("choice assignment", "[choice][assignment]")
     }());
     SUCCEED();
   }
+}
+
+TEST_CASE("choice special members", "[choice]")
+{
+  using fn::choice;
+
+  // choice declares all five, and defaults all five: the copy constructor because a user-declared
+  // move constructor would otherwise delete it, and the two assignments because they would otherwise
+  // be deleted and suppressed in turn. Removing a `= default`, adding a `noexcept` the base does not
+  // promise, or narrowing a requires-clause would all break the equalities below.
+  static_assert(special_members_follow_sum<int>());
+  static_assert(special_members_follow_sum<bool, int>());
+  static_assert(special_members_follow_sum<std::string>());
+  static_assert(special_members_follow_sum<helper_move_only>());
+  static_assert(special_members_follow_sum<helper_immovable>());
+
+  // ... and what they follow it TO, so that the equalities cannot be satisfied by both being wrong
+  static_assert(std::is_nothrow_copy_constructible_v<choice<int>>);
+  static_assert(std::is_nothrow_move_constructible_v<choice<int>>);
+  static_assert(std::is_nothrow_copy_assignable_v<choice<int>>);
+  static_assert(std::is_nothrow_move_assignable_v<choice<int>>);
+  static_assert(std::is_nothrow_destructible_v<choice<int>>);
+  static_assert(not std::is_trivially_destructible_v<choice<int>>); // the base destroys its alternative
+
+  // a throwing copy is reported as one, rather than promised away
+  static_assert(std::is_copy_constructible_v<choice<std::string>>);
+  static_assert(not std::is_nothrow_copy_constructible_v<choice<std::string>>);
+  static_assert(std::is_nothrow_move_constructible_v<choice<std::string>>);
+  static_assert(not std::is_nothrow_copy_assignable_v<choice<std::string>>);
+  static_assert(std::is_nothrow_move_assignable_v<choice<std::string>>);
+
+  // an alternative that cannot be copied takes copy construction and copy assignment with it
+  static_assert(not std::is_copy_constructible_v<choice<helper_move_only>>);
+  static_assert(not std::is_copy_assignable_v<choice<helper_move_only>>);
+  static_assert(std::is_nothrow_move_constructible_v<choice<helper_move_only>>);
+  static_assert(std::is_nothrow_move_assignable_v<choice<helper_move_only>>);
+
+  // ... and one that can be neither copied nor moved leaves none of the four
+  static_assert(not std::is_copy_constructible_v<choice<helper_immovable>>);
+  static_assert(not std::is_move_constructible_v<choice<helper_immovable>>);
+  static_assert(not std::is_copy_assignable_v<choice<helper_immovable>>);
+  static_assert(not std::is_move_assignable_v<choice<helper_immovable>>);
+  SUCCEED();
 }

--- a/tests/fn/pack.cpp
+++ b/tests/fn/pack.cpp
@@ -15,6 +15,7 @@
 #include <array>
 #include <memory>
 #include <stdexcept>
+#include <string>
 #include <tuple>
 #include <utility>
 
@@ -39,7 +40,85 @@ concept can_append = requires(V v, Arg arg) { FWD(v).append(FWD(arg)); };
 template <typename... Args>
 concept can_as_pack = requires(Args &&...args) { fn::as_pack(FWD(args)...); };
 
+// pack declares no special member, so each one is implicit - composed from the _element bases which
+// hold the data. Ask the elements, not the element types: a holder of a reference or of a const
+// member answers assignment differently than the bare type would.
+template <typename T> using elem = fn::detail::_element<0, T>;
+template <typename... Ts> consteval bool special_members_follow_elements()
+{
+  using P = fn::pack<Ts...>;
+  bool ok = std::is_copy_constructible_v<P> == (... && std::is_copy_constructible_v<elem<Ts>>);
+  ok = ok && std::is_nothrow_copy_constructible_v<P> == (... && std::is_nothrow_copy_constructible_v<elem<Ts>>);
+  ok = ok && std::is_move_constructible_v<P> == (... && std::is_move_constructible_v<elem<Ts>>);
+  ok = ok && std::is_nothrow_move_constructible_v<P> == (... && std::is_nothrow_move_constructible_v<elem<Ts>>);
+  ok = ok && std::is_copy_assignable_v<P> == (... && std::is_copy_assignable_v<elem<Ts>>);
+  ok = ok && std::is_nothrow_copy_assignable_v<P> == (... && std::is_nothrow_copy_assignable_v<elem<Ts>>);
+  ok = ok && std::is_move_assignable_v<P> == (... && std::is_move_assignable_v<elem<Ts>>);
+  ok = ok && std::is_nothrow_move_assignable_v<P> == (... && std::is_nothrow_move_assignable_v<elem<Ts>>);
+  ok = ok && std::is_destructible_v<P> == (... && std::is_destructible_v<elem<Ts>>);
+  ok = ok && std::is_nothrow_destructible_v<P> == (... && std::is_nothrow_destructible_v<elem<Ts>>);
+  ok = ok && std::is_trivially_destructible_v<P> == (... && std::is_trivially_destructible_v<elem<Ts>>);
+  return ok;
+}
+
 } // namespace
+
+// pack is an aggregate at every layer - the element holder, the implementation, and pack itself.
+// Everything above rests on that: brace initialization with elision, the structural type, and
+// special members composed from the elements' own. A constructor added anywhere in the stack would
+// change all of it in silence; these assertions fail instead.
+TEST_CASE("design: an aggregate, at every layer", "[pack][design]")
+{
+  using fn::pack;
+
+  WHEN("aggregates")
+  {
+    static_assert(std::is_aggregate_v<fn::detail::_element<0, int>>);
+    static_assert(std::is_aggregate_v<fn::detail::_element<1, int &>>);
+    static_assert(std::is_aggregate_v<fn::detail::pack_impl<std::index_sequence<0, 1>, int, int &>>);
+    static_assert(std::is_aggregate_v<pack<>>);
+    static_assert(std::is_aggregate_v<pack<int, int &, int const, std::string>>);
+    SUCCEED();
+  }
+
+  WHEN("brace elision")
+  {
+    // flat initializers reach the elements through two layers of subaggregate without written braces
+    constexpr pack<int, double> p{3, 0.5};
+    static_assert(fn::get<0>(p) == 3);
+    CHECK(fn::get<1>(p) == 0.5);
+  }
+
+  WHEN("special members follow the elements")
+  {
+    static_assert(special_members_follow_elements<>());
+    static_assert(special_members_follow_elements<int>());
+    static_assert(special_members_follow_elements<int, double>());
+    static_assert(special_members_follow_elements<std::string>());
+    static_assert(special_members_follow_elements<std::unique_ptr<int>>());
+    static_assert(special_members_follow_elements<int &>());
+    static_assert(special_members_follow_elements<int const>());
+    static_assert(special_members_follow_elements<int, std::string, std::unique_ptr<int>, int &>());
+
+    struct Immovable {
+      Immovable(Immovable &&) = delete;
+    };
+    static_assert(special_members_follow_elements<Immovable>());
+
+    // anchors, so the equalities above cannot be satisfied by both sides being wrong at once
+    static_assert(std::is_nothrow_move_constructible_v<pack<std::string>>);
+    static_assert(not std::is_nothrow_copy_constructible_v<pack<std::string>>);
+    static_assert(not std::is_copy_constructible_v<pack<std::unique_ptr<int>>>);
+    static_assert(std::is_nothrow_move_constructible_v<pack<std::unique_ptr<int>>>);
+    static_assert(not std::is_move_constructible_v<pack<Immovable>>);
+    static_assert(std::is_copy_constructible_v<pack<int &>>);
+    static_assert(not std::is_copy_assignable_v<pack<int &>>);
+    static_assert(not std::is_copy_assignable_v<pack<int const>>);
+    static_assert(std::is_trivially_destructible_v<pack<int, int &>>);
+    static_assert(not std::is_trivially_destructible_v<pack<std::string>>);
+    SUCCEED();
+  }
+}
 
 TEST_CASE("pack", "[pack]")
 {

--- a/tests/fn/pack.cpp
+++ b/tests/fn/pack.cpp
@@ -13,6 +13,8 @@
 #include <catch2/catch_all.hpp>
 
 #include <array>
+#include <memory>
+#include <stdexcept>
 #include <tuple>
 #include <utility>
 
@@ -33,6 +35,9 @@ concept can_append_in_place = requires(V v, Args... args) { FWD(v).append(std::i
 
 template <typename V, typename Arg>
 concept can_append = requires(V v, Arg arg) { FWD(v).append(FWD(arg)); };
+
+template <typename... Args>
+concept can_as_pack = requires(Args &&...args) { fn::as_pack(FWD(args)...); };
 
 } // namespace
 
@@ -209,6 +214,19 @@ TEST_CASE("append value categories", "[pack][append]")
       CHECK(std::move(std::as_const(s)).append(std::in_place_type<C>).invoke_r<int>(check) == 1);
       CHECK(std::move(s).append(std::in_place_type<C>).invoke_r<int>(check) == 1);
     }
+
+    WHEN("aggregate forwarding")
+    {
+      // braces elide through the aggregate: three ints construct the array element in place
+      auto q = s.append(std::in_place_type<std::array<int, 3>>, 5, 6, 7);
+      static_assert(std::same_as<decltype(q), T::append_type<std::array<int, 3>>>);
+      CHECK(q.invoke([](int, std::string_view, A, std::array<int, 3> const &a) //
+                     { return a[0] * 100 + a[1] * 10 + a[2]; })
+            == 567);
+      static_assert(fn::pack<>{}.append(std::in_place_type<std::array<int, 3>>, 5, 6, 7).invoke([](auto const &a) {
+        return a[0] * 100 + a[1] * 10 + a[2];
+      }) == 567);
+    }
   }
 
   WHEN("deduced type")
@@ -304,6 +322,22 @@ TEST_CASE("append value categories", "[pack][append]")
     static_assert(not can_append_in_place<T &, fn::sum<int>, fn::sum<int>>);
     static_assert(not can_append_in_place<T &, fn::sum_for<bool, int>, fn::sum_for<bool, int>>);
 
+    // relocation is part of the question: the elements already held move into the new pack in the
+    // pack's own value category, and an element which cannot make that move rejects the append
+    // instead of hard-erroring inside it
+    static_assert(can_append_in_place<pack<std::unique_ptr<int>> &&, int, int>);
+    static_assert(not can_append_in_place<pack<std::unique_ptr<int>> &, int, int>);
+    static_assert(not can_append_in_place<pack<std::unique_ptr<int>> const &, int, int>);
+    static_assert(not can_append<pack<std::unique_ptr<int>> const &, int>);
+    // the same guard covers both operands when appending a whole pack
+    static_assert(can_append<pack<int> &, pack<std::unique_ptr<int>>>);
+    static_assert(not can_append<pack<int> &, pack<std::unique_ptr<int>> const &>);
+    static_assert(not can_append<pack<std::unique_ptr<int>> const &, pack<int>>);
+    // const propagates through a reference element, so a const pack cannot rebind it into the new
+    // pack's non-const reference element - the same pack, non-const, can
+    static_assert(can_append_in_place<pack<int &> &, int, int>);
+    static_assert(not can_append_in_place<pack<int &> const &, int, int>);
+
     SUCCEED();
   }
 }
@@ -322,6 +356,11 @@ TEST_CASE("pack noexcept", "[pack][noexcept]")
     Quiet(Quiet const &) noexcept {}
     Quiet(Quiet &&) noexcept {}
   };
+  struct Evil {
+    Evil() = default;
+    explicit Evil(Evil &&) noexcept {}
+    Evil(Evil const &) { throw std::runtime_error{"copied"}; }
+  };
 
   WHEN("append")
   {
@@ -334,7 +373,33 @@ TEST_CASE("pack noexcept", "[pack][noexcept]")
     // ... and so can relocating an element the pack already holds, even where the new one cannot
     static_assert(not noexcept(std::declval<pack<Throwy> &>().append(std::in_place_type<int>, 1)));
     static_assert(not noexcept(std::declval<pack<Throwy> &>().append(1))); // deduced form
+
+    // relocation copy-initializes ([dcl.init.aggr]/4.3), and copy-initialization cannot reach an
+    // explicit constructor - a promise computed from is_nothrow_constructible_v would see the
+    // explicit nothrow move and promise what the deed cannot keep: this throw must propagate
+    static_assert(std::is_nothrow_constructible_v<Evil, Evil>); // the questions disagree here ...
+    static_assert(not noexcept(std::declval<pack<Evil> &&>().append(std::in_place_type<int>, 1))); // ... deed answers
+    pack<Evil> p{Evil{}}; // elided, nothing copied yet
+    CHECK_THROWS_AS(std::move(p).append(std::in_place_type<int>, 1), std::runtime_error);
     SUCCEED();
+  }
+
+  WHEN("as_pack")
+  {
+    // asked of the braces as_pack performs - a question about pack's (nonexistent) constructors
+    // would answer false for every argument list
+    static_assert(noexcept(fn::as_pack(true, 12)));
+    static_assert(std::same_as<decltype(fn::as_pack(true, 12)), fn::pack<bool, int>>);
+    static_assert(not noexcept(fn::as_pack(Throwy{}))); // moving the argument in can throw ...
+    Throwy t{};
+    static_assert(noexcept(fn::as_pack(t))); // ... but an lvalue binds, and binding cannot
+    struct NoMove {
+      NoMove() = default;
+      NoMove(NoMove &&) = delete;
+    };
+    static_assert(not can_as_pack<NoMove>); // constrained on the same initialization ...
+    static_assert(can_as_pack<NoMove &>);   // ... which a binding reference element satisfies
+    CHECK(fn::as_pack(t, 12).invoke([&t](Throwy const &x, int i) { return &x == &t && i == 12; }));
   }
 
   WHEN("invoke")
@@ -345,7 +410,21 @@ TEST_CASE("pack noexcept", "[pack][noexcept]")
     static_assert(not noexcept(std::declval<pack<int, bool> &>().invoke(throwing_fn)));
     static_assert(noexcept(std::declval<pack<int, bool> &>().template invoke_r<int>(nothrow_fn)));
     static_assert(not noexcept(std::declval<pack<int, bool> &>().template invoke_r<int>(throwing_fn)));
-    SUCCEED();
+
+    // Ret is entered by INVOKE<R>'s implicit conversion; the promise asks that call rather than
+    // is_nothrow_constructible_v, whose direct-initialization would reach the explicit move
+    static_assert(std::is_nothrow_constructible_v<Evil, Evil &&>);
+    pack<int> p{1};
+    Evil ev{};
+    auto give_evil = [&ev](int) noexcept -> Evil && { return std::move(ev); };
+    static_assert(not noexcept(std::declval<pack<int> &>().template invoke_r<Evil>(give_evil)));
+    CHECK_THROWS_AS(p.invoke_r<Evil>(give_evil), std::runtime_error);
+    // exactly std::invoke_r's own promise - conservative for a prvalue result (the deed elides,
+    // and indeed nothing throws below), but never a lie
+    auto make_evil = [](int) noexcept -> Evil { return {}; };
+    static_assert(noexcept(std::declval<pack<int> &>().template invoke_r<Evil>(make_evil))
+                  == std::is_nothrow_invocable_r_v<Evil, decltype(make_evil) &, int &>);
+    CHECK_NOTHROW(p.invoke_r<Evil>(make_evil));
   }
 }
 

--- a/tests/fn/sum.cpp
+++ b/tests/fn/sum.cpp
@@ -9,6 +9,7 @@
 
 #include <catch2/catch_all.hpp>
 
+#include <array>
 #include <concepts>
 #include <stdexcept>
 #include <string>
@@ -16,6 +17,7 @@
 #include <type_traits>
 #include <utility>
 #include <variant>
+#include <vector>
 
 namespace {
 struct TestType final {
@@ -72,6 +74,106 @@ concept can_as_sum = requires(Args... args) { fn::as_sum(std::in_place_type<T>, 
 template <typename T>
 concept can_as_sum_value = requires(T v) { fn::as_sum(FWD(v)); };
 } // anonymous namespace
+
+// A sum brace-initializes the alternative it stores. That is a DESIGN DIRECTION, not an
+// implementation detail, and this TEST_CASE exists to fail if it is ever switched to the
+// parenthesized initialization `std::variant` uses. Many other tests would fail with it, but
+// incidentally - this one is here to say what was chosen, and why.
+//
+// What braces buy:
+//   * Aggregate forwarding, through brace elision: `sum{in_place_type<array<int,3>>, 1, 2, 3}`.
+//     `std::variant` cannot express this, and neither can parenthesized initialization - P0960
+//     admits aggregates but forbids brace elision.
+//   * Coherence with `sum` being a structural type. A structural type's alternatives must themselves
+//     be structural - public-member types, written with braces, exactly as one writes them as a
+//     template argument. Storing them any other way would put the two spellings at odds.
+//   * Narrowing is rejected outright rather than silently truncating.
+//
+// What braces cost:
+//   * An initializer-list constructor wins where `std::variant` would call the (count, value) one:
+//     `sum<vector<int>>{in_place_type<vector<int>>, 3, 0}` holds `{3, 0}`, where a variant would hold
+//     `{0, 0, 0}`. This divergence is the cost of giving `sum` a capability which `std::variant` lacks.
+//
+// And the consequence that actually bites, which is why the last section is here: every trait that
+// constrains or specifies the construction of an alternative must ask the BRACE question
+// (`fn::detail::_initializable` / `_nothrow_initializable`), never `std::is_[nothrow_]constructible`,
+// which asks about parentheses. Where the two disagree, the parenthesized answer is a lie.
+TEST_CASE("design: braces, not parentheses", "[sum][design]")
+{
+  using fn::sum;
+
+  WHEN("aggregate forwarding")
+  {
+    using A = std::array<int, 3>;
+    static_assert(can_in_place<sum<A>, A, int, int, int>);        // braces elide; parentheses cannot
+    static_assert(not std::is_constructible_v<A, int, int, int>); // ... which is why the std trait misleads
+    static_assert(fn::detail::_initializable<A, int, int, int>);  // ... and this is the trait that does not
+
+    sum<A> a{std::in_place_type<A>, 1, 2, 3};
+    CHECK(a.invoke([](A const &v) { return v[0] * 100 + v[1] * 10 + v[2]; }) == 123);
+    static_assert(sum<A>{std::in_place_type<A>, 1, 2, 3}.invoke([](A const &v) { return v[2]; }) == 3);
+  }
+
+  WHEN("narrowing")
+  {
+    static_assert(not can_in_place<sum<int>, int, double>); // braces reject it ...
+    static_assert(std::is_constructible_v<int, double>);    // ... where parentheses would truncate in silence
+    SUCCEED();
+  }
+
+  WHEN("initializer-list constructors win")
+  {
+    // the price of the above, and the same mechanism as the trap below: `std::variant` would hold
+    // three zeroes here, and a sum holds the two elements it was written with
+    using V = std::vector<int>;
+    sum<V> v{std::in_place_type<V>, 3, 0};
+    CHECK(v.invoke([](V const &x) { return x.size(); }) == 2);
+    CHECK(v.invoke([](V const &x) { return x[0]; }) == 3);
+  }
+
+  WHEN("the traits must ask the brace question")
+  {
+    // Braced initialization considers initializer-list constructors FIRST, so the two questions can
+    // answer differently - and the parenthesized answer is not the one the storage acts on.
+    struct Listy final {
+      Listy(int) noexcept {}                               // parentheses select this ...
+      Listy(std::initializer_list<int>) noexcept(false) {} // ... braces select this
+    };
+    static_assert(std::is_nothrow_constructible_v<Listy, int>);            // the parenthesized question: nothrow
+    static_assert(not fn::detail::_nothrow_initializable<Listy, int>);     // the braced question: it can throw
+    static_assert(not noexcept(sum<Listy>{std::in_place_type<Listy>, 1})); // the sum promises what it does
+  }
+
+  WHEN("... including where a compiler answers it differently")
+  {
+    // The divergence also reaches the copy and move constructors, and the assignment built on them.
+    // `Evil` converts to double only as an rvalue, so `Evil{lvalue}` copies while `Evil{rvalue}`
+    // selects the throwing initializer-list constructor - which is what [over.match.list]/1 requires,
+    // [dcl.init.list]/3.2's same-type carve-out being for AGGREGATES only, and Evil is not one.
+    // gcc and clang>=20 have it so; clang<=19, AppleClang and MSVC pick the move constructor instead.
+    //
+    // So these pin the INVARIANT rather than the answer: whatever a compiler makes of the braces is
+    // what the sum must promise. Reading the parenthesized answer instead - which is always "nothrow
+    // move" here - declared a `noexcept` that std::terminate had to keep, and offered an assignment
+    // that destroyed the alternative it held and then failed to replace it.
+    struct Tag final {};
+    struct Evil final {
+      int v;
+      Evil(Tag, int i) noexcept : v(i) {} // NOLINT: constructs without touching either trap
+      operator double() && noexcept { return v; }
+      Evil(std::initializer_list<double>) { throw std::runtime_error("init-list"); }
+      Evil(Evil &&o) noexcept : v(o.v) {}
+      Evil(Evil const &o) noexcept(false) : v(o.v) {}
+    };
+    static_assert(std::is_nothrow_move_constructible_v<Evil>); // the parenthesized question, everywhere
+
+    static_assert(std::is_nothrow_move_constructible_v<sum<Evil>> == fn::detail::_nothrow_initializable<Evil, Evil>);
+    static_assert(std::is_nothrow_copy_constructible_v<sum<Evil>>
+                  == fn::detail::_nothrow_initializable<Evil, Evil const &>);
+    static_assert(std::is_move_assignable_v<sum<Evil>> == fn::detail::_nothrow_initializable<Evil, Evil>);
+    SUCCEED();
+  }
+}
 
 TEST_CASE("sum basic functionality tests", "[sum]")
 {
@@ -1280,21 +1382,35 @@ TEST_CASE("sum assignment", "[sum][assignment]")
     // throw, it is made into a temporary first, and only the (nothrow) move touches the storage.
     struct ThrowingCopy final {
       int v;
-      ThrowingCopy(int i) noexcept : v(i) {} // NOLINT: implicit on purpose
-      ThrowingCopy(ThrowingCopy const &o) : v(o.v)
+      constexpr ThrowingCopy(int i) noexcept : v(i) {} // NOLINT: implicit on purpose
+      constexpr ThrowingCopy(ThrowingCopy const &o) : v(o.v)
       {
         if (v == 0)
           throw std::runtime_error("copy");
       }
-      ThrowingCopy(ThrowingCopy &&o) noexcept : v(o.v) {}
+      constexpr ThrowingCopy(ThrowingCopy &&o) noexcept : v(o.v) {}
     };
     static_assert(std::is_copy_assignable_v<sum<ThrowingCopy>>);
     static_assert(not std::is_nothrow_copy_assignable_v<sum<ThrowingCopy>>);
+    constexpr auto value = [](ThrowingCopy const &t) { return t.v; };
 
     sum<ThrowingCopy> a{ThrowingCopy{7}};
     sum<ThrowingCopy> const bad{ThrowingCopy{0}};
     CHECK_THROWS_AS(a = bad, std::runtime_error);
-    CHECK(a.invoke([](ThrowingCopy const &t) { return t.v; }) == 7); // untouched
+    CHECK(a.invoke(value) == 7); // untouched
+
+    // the same arm, completing: the copy into the temporary succeeds, and only then is the old
+    // alternative destroyed and the temporary moved into the storage
+    sum<ThrowingCopy> const good{ThrowingCopy{5}};
+    a = good;
+    CHECK(a.invoke(value) == 5);
+
+    static_assert([] {
+      sum<ThrowingCopy> a{ThrowingCopy{7}};
+      sum<ThrowingCopy> const good{ThrowingCopy{5}};
+      a = good; // the temporary arm, in a constant expression
+      return a.invoke([](ThrowingCopy const &t) { return t.v; }) == 5;
+    }());
 
     WHEN("the two arms in one sum")
     {


### PR DESCRIPTION
The #291 sweep: constraints and specifications derived from the initialization the code performs, at the layer performing it - `sum`'s storage, `choice`'s inheritance, `pack`'s aggregate machinery - each pinned by tests so it cannot drift again.

### Ask of a `sum` alternative the same question its initialization answers

A sum brace-initializes the alternative it stores, but its constraints and noexcept specifications asked `std::is_[nothrow_]constructible`, which is a question about parentheses. The two disagree - braced initialization considers initializer-list constructors first - and where they disagree the parenthesized answer is a lie: a type can promise a nothrow move and still throw from `T{std::move(t)}`.

Believing it cost more than a wrong specification. `sum`'s move constructor was declared `noexcept` on that promise and called std::terminate when the promise broke; and `_reinit`, whose temporary arm rests on the move being nothrow, destroyed the alternative it held and then failed to replace it - leaving the sum with no alternative at all, which is not a lost guarantee but a dead object.

So every trait that constrains or specifies the construction of an alternative now asks the brace question, through `_initializable` / `_nothrow_initializable` - the traits that already exist for it.

The choice of braces is a design direction rather than an implementation detail - it is what gives `sum` aggregate forwarding through brace elision, which `std::variant` cannot express and parenthesized initialization cannot either - so a test now pins it, and says what it buys and what it costs. Other tests would break if it were switched; that one breaks on purpose.

The temporary arm's completion, as opposed to its throwing, had no coverage at all: only the throw was ever exercised.

### Derive what storing an alternative costs from the code that stores it

The constraints and specifications of `sum` restated what its storage does, and a restatement can drift from the deed - which is how `std::is_nothrow_move_constructible_v` came to answer for `T{std::move(t)}`, a question it does not ask.

`make_variadic_union` is the only thing that ever builds an alternative, so it now says what it can build and what that costs: constrained on the initialization it performs, and specified by it. Everything above asks that, through the two concepts beside it, rather than describing it again. `sum` names the operations once - copyable, movable, and their nothrow twins - and every constructor, assignment and `_reinit` is written in those terms. `choice` and the `as_sum` lifts ask the sum they construct, which asks its storage in turn. No declaration restates the initialization, and none can disagree with it.

The arm that assignment takes is still chosen per alternative, so `_copy_assignable` keeps that choice inside the fold: one arm serving them all would reject a sum whose alternatives simply need different ones.

`make_variadic_union` also declares its return type now. Deducing it meant instantiating the body to deduce it, and the body odr-uses the alternative's constructor - so merely ASKING whether an alternative could be stored demanded a definition of the constructor that would store it.

### Pin what `choice`'s defaulted special members follow

`choice` adds no state to the `sum` it derives from, and defaults all five of its special members - so each must behave exactly as the base's, down to its noexcept and its constraints. Nothing said so, and nothing would have noticed if it stopped being true: dropping a `= default`, promising a `noexcept` the base does not, or narrowing a requires-clause would all have passed in silence.

They are compared against `sum`'s across the property axes that make the answers differ - a throwing copy, a move-only alternative, an immovable one - and each comparison is backed by what the answer actually is, so that an equality cannot be satisfied by both sides being wrong at once.

### Derive what pack's storage performs from the code that performs it

The pack half of #291. Relocation asked `is_nothrow_constructible_v` - direct-initialization - where the aggregate initialization in `_append` copy-initializes each element from its source ([dcl.init.aggr]/4.3), which cannot reach an explicit constructor: an element with an explicit nothrow move and a throwing copy made `append` promise a `noexcept` the deed cannot keep. Nothing asked whether relocation was possible at all, so appending to a pack whose element cannot make the move hard-errored inside the body where a clean rejection was owed. `as_pack` asked the same question of `pack` itself, where parenthesized initialization performs no brace elision - false for every argument list, a permanent under-promise. `invoke_r` promised direct-initialization of `Ret` and performed a return statement.

`_make_element` now declares its own contract, `_relocatable_element` asks the element holder for the copy-initialization it performs, `_append` is constrained on and specified by both questions, and every `append` overload asks the `_append` it calls. `as_pack` is constrained on and specified by the braces it performs, and declares its return type. `invoke_r` delegates to the new `pack_impl::_invoke_r`, asking the same `INVOKE<R>` question `sum::invoke_r` asks - which also aligns `invoke_r<void>`, accepted by `std::invoke_r` and `sum` and until now rejected by `pack`.

### Pin what pack is: an aggregate, at every layer

`pack` declares no constructor and no special member - `_element`, `pack_impl` and `pack` itself are aggregates, and everything above rests on that: brace initialization with elision, the structural type, and special members composed from the elements' own. A constructor added anywhere in the stack would change all of it in silence; these assertions fail instead.

Closes #291

---
**Stack**: P11 of 13 — the release-0.1 bugfix queue, merging bottom-up into `main`. Based on #304 and to be retargeted to `main` once it merges; the diff shows only this PR's commits. Every stack boundary was validated with a gcc build and the full test suite on top of `main`, and the aggregate branch ran the full CI matrix green (#289).
