### PR TITLE
Answer `convertible_to_unexpected` for void instead of hard-erroring

### DIFF
--- a/include/fn/concepts.hpp
+++ b/include/fn/concepts.hpp
@@ -90,9 +90,10 @@ concept same_monadic_type_as = same_kind<T, U> && same_value_kind<T, U>;
  */
 // The void conjunct is load-bearing: `unexpected<void>` is ill-formed by a class-body mandate,
 // which fires during instantiation - outside any immediate context - so without it the question
-// hard-errors instead of answering false.
+// hard-errors instead of answering false. `remove_cvref_t` folds cv-qualified void back to plain
+// `void`, so the guard must cover every cv-flavour - `is_void_v`, not a `same_as` test.
 template <class T>
-concept convertible_to_unexpected = (not ::std::same_as<T, void>) && requires {
+concept convertible_to_unexpected = (not ::std::is_void_v<T>) && requires {
   static_cast<::fn::unexpected<::std::remove_cvref_t<T>>>(::std::declval<T>());
 };
 
@@ -103,9 +104,9 @@ concept convertible_to_unexpected = (not ::std::same_as<T, void>) && requires {
  * @tparam E TODO
  */
 template <class T, typename E>
-concept convertible_to_expected = (not ::std::same_as<T, void> && requires {
-                                    static_cast<expected<::std::remove_cvref_t<T>, E>>(::std::declval<T>());
-                                  }) || (::std::same_as<T, void>);
+concept convertible_to_expected
+    = (not ::std::is_void_v<T> && requires { static_cast<expected<::std::remove_cvref_t<T>, E>>(::std::declval<T>()); })
+      || (::std::is_void_v<T>);
 
 /**
  * @brief TODO
@@ -115,8 +116,8 @@ concept convertible_to_expected = (not ::std::same_as<T, void> && requires {
 // The same load-bearing void conjunct as `convertible_to_unexpected`'s: `optional<void>` and
 // `choice<void>` (below) are likewise ill-formed to instantiate, by a class-body mandate.
 template <class T>
-concept convertible_to_optional = (not ::std::same_as<T, void>)
-                                  && requires { static_cast<optional<::std::remove_cvref_t<T>>>(::std::declval<T>()); };
+concept convertible_to_optional
+    = (not ::std::is_void_v<T>) && requires { static_cast<optional<::std::remove_cvref_t<T>>>(::std::declval<T>()); };
 
 /**
  * @brief TODO
@@ -125,7 +126,7 @@ concept convertible_to_optional = (not ::std::same_as<T, void>)
  */
 template <class T>
 concept convertible_to_choice
-    = (not ::std::same_as<T, void>) && requires { static_cast<choice<::std::remove_cvref_t<T>>>(::std::declval<T>()); };
+    = (not ::std::is_void_v<T>) && requires { static_cast<choice<::std::remove_cvref_t<T>>>(::std::declval<T>()); };
 
 /**
  * @brief TODO

--- a/include/fn/concepts.hpp
+++ b/include/fn/concepts.hpp
@@ -112,8 +112,11 @@ concept convertible_to_expected = (not ::std::same_as<T, void> && requires {
  *
  * @tparam T TODO
  */
+// The same load-bearing void conjunct as `convertible_to_unexpected`'s: `optional<void>` and
+// `choice<void>` (below) are likewise ill-formed to instantiate, by a class-body mandate.
 template <class T>
-concept convertible_to_optional = requires { static_cast<optional<::std::remove_cvref_t<T>>>(::std::declval<T>()); };
+concept convertible_to_optional = (not ::std::same_as<T, void>)
+                                  && requires { static_cast<optional<::std::remove_cvref_t<T>>>(::std::declval<T>()); };
 
 /**
  * @brief TODO
@@ -121,7 +124,8 @@ concept convertible_to_optional = requires { static_cast<optional<::std::remove_
  * @tparam T TODO
  */
 template <class T>
-concept convertible_to_choice = requires { static_cast<choice<::std::remove_cvref_t<T>>>(::std::declval<T>()); };
+concept convertible_to_choice
+    = (not ::std::same_as<T, void>) && requires { static_cast<choice<::std::remove_cvref_t<T>>>(::std::declval<T>()); };
 
 /**
  * @brief TODO

--- a/include/fn/concepts.hpp
+++ b/include/fn/concepts.hpp
@@ -88,9 +88,13 @@ concept same_monadic_type_as = same_kind<T, U> && same_value_kind<T, U>;
  *
  * @tparam T TODO
  */
+// The void conjunct is load-bearing: `unexpected<void>` is ill-formed by a class-body mandate,
+// which fires during instantiation - outside any immediate context - so without it the question
+// hard-errors instead of answering false.
 template <class T>
-concept convertible_to_unexpected
-    = requires { static_cast<::fn::unexpected<::std::remove_cvref_t<T>>>(::std::declval<T>()); };
+concept convertible_to_unexpected = (not ::std::same_as<T, void>) && requires {
+  static_cast<::fn::unexpected<::std::remove_cvref_t<T>>>(::std::declval<T>());
+};
 
 /**
  * @brief TODO

--- a/tests/fn/concepts.cpp
+++ b/tests/fn/concepts.cpp
@@ -285,6 +285,18 @@ static_assert(not same_kind<expected<void, Error> const && , expected<void, Xerr
 static_assert(not same_kind<expected<void, Error> const && , expected<void, Xerror> &&>);
 static_assert(not same_kind<expected<void, Error> const && , expected<void, Xerror> const &&>);
 // clang-format on
+
+// void can never convert to any of these - and each concept must answer so, rather than
+// instantiate unexpected<void>, optional<void> or choice<void>, whose validity mandates are hard
+// errors. Contrast expected, where a void value is legitimate and carries its own arm.
+static_assert(not convertible_to_unexpected<void>);
+static_assert(not convertible_to_optional<void>);
+static_assert(not convertible_to_choice<void>);
+static_assert(convertible_to_unexpected<int>);
+static_assert(convertible_to_optional<int>);
+static_assert(convertible_to_choice<int>);
+static_assert(convertible_to_expected<void, Error>); // the legitimate void: expected<void, E>
+static_assert(convertible_to_expected<int, Error>);
 } // namespace fn
 
 TEST_CASE("Dummy") { SUCCEED(); }

--- a/tests/fn/concepts.cpp
+++ b/tests/fn/concepts.cpp
@@ -297,6 +297,15 @@ static_assert(convertible_to_optional<int>);
 static_assert(convertible_to_choice<int>);
 static_assert(convertible_to_expected<void, Error>); // the legitimate void: expected<void, E>
 static_assert(convertible_to_expected<int, Error>);
+// cv-qualified void is still void - remove_cvref_t folds it back - and every answer must match
+static_assert(not convertible_to_unexpected<void const>);
+static_assert(not convertible_to_optional<void const>);
+static_assert(not convertible_to_choice<void const>);
+static_assert(not convertible_to_unexpected<void const volatile>);
+static_assert(not convertible_to_optional<void const volatile>);
+static_assert(not convertible_to_choice<void const volatile>);
+static_assert(convertible_to_expected<void const, Error>);
+static_assert(convertible_to_expected<void const volatile, Error>);
 } // namespace fn
 
 TEST_CASE("Dummy") { SUCCEED(); }

--- a/tests/fn/transform.cpp
+++ b/tests/fn/transform.cpp
@@ -211,6 +211,12 @@ TEST_CASE("transform", "[transform][optional][pack]")
   constexpr auto fnValue = [](int i) -> int { return i + 1; };
   constexpr auto wrong = [](int) -> int { throw 0; };
   constexpr auto fnXabs = [](int i) -> Xint { return {std::abs(8 - i)}; };
+  constexpr auto fnVoid = [](int) {};
+
+  // void return: optional::transform mandates a value, so the callback is rejected - and asking
+  // must answer false, not instantiate optional<void>, whose validity mandate is a hard error
+  static_assert(not invocable_transform<decltype(fnVoid), operand_t>);
+  static_assert(is::not_invocable_with_any(fnVoid));
 
   static_assert(is::invocable_with_any(fnValue));
   static_assert(is::invocable_with_any([](auto...) -> int { throw 0; }));                    // allow generic call

--- a/tests/fn/transform_error.cpp
+++ b/tests/fn/transform_error.cpp
@@ -37,6 +37,7 @@ TEST_CASE("transform_error", "[transform_error][expected]")
   constexpr auto fnError = [](Error v) -> Error { return {"Got: " + v.what}; };
   constexpr auto wrong = [](Error) -> Error { throw 0; };
   constexpr auto fnXerror = [](Error v) -> Xerror { return {v.what.size()}; };
+  constexpr auto fnVoid = [](Error) {};
 
   static_assert(is::invocable_with_any(fnError));
   static_assert(is::invocable_with_any([](auto...) -> Error { throw 0; }));                // allow generic call
@@ -52,6 +53,11 @@ TEST_CASE("transform_error", "[transform_error][expected]")
   static_assert(is::not_invocable_with_any([](std::string) -> Error { throw 0; }));                       // bad type
   static_assert(is::not_invocable_with_any([]() -> Error { throw 0; }));                                  // bad arity
   static_assert(is::not_invocable_with_any([](int, int) -> Error { throw 0; }));                          // bad arity
+
+  // void return: there is no unexpected<void> to convert to - and asking must answer false, not
+  // instantiate unexpected<void>, whose validity mandate is a hard error
+  static_assert(not invocable_transform_error<decltype(fnVoid), operand_t>);
+  static_assert(is::not_invocable_with_any(fnVoid));
 
   WHEN("operand is lvalue")
   {


### PR DESCRIPTION
The same void conjunct for all three convertibility concepts whose named type is ill-formed to instantiate for void.

### Answer `convertible_to_unexpected` for void instead of hard-erroring

The mandate of `unexpected<void>` fires during instantiation, outside any immediate context - so the concept must not name it for void, which has no unexpected to convert to anyway.

### Extend the void answer to `convertible_to_optional` and `convertible_to_choice`

The same class-body mandates that the `convertible_to_unexpected` conjunct keeps out of reach - `optional<void>` and `choice<void>` are ill-formed to instantiate, so each concept says no to void instead of asking.

Closes #290
Closes #293

---
**Stack**: P12 of 13 — the release-0.1 bugfix queue, merging bottom-up into `main`. Based on #305 and to be retargeted to `main` once it merges; the diff shows only this PR's commits. Every stack boundary was validated with a gcc build and the full test suite on top of `main`, and the aggregate branch ran the full CI matrix green (#289).
