### PR TITLE
Drop the caller when a callback's result has no place in a sum

### DIFF
--- a/include/fn/choice.hpp
+++ b/include/fn/choice.hpp
@@ -365,7 +365,7 @@ struct choice<Ts...> : sum<Ts...> {
   [[nodiscard]] constexpr auto transform(Fn &&fn) & noexcept(
       detail::_is_nothrow_rts_invocable<
           typename detail::_sum_invoke_result<detail::_collapsing_sum_tag, decltype(fn), choice &>::type, Fn &&,
-          choice &>)
+          choice &>) -> typename detail::_sum_invoke_result<detail::_collapsing_sum_tag, Fn &&, choice &>::type
     requires typelist_invocable<Fn, choice &>
   {
     using type = detail::_sum_invoke_result<detail::_collapsing_sum_tag, decltype(fn), choice &>::type;
@@ -383,7 +383,8 @@ struct choice<Ts...> : sum<Ts...> {
   [[nodiscard]] constexpr auto transform(Fn &&fn) const & noexcept(
       detail::_is_nothrow_rts_invocable<
           typename detail::_sum_invoke_result<detail::_collapsing_sum_tag, decltype(fn), choice const &>::type, Fn &&,
-          choice const &>)
+          choice const &>) ->
+      typename detail::_sum_invoke_result<detail::_collapsing_sum_tag, Fn &&, choice const &>::type
     requires typelist_invocable<Fn, choice const &>
   {
     using type = detail::_sum_invoke_result<detail::_collapsing_sum_tag, decltype(fn), choice const &>::type;
@@ -401,7 +402,7 @@ struct choice<Ts...> : sum<Ts...> {
   [[nodiscard]] constexpr auto transform(Fn &&fn) && noexcept(
       detail::_is_nothrow_rts_invocable<
           typename detail::_sum_invoke_result<detail::_collapsing_sum_tag, decltype(fn), choice &&>::type, Fn &&,
-          choice &&>)
+          choice &&>) -> typename detail::_sum_invoke_result<detail::_collapsing_sum_tag, Fn &&, choice &&>::type
     requires typelist_invocable<Fn, choice &&>
   {
     using type = detail::_sum_invoke_result<detail::_collapsing_sum_tag, decltype(fn), choice &&>::type;
@@ -419,7 +420,8 @@ struct choice<Ts...> : sum<Ts...> {
   [[nodiscard]] constexpr auto transform(Fn &&fn) const && noexcept(
       detail::_is_nothrow_rts_invocable<
           typename detail::_sum_invoke_result<detail::_collapsing_sum_tag, decltype(fn), choice const &&>::type, Fn &&,
-          choice const &&>)
+          choice const &&>) ->
+      typename detail::_sum_invoke_result<detail::_collapsing_sum_tag, Fn &&, choice const &&>::type
     requires typelist_invocable<Fn, choice const &&>
   {
     using type = detail::_sum_invoke_result<detail::_collapsing_sum_tag, decltype(fn), choice const &&>::type;

--- a/include/fn/sum.hpp
+++ b/include/fn/sum.hpp
@@ -88,13 +88,28 @@ template <template <typename...> typename Tpl, typename... Ts> struct normalized
 };
 } // namespace _collapsing_sum
 
+// A result no sum can hold - void above all - must drop the caller's candidate, not explode:
+// everything behind the gate (flattening, normalization, the sum they name) hard-errors OUTSIDE
+// any immediate context. The false gate has no `type`, and the collapsing traits pass that absence
+// through by inheritance, so it surfaces where a return type names `::type` - in the immediate
+// context, as a clean substitution failure.
+template <bool, template <typename...> typename Tpl, typename... Rs> struct _collapsing_sum_gate {};
+template <template <typename...> typename Tpl, typename... Rs> struct _collapsing_sum_gate<true, Tpl, Rs...> {
+  using type = _collapsing_sum::normalized<Tpl, _collapsing_sum::flattened<Rs...>>::type;
+};
+
+template <typename R> constexpr inline bool _collapsible_result = some_sum<R> || _is_valid_sum_subtype<R>;
+
 template <typename Fn, typename Self, typename T, typename... Args> struct _typelist_collapsing_sum;
 template <typename Fn, typename Self, template <typename...> typename Tpl, typename... Ts, typename... Args>
-struct _typelist_collapsing_sum<Fn, Self, Tpl<Ts...>, Args...> {
-  using type = _collapsing_sum::normalized<
-      Tpl, _collapsing_sum::flattened<::std::remove_cvref_t<
-               typename ::fn::detail::_invoke_result<Fn, apply_const_lvalue_t<Self, Ts>, Args...>::type>...>>::type;
-};
+struct _typelist_collapsing_sum<Fn, Self, Tpl<Ts...>, Args...>
+    : _collapsing_sum_gate<
+          (...
+           && _collapsible_result<::std::remove_cvref_t<
+               typename ::fn::detail::_invoke_result<Fn, apply_const_lvalue_t<Self, Ts>, Args...>::type>>),
+          Tpl,
+          ::std::remove_cvref_t<
+              typename ::fn::detail::_invoke_result<Fn, apply_const_lvalue_t<Self, Ts>, Args...>::type>...> {};
 
 template <typename T, typename Fn, typename Self, typename... Args> struct _sum_invoke_result final {
   using type = T;
@@ -104,9 +119,8 @@ struct _sum_invoke_result<_invoke_autodetect_tag, Fn, Self, Args...> final {
   using type = _typelist_select_invoke_result<Fn, Self, ::std::remove_cvref_t<Self>, Args...>::type;
 };
 template <typename Fn, typename Self, typename... Args>
-struct _sum_invoke_result<_collapsing_sum_tag, Fn, Self, Args...> final {
-  using type = _typelist_collapsing_sum<Fn, Self, ::std::remove_cvref_t<Self>, Args...>::type;
-};
+struct _sum_invoke_result<_collapsing_sum_tag, Fn, Self, Args...> final
+    : _typelist_collapsing_sum<Fn, Self, ::std::remove_cvref_t<Self>, Args...> {};
 
 template <typename Fn, typename Self, typename T> struct _typelist_type_select_invoke_result;
 template <typename Fn, typename Self, template <typename...> typename Tpl, typename... Ts>
@@ -121,11 +135,14 @@ struct _typelist_type_select_invoke_result<Fn, Self, Tpl<Ts...>> {
 
 template <typename Fn, typename Self, typename T> struct _typelist_type_collapsing_sum;
 template <typename Fn, typename Self, template <typename...> typename Tpl, typename... Ts>
-struct _typelist_type_collapsing_sum<Fn, Self, Tpl<Ts...>> {
-  using type = _collapsing_sum::normalized<
-      Tpl, _collapsing_sum::flattened<::std::remove_cvref_t<
-               typename ::fn::detail::_invoke_type_result<Ts, Fn, apply_const_lvalue_t<Self, Ts>>::type>...>>::type;
-};
+struct _typelist_type_collapsing_sum<Fn, Self, Tpl<Ts...>>
+    : _collapsing_sum_gate<
+          (...
+           && _collapsible_result<::std::remove_cvref_t<
+               typename ::fn::detail::_invoke_type_result<Ts, Fn, apply_const_lvalue_t<Self, Ts>>::type>>),
+          Tpl,
+          ::std::remove_cvref_t<
+              typename ::fn::detail::_invoke_type_result<Ts, Fn, apply_const_lvalue_t<Self, Ts>>::type>...> {};
 
 template <typename T, typename Fn, typename Self> struct _sum_invoke_type_result final {
   using type = T;
@@ -133,9 +150,9 @@ template <typename T, typename Fn, typename Self> struct _sum_invoke_type_result
 template <typename Fn, typename Self> struct _sum_invoke_type_result<_invoke_autodetect_tag, Fn, Self> final {
   using type = _typelist_type_select_invoke_result<Fn, Self, ::std::remove_cvref_t<Self>>::type;
 };
-template <typename Fn, typename Self> struct _sum_invoke_type_result<_collapsing_sum_tag, Fn, Self> final {
-  using type = _typelist_type_collapsing_sum<Fn, Self, ::std::remove_cvref_t<Self>>::type;
-};
+template <typename Fn, typename Self>
+struct _sum_invoke_type_result<_collapsing_sum_tag, Fn, Self> final
+    : _typelist_type_collapsing_sum<Fn, Self, ::std::remove_cvref_t<Self>> {};
 
 } // namespace detail
 

--- a/tests/fn/choice.cpp
+++ b/tests/fn/choice.cpp
@@ -35,6 +35,9 @@ struct NonCopyable final {
 template <typename S, typename T, typename... Args>
 concept can_in_place = requires(Args... args) { S{std::in_place_type<T>, args...}; };
 
+template <typename S, typename Fn>
+concept can_transform = requires(S s, Fn fn) { FWD(s).transform(fn); };
+
 // Every special member of choice is defaulted, and choice adds no state to sum - so each must behave
 // exactly as sum's, down to its noexcept and its constraints.
 template <typename... Ts> consteval bool special_members_follow_sum()
@@ -663,6 +666,18 @@ TEST_CASE("choice and_then", "[choice][and_then]")
 
 TEST_CASE("choice transform", "[choice][transform]")
 {
+  WHEN("a result no choice can hold")
+  {
+    // a void-returning callback must drop the caller's candidate in the immediate context: the
+    // collapsing machinery would hard-error where no requires-expression can absorb it
+    constexpr auto fnVoid = [](auto &&...) {};
+    static_assert(not can_transform<fn::choice<bool, int> &, decltype(fnVoid)>);
+    static_assert(not can_transform<fn::choice<bool, int> const &, decltype(fnVoid)>);
+    static_assert(not can_transform<fn::choice<bool, int> &&, decltype(fnVoid)>);
+    static_assert(not can_transform<fn::choice<bool, int> const &&, decltype(fnVoid)>);
+    SUCCEED();
+  }
+
   WHEN("size 2, only one set")
   {
     using type = fn::choice<bool, int>;

--- a/tests/fn/sum.cpp
+++ b/tests/fn/sum.cpp
@@ -73,6 +73,9 @@ concept can_as_sum = requires(Args... args) { fn::as_sum(std::in_place_type<T>, 
 
 template <typename T>
 concept can_as_sum_value = requires(T v) { fn::as_sum(FWD(v)); };
+
+template <typename S, typename Fn>
+concept can_transform = requires(S s, Fn fn) { FWD(s).transform(fn); };
 } // anonymous namespace
 
 // A sum brace-initializes the alternative it stores. That is a DESIGN DIRECTION, not an
@@ -870,6 +873,19 @@ TEST_CASE("sum type collapsing", "[sum][transform][normalized]")
     using type = sum<double>;
     static_assert(
         std::same_as<typename _sum_invoke_result<_collapsing_sum_tag, decltype(fn), type &>::type, sum<double>>);
+  }
+
+  WHEN("a result no sum can hold")
+  {
+    // a void-returning callback must drop the caller's candidate in the immediate context: the
+    // collapsing machinery would hard-error where no requires-expression can absorb it
+    constexpr auto fnVoid = [](auto &&...) {};
+    static_assert(not can_transform<sum<double, int> &, decltype(fnVoid)>);
+    static_assert(not can_transform<sum<double, int> const &, decltype(fnVoid)>);
+    static_assert(not can_transform<sum<double, int> &&, decltype(fnVoid)>);
+    static_assert(not can_transform<sum<double, int> const &&, decltype(fnVoid)>);
+    static_assert(can_transform<sum<double, int> &, PassThrough>); // the same sum, a holdable result
+    SUCCEED();
   }
 
   WHEN("two elements")

--- a/tests/fn/transform_error.cpp
+++ b/tests/fn/transform_error.cpp
@@ -174,6 +174,11 @@ TEST_CASE("constexpr transform_error expected with sum", "[transform_error][cons
   enum class Error { ThresholdExceeded, SomethingElse };
   using T = fn::expected<int, fn::sum_for<Error, bool>>;
 
+  // a void-returning callback: the sum arm's error().transform(fn) must be non-viable, so the
+  // concept answers false instead of exploding in the collapsing machinery
+  constexpr auto fnVoid = [](auto &&...) {};
+  static_assert(not fn::invocable_transform_error<decltype(fnVoid), T>);
+
   WHEN("same value type")
   {
     constexpr auto fn = fn::overload{[](bool i) constexpr noexcept -> fn::sum_for<Error, bool> { return not i; },


### PR DESCRIPTION
The collapsing traits flattened and normalized the per-alternative results unconditionally, and for a result no sum can hold - void above all - that computation hard-errors outside any immediate context: `sum::transform` with a void-returning callback was a compile error rather than non-viable, and the sum arm of `invocable_transform_error` exploded instead of answering false. A gate with no `type` now sits in front, and the collapsing traits pass that absence through by inheritance, so it surfaces as a clean substitution failure where the return type names `::type`.

`choice::transform` needed its return types declared for the same reason `sum`'s already are: with a deduced return, the requires-expression instantiates the body to answer, and the absence lands beyond any immediate context.

Closes #294

---
**Stack**: P13 of 13 — the release-0.1 bugfix queue, merging bottom-up into `main`. Based on #306 and to be retargeted to `main` once it merges; the diff shows only this PR's commits. Every stack boundary was validated with a gcc build and the full test suite on top of `main`, and the aggregate branch ran the full CI matrix green (#289).
