### PR TITLE
Run linux package tests on arm64 runners

### DIFF
--- a/.github/workflows/package-test-bazel.yml
+++ b/.github/workflows/package-test-bazel.yml
@@ -28,7 +28,8 @@ env:
 
 jobs:
   test_bazel:
-    runs-on: ${{ github.repository == 'libfn/functional' && 'warp-ubuntu-latest-x64-4x' || 'ubuntu-latest' }}
+    # arm64: the amd64 warp fleet pulls images at 1-2 MB/s; the arm64 fleet serves them in seconds
+    runs-on: ${{ github.repository == 'libfn/functional' && 'warp-ubuntu-latest-arm64-2x' || 'ubuntu-latest' }}
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/package-test-conan.yml
+++ b/.github/workflows/package-test-conan.yml
@@ -23,7 +23,8 @@ on:
 
 jobs:
   test_conan_linux:
-    runs-on: ${{ github.repository == 'libfn/functional' && 'warp-ubuntu-latest-x64-4x' || 'ubuntu-latest' }}
+    # arm64: the amd64 warp fleet pulls images at 1-2 MB/s; the arm64 fleet serves them in seconds
+    runs-on: ${{ github.repository == 'libfn/functional' && 'warp-ubuntu-latest-arm64-2x' || 'ubuntu-latest' }}
     container: libfn.azurecr.io/ci-build-gcc:15-sha-08b1133
 
     steps:


### PR DESCRIPTION
Linux package tests move from the x64 to the arm64 warp fleet. The x64 fleet pulls container images at 1–2 MB/s, so each ~0.5 GB image cost 4–10 minutes per job against seconds of actual test work — the cancelled `test_bazel (ci-build-clang-bazel:22)` on #312 was this pull hanging. The arm64 fleet initializes the same images in ~15 s (measured across the `build` matrix, ~28 concurrent jobs pulling simultaneously). The images are multi-arch, the library is header-only, and x64 packaging remains covered by the Windows conan and vcpkg jobs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
