### PR TITLE
Add widening assignment to `sum` and `choice`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 Design history of libfn, newest first. The living documents — [README.md](README.md), [CONTRIBUTING.md](CONTRIBUTING.md), [docs/](docs/) — describe only the present state of the design; when a decision makes an earlier idea obsolete, this file is where the transition is recorded and explained.
 
+## `sum` and `choice` assign across widening — 14 July 2026
+
+- **A narrower `sum` now assigns into a wider one on the widening constructors' terms** ([#310](https://github.com/libfn/functional/issues/310)): `operator=` is constrained on the alternatives the source can actually deliver, and the incoming alternative is assigned in place when it is the one held, or replaces it by construction otherwise — the per-alternative decision same-type assignment already makes. Previously `wide = narrow` existed only by routing through the widening constructor: a whole temporary sum, a copy plus a move where one copy suffices, and viability gated on the destination's every alternative — an uninvolved alternative with no safe replacement arm forbade assignments it took no part in.
+- **`choice` declares its own widening assignment and delegates to `sum`'s.** A declared `operator=` hides every base overload, so without its own pair `choice` would have been left out silently; the delegation also admits a `sum` over the same alternatives, which previously paid for a temporary despite having nothing to widen.
+
 ## `sum` is as trivial as its alternatives permit — 14 July 2026
 
 - **Every special member of `sum` (and through it `choice`) is now trivial exactly when every alternative permits it** — the gates `std::variant` uses ([#309](https://github.com/libfn/functional/issues/309)). A `sum` of fundamentals, or of trivially copyable `pack`s, is trivially copyable — register-passed and `memcpy`-safe — where previously no `sum` supported any trivial operation. The sum-of-packs case is the one that pays: joining sum-valued monads yields the cartesian product, and that is what a multidispatch pipeline copies at every stage. Trivially copyable sums change ABI (register passing), which is why this lands before the first tagged release.

--- a/include/fn/choice.hpp
+++ b/include/fn/choice.hpp
@@ -181,6 +181,27 @@ struct choice<Ts...> : sum<Ts...> {
   constexpr choice &operator=(choice const &other) = default;
   constexpr choice &operator=(choice &&other) = default;
 
+  // choice declares its copy and move assignment, and a declared operator= hides every base
+  // overload - sum's widening assignment must be restated here to exist at all. Delegating keeps
+  // the answer sum's, and admits a sum over the same alternatives, which would otherwise pay for
+  // the temporary the widening constructor builds.
+  template <typename... Tx>
+  constexpr choice &operator=(sum<Tx...> const &arg) //
+      noexcept(::std::is_nothrow_assignable_v<sum<Ts...> &, sum<Tx...> const &>)
+    requires ::std::is_assignable_v<sum<Ts...> &, sum<Tx...> const &>
+  {
+    static_cast<sum<Ts...> &>(*this) = arg;
+    return *this;
+  }
+  template <typename... Tx>
+  constexpr choice &operator=(sum<Tx...> &&arg) //
+      noexcept(::std::is_nothrow_assignable_v<sum<Ts...> &, sum<Tx...>>)
+    requires ::std::is_assignable_v<sum<Ts...> &, sum<Tx...>>
+  {
+    static_cast<sum<Ts...> &>(*this) = ::std::move(arg);
+    return *this;
+  }
+
   /**
    * @brief TODO
    *

--- a/include/fn/sum.hpp
+++ b/include/fn/sum.hpp
@@ -568,6 +568,58 @@ struct sum<Ts...> {
   }
 
   /**
+   * @brief Widening copy assignment from a sum over a subset of the alternatives
+   *
+   * @param arg TODO
+   * @return TODO
+   */
+  // Constrained on the alternatives the source can actually deliver, like the widening
+  // constructors: routing through construction and same-type assignment would let an uninvolved
+  // alternative of the destination forbid the assignment, and would build a whole temporary sum.
+  // The incoming alternative is assigned in place when it is the one held, and replaces it by
+  // construction otherwise, exactly as the same-type operator= does.
+  template <typename... Tx>
+  constexpr sum &operator=(sum<Tx...> const &arg) //
+      noexcept((... && (::std::is_nothrow_copy_assignable_v<Tx> && detail::_nothrow_makeable<data_t, Tx, Tx const &>)))
+    requires detail::is_superset_of<sum, sum<Tx...>> && (not ::std::is_same_v<sum, sum<Tx...>>)
+             && (...
+                 && (::std::is_copy_assignable_v<Tx> && detail::_makeable<data_t, Tx, Tx const &>
+                     && (detail::_nothrow_makeable<data_t, Tx, Tx const &>
+                         || detail::_nothrow_makeable<data_t, Tx, Tx>)))
+             && (sizeof...(Tx) > 0)
+  {
+    arg.template _invoke<void>([this]<typename T>(::std::in_place_type_t<T>, auto const &v) {
+      if (this->index == detail::type_index<T, Ts...>)
+        this->template _reassign<T>(v);
+      else
+        this->template _reinit<T>(v);
+    });
+    return *this;
+  }
+
+  /**
+   * @brief Widening move assignment from a sum over a subset of the alternatives
+   *
+   * @param arg TODO
+   * @return TODO
+   */
+  template <typename... Tx>
+  constexpr sum &operator=(sum<Tx...> &&arg) //
+      noexcept((... && ::std::is_nothrow_move_assignable_v<Tx>))
+    requires detail::is_superset_of<sum, sum<Tx...>> && (not ::std::is_same_v<sum, sum<Tx...>>)
+             && (... && (::std::is_move_assignable_v<Tx> && detail::_nothrow_makeable<data_t, Tx, Tx>))
+             && (sizeof...(Tx) > 0)
+  {
+    ::std::move(arg).template _invoke<void>([this]<typename T>(::std::in_place_type_t<T>, auto &&v) {
+      if (this->index == detail::type_index<T, Ts...>)
+        this->template _reassign<T>(FWD(v));
+      else
+        this->template _reinit<T>(FWD(v));
+    });
+    return *this;
+  }
+
+  /**
    * @brief TODO
    *
    * @tparam T TODO

--- a/tests/fn/choice.cpp
+++ b/tests/fn/choice.cpp
@@ -359,6 +359,38 @@ TEST_CASE("choice non-monadic functionality", "[choice]")
     }
   }
 
+  SECTION("assignment from sum")
+  {
+    // choice declares its operator=, hiding sum's widening overloads, so it carries its own pair
+    // and delegates - which also admits a sum over the same alternatives, with nothing to widen
+    constexpr auto battery = [] {
+      choice<bool, int> a{12};
+      a = fn::sum<int>{42}; // the alternative in hand
+      bool ok = a == choice{42};
+      a = fn::sum<bool>{true}; // a different alternative
+      ok = ok && a == choice{true};
+      fn::sum<int> const n{7};
+      a = n; // by copy
+      ok = ok && a == choice{7};
+      a = choice<int>{3}; // a narrower choice, deduced through its sum base
+      ok = ok && a == choice{3};
+      a = fn::sum<bool, int>{5}; // the same alternatives, delegated to same-type assignment
+      return ok && a == choice{5};
+    };
+    CHECK(battery());
+    static_assert(battery());
+
+    SECTION("constraints")
+    {
+      static_assert(std::is_assignable_v<choice<bool, int> &, fn::sum<int> const &>);
+      static_assert(std::is_assignable_v<choice<bool, int> &, fn::sum<bool, int> &&>); // same alternatives
+      static_assert(std::is_assignable_v<choice<bool, int> &, choice<int> const &>);   // through the base
+      static_assert(not std::is_assignable_v<choice<int> &, fn::sum<bool> const &>);   // not a superset
+      static_assert(noexcept(std::declval<choice<bool, int> &>() = std::declval<fn::sum<int> const &>()));
+      SUCCEED();
+    }
+  }
+
   SECTION("forwarding constructors (immovable)")
   {
     choice<NonCopyable> a{std::in_place_type<NonCopyable>, 42};

--- a/tests/fn/sum.cpp
+++ b/tests/fn/sum.cpp
@@ -1863,6 +1863,21 @@ TEST_CASE("sum assignment", "[sum][assignment]")
       static_assert(std::is_assignable_v<S2 &, sum<int> const &>);
       static_assert(not std::is_assignable_v<S2 &, sum<Skittish> const &>);
 
+      // the constructor route survives where the direct overload declines: a copy-deleted move
+      // assignment refuses widening-copy, and `wide = narrow` still compiles as it always did -
+      // the widening constructor's temporary, then whole-type assignment
+      struct MoveAssign final {
+        constexpr MoveAssign() noexcept = default;
+        constexpr MoveAssign(MoveAssign const &) noexcept = default;
+        constexpr MoveAssign(MoveAssign &&) noexcept = default;
+        MoveAssign &operator=(MoveAssign const &) = delete;
+        constexpr MoveAssign &operator=(MoveAssign &&) noexcept = default;
+      };
+      static_assert(not std::is_copy_assignable_v<MoveAssign>);
+      using S3 = fn::sum_for<MoveAssign, int>;
+      static_assert(std::is_assignable_v<S3 &, sum<MoveAssign> const &>); // through the constructor
+      static_assert(std::is_assignable_v<S3 &, sum<MoveAssign> &&>);      // directly
+
       // a sum it is not a superset of is refused
       static_assert(not std::is_assignable_v<sum<int> &, sum<bool> const &>);
       SUCCEED();

--- a/tests/fn/sum.cpp
+++ b/tests/fn/sum.cpp
@@ -1147,6 +1147,20 @@ TEST_CASE("sum noexcept", "[sum][noexcept]")
     // safely - and Throwy's throwing everything leaves no nothrow arm at all
     static_assert(not std::is_move_assignable_v<sum<Throwy>>);
     static_assert(not std::is_copy_assignable_v<sum<Throwy>>);
+
+    // widening assignment weighs only the source's alternatives: Throwy, uninvolved, neither
+    // forbids the assignment nor enters its specification
+    static_assert(std::is_assignable_v<fn::sum_for<Quiet, Throwy> &, sum<Quiet> const &>);
+    static_assert(noexcept(std::declval<fn::sum_for<Quiet, Throwy> &>() = std::declval<sum<Quiet> const &>()));
+    struct Loud { // nothrow to deliver, throwing to assign: viability and the specification differ
+      Loud() = default;
+      Loud(Loud const &) noexcept {}
+      Loud(Loud &&) noexcept {}
+      Loud &operator=(Loud const &) noexcept(false) { return *this; }
+      Loud &operator=(Loud &&) noexcept(false) { return *this; }
+    };
+    static_assert(std::is_assignable_v<fn::sum_for<Quiet, Loud> &, sum<Loud> const &>);
+    static_assert(not noexcept(std::declval<fn::sum_for<Quiet, Loud> &>() = std::declval<sum<Loud> const &>()));
     SUCCEED();
   }
 }
@@ -1743,6 +1757,116 @@ TEST_CASE("sum assignment", "[sum][assignment]")
       CHECK(Counted::live == 1);
     }
     CHECK(Counted::live == 0);
+  }
+
+  SECTION("widening")
+  {
+    // a narrower sum assigns on the widening constructors' terms, deciding per incoming
+    // alternative: the one held is assigned in place, any other replaces by construction
+    constexpr auto basic = [] {
+      sum<bool, int> a{12};
+      sum<int> const n{42};
+      a = n; // the alternative in hand, by copy
+      bool ok = a == sum{42};
+      a = sum<bool>{true}; // a different alternative
+      ok = ok && a == sum{true};
+      a = sum<int>{7}; // and back, by move
+      return ok && a == sum{7};
+    };
+    CHECK(basic());
+    static_assert(basic());
+
+    SECTION("one relocation, or none")
+    {
+      // `wide = narrow` used to route through the widening constructor: a whole temporary sum, one
+      // copy plus one move; the incoming alternative is now delivered straight to its destination
+      struct Reloc final {
+        int v;
+        int *copied;
+        int *moved;
+        int *assigned;
+        constexpr Reloc(int i, int *c, int *m, int *a) noexcept : v(i), copied(c), moved(m), assigned(a) {}
+        constexpr Reloc(Reloc const &o) noexcept : v(o.v), copied(o.copied), moved(o.moved), assigned(o.assigned)
+        {
+          ++*copied;
+        }
+        constexpr Reloc(Reloc &&o) noexcept : v(o.v), copied(o.copied), moved(o.moved), assigned(o.assigned)
+        {
+          ++*moved;
+        }
+        constexpr Reloc &operator=(Reloc const &o) noexcept
+        {
+          v = o.v;
+          ++*assigned;
+          return *this;
+        }
+        constexpr Reloc &operator=(Reloc &&o) noexcept
+        {
+          v = o.v;
+          ++*assigned;
+          return *this;
+        }
+      };
+      constexpr auto counts = [] {
+        int copied = 0;
+        int moved = 0;
+        int assigned = 0;
+        using W = fn::sum_for<Reloc, int>;
+        fn::sum<Reloc> n{Reloc{42, &copied, &moved, &assigned}};
+        fn::sum<Reloc> m{Reloc{9, &copied, &moved, &assigned}};
+
+        W a{12};
+        copied = moved = assigned = 0;
+        a = std::as_const(n); // a different alternative, by copy: one copy, straight into place
+        bool ok = copied == 1 && moved == 0 && assigned == 0 && a.get_ptr<Reloc>()->v == 42;
+
+        copied = moved = assigned = 0;
+        a = std::as_const(n); // the alternative in hand: assigned, nothing relocates
+        ok = ok && copied == 0 && moved == 0 && assigned == 1;
+
+        a = W{12};
+        copied = moved = assigned = 0;
+        a = std::move(m); // a different alternative, by move: one move, nothing else
+        return ok && copied == 0 && moved == 1 && assigned == 0 && a.get_ptr<Reloc>()->v == 9;
+      };
+      CHECK(counts());
+      static_assert(counts());
+    }
+
+    SECTION("constraints")
+    {
+      // constrained on the source's alternatives: an uninvolved alternative of the destination
+      // forbids nothing - though it still forbids assignment of the whole type - and decides only
+      // when the source can actually deliver it
+      struct Fixed final { // copyable, not assignable
+        constexpr Fixed() noexcept = default;
+        constexpr Fixed(Fixed const &) noexcept = default;
+        constexpr Fixed(Fixed &&) noexcept = default;
+        Fixed &operator=(Fixed const &) = delete;
+        Fixed &operator=(Fixed &&) = delete;
+      };
+      using S = fn::sum_for<Fixed, int>;
+      static_assert(not std::is_copy_assignable_v<S>);
+      static_assert(std::is_assignable_v<S &, sum<int> const &>);
+      static_assert(std::is_assignable_v<S &, sum<int> &&>);
+      static_assert(not std::is_assignable_v<S &, sum<Fixed> const &>);
+
+      struct Skittish final { // assignable, but no arm can deliver it without throwing
+        constexpr Skittish() noexcept = default;
+        Skittish(Skittish const &) noexcept(false) {}
+        Skittish(Skittish &&) noexcept(false) {}
+        Skittish &operator=(Skittish const &) noexcept { return *this; }
+        Skittish &operator=(Skittish &&) noexcept { return *this; }
+      };
+      using S2 = fn::sum_for<Skittish, int>;
+      static_assert(not std::is_copy_assignable_v<S2>);
+      static_assert(std::is_assignable_v<S2 &, sum<int> const &>);
+      static_assert(not std::is_assignable_v<S2 &, sum<Skittish> const &>);
+
+      // a sum it is not a superset of is refused
+      static_assert(not std::is_assignable_v<sum<int> &, sum<bool> const &>);
+      SUCCEED();
+    }
   }
 
   SECTION("constexpr")


### PR DESCRIPTION
`wide = narrow` existed only through the widening constructor: a whole temporary sum, a copy plus a move where one suffices, and viability gated on the destination's every alternative — an uninvolved alternative with no safe replacement arm forbade assignments it took no part in. The new overloads are constrained on the source's alternatives, mirroring the widening constructors, and deliver the incoming alternative straight to its destination: assigned in place when it is the one held, replacing it by construction otherwise — the per-alternative decision same-type assignment already makes, with the same strong guarantee.

`choice` declares its own pair and delegates to `sum`'s: a declared `operator=` hides every base overload, so without them `choice` would have been left out silently. The delegation also admits a `sum` over the same alternatives, which previously paid for a temporary despite having nothing to widen.

Closes #310
