### PR TITLE
Make `optional` and `expected` assignment conditionally trivial

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 Design history of libfn, newest first. The living documents — [README.md](README.md), [CONTRIBUTING.md](CONTRIBUTING.md), [docs/](docs/) — describe only the present state of the design; when a decision makes an earlier idea obsolete, this file is where the transition is recorded and explained.
 
+## `optional` and `expected` assignment is trivial when the payload permits — 15 July 2026
+
+- **Copy and move assignment of `optional` and `expected` are now trivial exactly under the standard's conditions** ([#308](https://github.com/libfn/functional/issues/308)): the contained types trivially copy/move constructible, trivially assignable and trivially destructible ([optional.assign], [expected.object.assign], [expected.void.assign]). Neither type was ever trivially assignable, in either library — a conformance defect, and with the constructors and destructor already conditionally trivial, assignment was the one member keeping these types out of `is_trivially_copyable`. Like `sum`'s entry below, this lands before the first tagged release because trivially copyable types change ABI.
+
 ## `sum` and `choice` assign across widening — 14 July 2026
 
 - **A narrower `sum` now assigns into a wider one on the widening constructors' terms** ([#310](https://github.com/libfn/functional/issues/310)): `operator=` is constrained on the alternatives the source can actually deliver, and the incoming alternative is assigned in place when it is the one held, or replaces it by construction otherwise — the per-alternative decision same-type assignment already makes. Previously `wide = narrow` existed only by routing through the widening constructor: a whole temporary sum, a copy plus a move where one copy suffices, and viability gated on the destination's every alternative — an uninvolved alternative with no safe replacement arm forbade assignments it took no part in.

--- a/include/fn/expected.hpp
+++ b/include/fn/expected.hpp
@@ -552,22 +552,48 @@ public:
     return *this;
   }
   constexpr expected &operator=(expected const &) = delete;
+  constexpr expected &operator=(expected const &) //
+      noexcept(::std::is_nothrow_copy_assignable_v<T> && ::std::is_nothrow_copy_constructible_v<T>
+               && ::std::is_nothrow_copy_assignable_v<Err> && ::std::is_nothrow_copy_constructible_v<Err>)
+    requires(::std::is_copy_assignable_v<T> && ::std::is_copy_constructible_v<T> && ::std::is_copy_assignable_v<Err>
+             && ::std::is_copy_constructible_v<Err>
+             && (::std::is_nothrow_move_constructible_v<T> || ::std::is_nothrow_move_constructible_v<Err>)
+             && ::std::is_trivially_copy_constructible_v<T> && ::std::is_trivially_copy_assignable_v<T>
+             && ::std::is_trivially_destructible_v<T> && ::std::is_trivially_copy_constructible_v<Err>
+             && ::std::is_trivially_copy_assignable_v<Err> && ::std::is_trivially_destructible_v<Err>)
+  = default;
   constexpr expected &operator=(expected const &s) //
       noexcept(::std::is_nothrow_copy_assignable_v<T> && ::std::is_nothrow_copy_constructible_v<T>
                && ::std::is_nothrow_copy_assignable_v<Err> && ::std::is_nothrow_copy_constructible_v<Err>)
     requires(::std::is_copy_assignable_v<T> && ::std::is_copy_constructible_v<T> && ::std::is_copy_assignable_v<Err>
              && ::std::is_copy_constructible_v<Err>
-             && (::std::is_nothrow_move_constructible_v<T> || ::std::is_nothrow_move_constructible_v<Err>))
+             && (::std::is_nothrow_move_constructible_v<T> || ::std::is_nothrow_move_constructible_v<Err>)
+             && (not ::std::is_trivially_copy_constructible_v<T> || not ::std::is_trivially_copy_assignable_v<T>
+                 || not ::std::is_trivially_destructible_v<T> || not ::std::is_trivially_copy_constructible_v<Err>
+                 || not ::std::is_trivially_copy_assignable_v<Err> || not ::std::is_trivially_destructible_v<Err>))
   {
     this->_assign(static_cast<_base const &>(s));
     return *this;
   }
+  constexpr expected &operator=(expected &&) //
+      noexcept(::std::is_nothrow_move_assignable_v<T> && ::std::is_nothrow_move_constructible_v<T>
+               && ::std::is_nothrow_move_assignable_v<Err> && ::std::is_nothrow_move_constructible_v<Err>)
+    requires(::std::is_move_constructible_v<T> && ::std::is_move_assignable_v<T> && ::std::is_move_constructible_v<Err>
+             && ::std::is_move_assignable_v<Err>
+             && (::std::is_nothrow_move_constructible_v<T> || ::std::is_nothrow_move_constructible_v<Err>)
+             && ::std::is_trivially_move_constructible_v<T> && ::std::is_trivially_move_assignable_v<T>
+             && ::std::is_trivially_destructible_v<T> && ::std::is_trivially_move_constructible_v<Err>
+             && ::std::is_trivially_move_assignable_v<Err> && ::std::is_trivially_destructible_v<Err>)
+  = default;
   constexpr expected &operator=(expected &&s) //
       noexcept(::std::is_nothrow_move_assignable_v<T> && ::std::is_nothrow_move_constructible_v<T>
                && ::std::is_nothrow_move_assignable_v<Err> && ::std::is_nothrow_move_constructible_v<Err>)
     requires(::std::is_move_constructible_v<T> && ::std::is_move_assignable_v<T> && ::std::is_move_constructible_v<Err>
              && ::std::is_move_assignable_v<Err>
-             && (::std::is_nothrow_move_constructible_v<T> || ::std::is_nothrow_move_constructible_v<Err>))
+             && (::std::is_nothrow_move_constructible_v<T> || ::std::is_nothrow_move_constructible_v<Err>)
+             && (not ::std::is_trivially_move_constructible_v<T> || not ::std::is_trivially_move_assignable_v<T>
+                 || not ::std::is_trivially_destructible_v<T> || not ::std::is_trivially_move_constructible_v<Err>
+                 || not ::std::is_trivially_move_assignable_v<Err> || not ::std::is_trivially_destructible_v<Err>))
   {
     this->_assign(static_cast<_base &&>(s));
     return *this;
@@ -919,16 +945,32 @@ public:
     return *this;
   }
   constexpr expected &operator=(expected const &) = delete;
+  constexpr expected &operator=(expected const &) //
+      noexcept(::std::is_nothrow_copy_assignable_v<Err> && ::std::is_nothrow_copy_constructible_v<Err>)
+    requires(::std::is_copy_assignable_v<Err> && ::std::is_copy_constructible_v<Err>
+             && ::std::is_trivially_copy_constructible_v<Err> && ::std::is_trivially_copy_assignable_v<Err>
+             && ::std::is_trivially_destructible_v<Err>)
+  = default;
   constexpr expected &operator=(expected const &s) //
       noexcept(::std::is_nothrow_copy_assignable_v<Err> && ::std::is_nothrow_copy_constructible_v<Err>)
-    requires(::std::is_copy_assignable_v<Err> && ::std::is_copy_constructible_v<Err>)
+    requires(::std::is_copy_assignable_v<Err> && ::std::is_copy_constructible_v<Err>
+             && (not ::std::is_trivially_copy_constructible_v<Err> || not ::std::is_trivially_copy_assignable_v<Err>
+                 || not ::std::is_trivially_destructible_v<Err>))
   {
     this->_assign(static_cast<_base const &>(s));
     return *this;
   }
+  constexpr expected &operator=(expected &&) //
+      noexcept(::std::is_nothrow_move_assignable_v<Err> && ::std::is_nothrow_move_constructible_v<Err>)
+    requires(::std::is_move_constructible_v<Err> && ::std::is_move_assignable_v<Err>
+             && ::std::is_trivially_move_constructible_v<Err> && ::std::is_trivially_move_assignable_v<Err>
+             && ::std::is_trivially_destructible_v<Err>)
+  = default;
   constexpr expected &operator=(expected &&s) //
       noexcept(::std::is_nothrow_move_assignable_v<Err> && ::std::is_nothrow_move_constructible_v<Err>)
-    requires(::std::is_move_constructible_v<Err> && ::std::is_move_assignable_v<Err>)
+    requires(::std::is_move_constructible_v<Err> && ::std::is_move_assignable_v<Err>
+             && (not ::std::is_trivially_move_constructible_v<Err> || not ::std::is_trivially_move_assignable_v<Err>
+                 || not ::std::is_trivially_destructible_v<Err>))
   {
     this->_assign(static_cast<_base &&>(s));
     return *this;

--- a/include/fn/optional.hpp
+++ b/include/fn/optional.hpp
@@ -362,16 +362,32 @@ public:
     return *this;
   }
   constexpr optional &operator=(optional const &) = delete;
+  constexpr optional &operator=(optional const &)                                                   //
+      noexcept(::std::is_nothrow_copy_assignable_v<T> && ::std::is_nothrow_copy_constructible_v<T>) // extension
+    requires(::std::is_copy_constructible_v<T> && ::std::is_copy_assignable_v<T>
+             && ::std::is_trivially_copy_constructible_v<T> && ::std::is_trivially_copy_assignable_v<T>
+             && ::std::is_trivially_destructible_v<T>)
+  = default;
   constexpr optional &operator=(optional const &s)                                                  //
       noexcept(::std::is_nothrow_copy_assignable_v<T> && ::std::is_nothrow_copy_constructible_v<T>) // extension
-    requires(::std::is_copy_constructible_v<T> && ::std::is_copy_assignable_v<T>)
+    requires(::std::is_copy_constructible_v<T> && ::std::is_copy_assignable_v<T>
+             && (not ::std::is_trivially_copy_constructible_v<T> || not ::std::is_trivially_copy_assignable_v<T>
+                 || not ::std::is_trivially_destructible_v<T>))
   {
     this->_assign(static_cast<_base const &>(s));
     return *this;
   }
+  constexpr optional &operator=(optional &&) //
+      noexcept(::std::is_nothrow_move_assignable_v<T> && ::std::is_nothrow_move_constructible_v<T>)
+    requires(::std::is_move_constructible_v<T> && ::std::is_move_assignable_v<T>
+             && ::std::is_trivially_move_constructible_v<T> && ::std::is_trivially_move_assignable_v<T>
+             && ::std::is_trivially_destructible_v<T>)
+  = default;
   constexpr optional &operator=(optional &&s) //
       noexcept(::std::is_nothrow_move_assignable_v<T> && ::std::is_nothrow_move_constructible_v<T>)
-    requires(::std::is_move_constructible_v<T> && ::std::is_move_assignable_v<T>)
+    requires(::std::is_move_constructible_v<T> && ::std::is_move_assignable_v<T>
+             && (not ::std::is_trivially_move_constructible_v<T> || not ::std::is_trivially_move_assignable_v<T>
+                 || not ::std::is_trivially_destructible_v<T>))
   {
     this->_assign(static_cast<_base &&>(s));
     return *this;

--- a/include/pfn/expected.hpp
+++ b/include/pfn/expected.hpp
@@ -229,7 +229,13 @@ template <class T, class E> union _expected_union_t {
     requires(::std::is_trivially_move_constructible_v<T> && ::std::is_trivially_move_constructible_v<E>)
   = default;
   constexpr _expected_union_t &operator=(_expected_union_t const &) = delete;
+  constexpr _expected_union_t &operator=(_expected_union_t const &) noexcept //
+    requires(::std::is_trivially_copy_assignable_v<T> && ::std::is_trivially_copy_assignable_v<E>)
+  = default;
   constexpr _expected_union_t &operator=(_expected_union_t &&) = delete;
+  constexpr _expected_union_t &operator=(_expected_union_t &&) noexcept //
+    requires(::std::is_trivially_move_assignable_v<T> && ::std::is_trivially_move_assignable_v<E>)
+  = default;
 
   template <class... Args>
   constexpr explicit _expected_union_t(::std::in_place_t /*ignored*/, Args &&...a) //
@@ -358,7 +364,13 @@ template <class E> union _expected_union_t<void, E> {
     requires(::std::is_trivially_move_constructible_v<E>)
   = default;
   constexpr _expected_union_t &operator=(_expected_union_t const &) = delete;
+  constexpr _expected_union_t &operator=(_expected_union_t const &) noexcept //
+    requires(::std::is_trivially_copy_assignable_v<E>)
+  = default;
   constexpr _expected_union_t &operator=(_expected_union_t &&) = delete;
+  constexpr _expected_union_t &operator=(_expected_union_t &&) noexcept //
+    requires(::std::is_trivially_move_assignable_v<E>)
+  = default;
 
   constexpr explicit _expected_union_t(::std::in_place_t /*ignored*/) noexcept
       : v_{} // NOSONAR cpp:S3230 activates the member
@@ -597,8 +609,8 @@ template <class T, class E, class Policy> struct _expected_base {
 
   constexpr _expected_base(_expected_base const &) noexcept = default;
   constexpr _expected_base(_expected_base &&) noexcept = default;
-  constexpr _expected_base &operator=(_expected_base const &) = delete;
-  constexpr _expected_base &operator=(_expected_base &&) = delete;
+  constexpr _expected_base &operator=(_expected_base const &) noexcept = default;
+  constexpr _expected_base &operator=(_expected_base &&) noexcept = default;
 
   constexpr ~_expected_base() //
     requires(::std::is_trivially_destructible_v<_value_t> && ::std::is_trivially_destructible_v<E>)
@@ -1266,23 +1278,49 @@ public:
   }
 
   constexpr expected &operator=(expected const &) = delete;
+  constexpr expected &operator=(expected const &) //
+      noexcept(::std::is_nothrow_copy_assignable_v<T> && ::std::is_nothrow_copy_constructible_v<T>
+               && ::std::is_nothrow_copy_assignable_v<E> && ::std::is_nothrow_copy_constructible_v<E>) // extension
+    requires(::std::is_copy_assignable_v<T> && ::std::is_copy_constructible_v<T> && ::std::is_copy_assignable_v<E>
+             && ::std::is_copy_constructible_v<E>
+             && (::std::is_nothrow_move_constructible_v<T> || ::std::is_nothrow_move_constructible_v<E>)
+             && ::std::is_trivially_copy_constructible_v<T> && ::std::is_trivially_copy_assignable_v<T>
+             && ::std::is_trivially_destructible_v<T> && ::std::is_trivially_copy_constructible_v<E>
+             && ::std::is_trivially_copy_assignable_v<E> && ::std::is_trivially_destructible_v<E>)
+  = default;
   constexpr expected &operator=(expected const &s) //
       noexcept(::std::is_nothrow_copy_assignable_v<T> && ::std::is_nothrow_copy_constructible_v<T>
                && ::std::is_nothrow_copy_assignable_v<E> && ::std::is_nothrow_copy_constructible_v<E>) // extension
     requires(::std::is_copy_assignable_v<T> && ::std::is_copy_constructible_v<T> && ::std::is_copy_assignable_v<E>
              && ::std::is_copy_constructible_v<E>
-             && (::std::is_nothrow_move_constructible_v<T> || ::std::is_nothrow_move_constructible_v<E>))
+             && (::std::is_nothrow_move_constructible_v<T> || ::std::is_nothrow_move_constructible_v<E>)
+             && (not ::std::is_trivially_copy_constructible_v<T> || not ::std::is_trivially_copy_assignable_v<T>
+                 || not ::std::is_trivially_destructible_v<T> || not ::std::is_trivially_copy_constructible_v<E>
+                 || not ::std::is_trivially_copy_assignable_v<E> || not ::std::is_trivially_destructible_v<E>))
   {
     this->_assign(static_cast<_base const &>(s));
     return *this;
   }
 
+  constexpr expected &operator=(expected &&) // NOSONAR cpp:S5018 standard mandated `noexcept` spec.
+      noexcept(::std::is_nothrow_move_assignable_v<T> && ::std::is_nothrow_move_constructible_v<T>
+               && ::std::is_nothrow_move_assignable_v<E> && ::std::is_nothrow_move_constructible_v<E>) // required
+    requires(::std::is_move_constructible_v<T> && ::std::is_move_assignable_v<T> && ::std::is_move_constructible_v<E>
+             && ::std::is_move_assignable_v<E>
+             && (::std::is_nothrow_move_constructible_v<T> || ::std::is_nothrow_move_constructible_v<E>)
+             && ::std::is_trivially_move_constructible_v<T> && ::std::is_trivially_move_assignable_v<T>
+             && ::std::is_trivially_destructible_v<T> && ::std::is_trivially_move_constructible_v<E>
+             && ::std::is_trivially_move_assignable_v<E> && ::std::is_trivially_destructible_v<E>)
+  = default;
   constexpr expected &operator=(expected &&s) // NOSONAR cpp:S5018 standard mandated `noexcept` spec.
       noexcept(::std::is_nothrow_move_assignable_v<T> && ::std::is_nothrow_move_constructible_v<T>
                && ::std::is_nothrow_move_assignable_v<E> && ::std::is_nothrow_move_constructible_v<E>) // required
     requires(::std::is_move_constructible_v<T> && ::std::is_move_assignable_v<T> && ::std::is_move_constructible_v<E>
              && ::std::is_move_assignable_v<E>
-             && (::std::is_nothrow_move_constructible_v<T> || ::std::is_nothrow_move_constructible_v<E>))
+             && (::std::is_nothrow_move_constructible_v<T> || ::std::is_nothrow_move_constructible_v<E>)
+             && (not ::std::is_trivially_move_constructible_v<T> || not ::std::is_trivially_move_assignable_v<T>
+                 || not ::std::is_trivially_destructible_v<T> || not ::std::is_trivially_move_constructible_v<E>
+                 || not ::std::is_trivially_move_assignable_v<E> || not ::std::is_trivially_destructible_v<E>))
   {
     this->_assign(static_cast<_base &&>(s));
     return *this;
@@ -1552,17 +1590,33 @@ public:
   }
 
   constexpr expected &operator=(expected const &) = delete;
+  constexpr expected &operator=(expected const &)                                                   //
+      noexcept(::std::is_nothrow_copy_assignable_v<E> && ::std::is_nothrow_copy_constructible_v<E>) // extension
+    requires(::std::is_copy_assignable_v<E> && ::std::is_copy_constructible_v<E>
+             && ::std::is_trivially_copy_constructible_v<E> && ::std::is_trivially_copy_assignable_v<E>
+             && ::std::is_trivially_destructible_v<E>)
+  = default;
   constexpr expected &operator=(expected const &s)                                                  //
       noexcept(::std::is_nothrow_copy_assignable_v<E> && ::std::is_nothrow_copy_constructible_v<E>) // extension
-    requires(::std::is_copy_assignable_v<E> && ::std::is_copy_constructible_v<E>)
+    requires(::std::is_copy_assignable_v<E> && ::std::is_copy_constructible_v<E>
+             && (not ::std::is_trivially_copy_constructible_v<E> || not ::std::is_trivially_copy_assignable_v<E>
+                 || not ::std::is_trivially_destructible_v<E>))
   {
     this->_assign(static_cast<_base const &>(s));
     return *this;
   }
 
+  constexpr expected &operator=(expected &&) // NOSONAR cpp:S5018 standard mandated `noexcept` spec.
+      noexcept(::std::is_nothrow_move_assignable_v<E> && ::std::is_nothrow_move_constructible_v<E>) // required
+    requires(::std::is_move_constructible_v<E> && ::std::is_move_assignable_v<E>
+             && ::std::is_trivially_move_constructible_v<E> && ::std::is_trivially_move_assignable_v<E>
+             && ::std::is_trivially_destructible_v<E>)
+  = default;
   constexpr expected &operator=(expected &&s) // NOSONAR cpp:S5018 standard mandated `noexcept` spec.
       noexcept(::std::is_nothrow_move_assignable_v<E> && ::std::is_nothrow_move_constructible_v<E>) // required
-    requires(::std::is_move_constructible_v<E> && ::std::is_move_assignable_v<E>)
+    requires(::std::is_move_constructible_v<E> && ::std::is_move_assignable_v<E>
+             && (not ::std::is_trivially_move_constructible_v<E> || not ::std::is_trivially_move_assignable_v<E>
+                 || not ::std::is_trivially_destructible_v<E>))
   {
     this->_assign(static_cast<_base &&>(s));
     return *this;

--- a/include/pfn/optional.hpp
+++ b/include/pfn/optional.hpp
@@ -236,7 +236,8 @@ namespace detail {
 // roles reversed: the engaged value lives in `v_`, and `e_` is a trivial placeholder
 // for the disengaged state, so the union always has an active member (required for
 // constexpr use). Copy/move ctors are defaulted iff `T` is trivially copy/move
-// constructible; the destructor is defaulted iff `T` is trivially destructible.
+// constructible, assignments iff `T` is trivially copy/move assignable; the
+// destructor is defaulted iff `T` is trivially destructible.
 // Tag selecting _optional_union_t's/_optional_base's "construct from any source exposing
 // has_value()/operator*()" constructor, disambiguating it from the (bool, S&&) one below
 // (which instead reads another union's raw v_ member directly).
@@ -309,7 +310,13 @@ template <class T> union _optional_union_t {
     requires(::std::is_trivially_move_constructible_v<T>)
   = default;
   constexpr _optional_union_t &operator=(_optional_union_t const &) = delete;
+  constexpr _optional_union_t &operator=(_optional_union_t const &) noexcept //
+    requires(::std::is_trivially_copy_assignable_v<T>)
+  = default;
   constexpr _optional_union_t &operator=(_optional_union_t &&) = delete;
+  constexpr _optional_union_t &operator=(_optional_union_t &&) noexcept //
+    requires(::std::is_trivially_move_assignable_v<T>)
+  = default;
 
   template <class... Args>
   constexpr explicit _optional_union_t(::std::in_place_t /*ignored*/, Args &&...a) //
@@ -488,8 +495,8 @@ template <class T, class Policy> struct _optional_base {
 
   constexpr _optional_base(_optional_base const &) noexcept = default;
   constexpr _optional_base(_optional_base &&) noexcept = default;
-  constexpr _optional_base &operator=(_optional_base const &) = delete;
-  constexpr _optional_base &operator=(_optional_base &&) = delete;
+  constexpr _optional_base &operator=(_optional_base const &) noexcept = default;
+  constexpr _optional_base &operator=(_optional_base &&) noexcept = default;
 
   constexpr ~_optional_base() //
     requires(::std::is_trivially_destructible_v<_value_t>)
@@ -1118,16 +1125,32 @@ public:
     return *this;
   }
   constexpr optional &operator=(optional const &) = delete;
+  constexpr optional &operator=(optional const &)                                                   //
+      noexcept(::std::is_nothrow_copy_assignable_v<T> && ::std::is_nothrow_copy_constructible_v<T>) // extension
+    requires(::std::is_copy_constructible_v<T> && ::std::is_copy_assignable_v<T>
+             && ::std::is_trivially_copy_constructible_v<T> && ::std::is_trivially_copy_assignable_v<T>
+             && ::std::is_trivially_destructible_v<T>)
+  = default;
   constexpr optional &operator=(optional const &s)                                                  //
       noexcept(::std::is_nothrow_copy_assignable_v<T> && ::std::is_nothrow_copy_constructible_v<T>) // extension
-    requires(::std::is_copy_constructible_v<T> && ::std::is_copy_assignable_v<T>)
+    requires(::std::is_copy_constructible_v<T> && ::std::is_copy_assignable_v<T>
+             && (not ::std::is_trivially_copy_constructible_v<T> || not ::std::is_trivially_copy_assignable_v<T>
+                 || not ::std::is_trivially_destructible_v<T>))
   {
     this->_assign(static_cast<_base const &>(s));
     return *this;
   }
+  constexpr optional &operator=(optional &&) // NOSONAR cpp:S5018 standard mandated `noexcept` spec.
+      noexcept(::std::is_nothrow_move_assignable_v<T> && ::std::is_nothrow_move_constructible_v<T>) // required
+    requires(::std::is_move_constructible_v<T> && ::std::is_move_assignable_v<T>
+             && ::std::is_trivially_move_constructible_v<T> && ::std::is_trivially_move_assignable_v<T>
+             && ::std::is_trivially_destructible_v<T>)
+  = default;
   constexpr optional &operator=(optional &&s) // NOSONAR cpp:S5018 standard mandated `noexcept` spec.
       noexcept(::std::is_nothrow_move_assignable_v<T> && ::std::is_nothrow_move_constructible_v<T>) // required
-    requires(::std::is_move_constructible_v<T> && ::std::is_move_assignable_v<T>)
+    requires(::std::is_move_constructible_v<T> && ::std::is_move_assignable_v<T>
+             && (not ::std::is_trivially_move_constructible_v<T> || not ::std::is_trivially_move_assignable_v<T>
+                 || not ::std::is_trivially_destructible_v<T>))
   {
     this->_assign(static_cast<_base &&>(s));
     return *this;

--- a/tests/pfn/expected.cpp
+++ b/tests/pfn/expected.cpp
@@ -2346,8 +2346,8 @@ TEST_CASE("expected non void", "[expected][polyfill]")
       SECTION("all trivial")
       {
         using T = expected<int, Error>;
-// libc++ (22) does not yet implement the trivial assignment of std::expected
-#if !defined(PFN_TEST_VALIDATION) || !defined(_LIBCPP_VERSION)
+// std::expected's assignment became trivial late: libstdc++ in GCC 16; libc++ (22) not yet
+#if !defined(PFN_TEST_VALIDATION) || (defined(__GLIBCXX__) && _GLIBCXX_RELEASE >= 16)
         static_assert(std::is_trivially_copy_assignable_v<T>);
         static_assert(std::is_trivially_move_assignable_v<T>);
         static_assert(std::is_trivially_copyable_v<T>);
@@ -2467,8 +2467,8 @@ TEST_CASE("expected non void", "[expected][polyfill]")
             return *this;
           }
         };
-// libc++ (22) does not yet implement the trivial assignment of std::expected
-#if !defined(PFN_TEST_VALIDATION) || !defined(_LIBCPP_VERSION)
+// std::expected's assignment became trivial late: libstdc++ in GCC 16; libc++ (22) not yet
+#if !defined(PFN_TEST_VALIDATION) || (defined(__GLIBCXX__) && _GLIBCXX_RELEASE >= 16)
         static_assert(std::is_trivially_copy_assignable_v<expected<move_split_t, Error>>);
 #endif
         static_assert(not std::is_trivially_move_assignable_v<expected<move_split_t, Error>>);
@@ -2485,8 +2485,8 @@ TEST_CASE("expected non void", "[expected][polyfill]")
           copy_split_t &operator=(copy_split_t &&) = default;
         };
         static_assert(not std::is_trivially_copy_assignable_v<expected<copy_split_t, Error>>);
-// libc++ (22) does not yet implement the trivial assignment of std::expected
-#if !defined(PFN_TEST_VALIDATION) || !defined(_LIBCPP_VERSION)
+// std::expected's assignment became trivial late: libstdc++ in GCC 16; libc++ (22) not yet
+#if !defined(PFN_TEST_VALIDATION) || (defined(__GLIBCXX__) && _GLIBCXX_RELEASE >= 16)
         static_assert(std::is_trivially_move_assignable_v<expected<copy_split_t, Error>>);
 #endif
         SUCCEED();
@@ -2510,8 +2510,8 @@ TEST_CASE("expected non void", "[expected][polyfill]")
         // one nothrow-move-constructible side restores the operator, in its trivial form
         static_assert(std::is_copy_assignable_v<expected<no_move_t, Error>>);
         static_assert(std::is_copy_assignable_v<expected<int, no_move_t>>);
-// libc++ (22) does not yet implement the trivial assignment of std::expected
-#if !defined(PFN_TEST_VALIDATION) || !defined(_LIBCPP_VERSION)
+// std::expected's assignment became trivial late: libstdc++ in GCC 16; libc++ (22) not yet
+#if !defined(PFN_TEST_VALIDATION) || (defined(__GLIBCXX__) && _GLIBCXX_RELEASE >= 16)
         static_assert(std::is_trivially_copy_assignable_v<expected<no_move_t, Error>>);
         static_assert(std::is_trivially_copy_assignable_v<expected<int, no_move_t>>);
 #endif
@@ -5015,8 +5015,8 @@ TEST_CASE("expected void", "[expected_void][polyfill]")
       SECTION("all trivial")
       {
         using T = expected<void, Error>;
-// libc++ (22) does not yet implement the trivial assignment of std::expected
-#if !defined(PFN_TEST_VALIDATION) || !defined(_LIBCPP_VERSION)
+// std::expected's assignment became trivial late: libstdc++ in GCC 16; libc++ (22) not yet
+#if !defined(PFN_TEST_VALIDATION) || (defined(__GLIBCXX__) && _GLIBCXX_RELEASE >= 16)
         static_assert(std::is_trivially_copy_assignable_v<T>);
         static_assert(std::is_trivially_move_assignable_v<T>);
         static_assert(std::is_trivially_copyable_v<T>);
@@ -5130,8 +5130,8 @@ TEST_CASE("expected void", "[expected_void][polyfill]")
             return *this;
           }
         };
-// libc++ (22) does not yet implement the trivial assignment of std::expected
-#if !defined(PFN_TEST_VALIDATION) || !defined(_LIBCPP_VERSION)
+// std::expected's assignment became trivial late: libstdc++ in GCC 16; libc++ (22) not yet
+#if !defined(PFN_TEST_VALIDATION) || (defined(__GLIBCXX__) && _GLIBCXX_RELEASE >= 16)
         static_assert(std::is_trivially_copy_assignable_v<expected<void, move_split_t>>);
 #endif
         static_assert(not std::is_trivially_move_assignable_v<expected<void, move_split_t>>);
@@ -5148,8 +5148,8 @@ TEST_CASE("expected void", "[expected_void][polyfill]")
           copy_split_t &operator=(copy_split_t &&) = default;
         };
         static_assert(not std::is_trivially_copy_assignable_v<expected<void, copy_split_t>>);
-// libc++ (22) does not yet implement the trivial assignment of std::expected
-#if !defined(PFN_TEST_VALIDATION) || !defined(_LIBCPP_VERSION)
+// std::expected's assignment became trivial late: libstdc++ in GCC 16; libc++ (22) not yet
+#if !defined(PFN_TEST_VALIDATION) || (defined(__GLIBCXX__) && _GLIBCXX_RELEASE >= 16)
         static_assert(std::is_trivially_move_assignable_v<expected<void, copy_split_t>>);
 #endif
         SUCCEED();

--- a/tests/pfn/expected.cpp
+++ b/tests/pfn/expected.cpp
@@ -2338,6 +2338,198 @@ TEST_CASE("expected non void", "[expected][polyfill]")
         }
       }
     }
+
+    SECTION("trivial")
+    {
+      // [expected.object.assign] p5/p10: assignment is trivial iff T and E are both trivially
+      // copy/move constructible, trivially copy/move assignable and trivially destructible
+      SECTION("all trivial")
+      {
+        using T = expected<int, Error>;
+// libc++ (22) does not yet implement the trivial assignment of std::expected
+#if !defined(PFN_TEST_VALIDATION) || !defined(_LIBCPP_VERSION)
+        static_assert(std::is_trivially_copy_assignable_v<T>);
+        static_assert(std::is_trivially_move_assignable_v<T>);
+        static_assert(std::is_trivially_copyable_v<T>);
+#endif
+        static_assert(not extension || std::is_nothrow_copy_assignable_v<T>);
+        static_assert(std::is_nothrow_move_assignable_v<T>);
+
+        // all four state transitions through the trivial assignment
+        static_assert([] {
+          T const a(std::in_place, 12);
+          T b(std::in_place, 1);
+          b = a; // value to value
+          T c(unexpect, Error::unknown);
+          c = a; // error to value
+          T d(std::in_place, 3);
+          d = T(unexpect, Error::unknown); // value to error
+          T e(unexpect, Error::file_not_found);
+          e = T(unexpect, Error::unknown); // error to error
+          return b.value() == 12 && c.value() == 12 && d.error() == Error::unknown && e.error() == Error::unknown;
+        }());
+
+        T const a(std::in_place, 12);
+        T b(std::in_place, 1);
+        b = a;
+        CHECK(b.value() == 12);
+        T c(unexpect, Error::unknown);
+        c = a;
+        CHECK(c.value() == 12);
+        T d(std::in_place, 3);
+        d = T(unexpect, Error::unknown);
+        CHECK(d.error() == Error::unknown);
+        T e(unexpect, Error::file_not_found);
+        e = T(unexpect, Error::unknown);
+        CHECK(e.error() == Error::unknown);
+      }
+
+      SECTION("non-trivial destructor")
+      {
+        struct dtor_t {
+          int v;
+          dtor_t(dtor_t const &) = default;
+          dtor_t(dtor_t &&) = default;
+          dtor_t &operator=(dtor_t const &) = default;
+          dtor_t &operator=(dtor_t &&) = default;
+          constexpr ~dtor_t() {}
+        };
+        static_assert(std::is_trivially_copy_assignable_v<dtor_t> && not std::is_trivially_destructible_v<dtor_t>);
+        static_assert(std::is_copy_assignable_v<expected<dtor_t, Error>>);
+        static_assert(not std::is_trivially_copy_assignable_v<expected<dtor_t, Error>>);
+        static_assert(not std::is_trivially_move_assignable_v<expected<dtor_t, Error>>);
+        static_assert(std::is_copy_assignable_v<expected<int, dtor_t>>);
+        static_assert(not std::is_trivially_copy_assignable_v<expected<int, dtor_t>>);
+        static_assert(not std::is_trivially_move_assignable_v<expected<int, dtor_t>>);
+        SUCCEED();
+      }
+
+      SECTION("non-trivial assignment")
+      {
+        struct assign_t {
+          int v;
+          assign_t(assign_t const &) = default;
+          assign_t(assign_t &&) = default;
+          constexpr assign_t &operator=(assign_t const &o)
+          {
+            v = o.v;
+            return *this;
+          }
+          constexpr assign_t &operator=(assign_t &&o)
+          {
+            v = o.v;
+            return *this;
+          }
+        };
+        static_assert(std::is_trivially_copy_constructible_v<assign_t> && std::is_trivially_destructible_v<assign_t>
+                      && not std::is_trivially_copy_assignable_v<assign_t>);
+        static_assert(std::is_copy_assignable_v<expected<assign_t, Error>>);
+        static_assert(not std::is_trivially_copy_assignable_v<expected<assign_t, Error>>);
+        static_assert(not std::is_trivially_move_assignable_v<expected<assign_t, Error>>);
+        static_assert(std::is_copy_assignable_v<expected<int, assign_t>>);
+        static_assert(not std::is_trivially_copy_assignable_v<expected<int, assign_t>>);
+        static_assert(not std::is_trivially_move_assignable_v<expected<int, assign_t>>);
+        SUCCEED();
+      }
+
+      SECTION("non-trivial construction")
+      {
+        // the value-to-error and error-to-value transitions construct, so a non-trivial
+        // copy constructor alone disqualifies the trivial assignment
+        struct ctor_t {
+          int v;
+          constexpr ctor_t(ctor_t const &o) : v(o.v) {}
+          constexpr ctor_t(ctor_t &&o) : v(o.v) {}
+          ctor_t &operator=(ctor_t const &) = default;
+          ctor_t &operator=(ctor_t &&) = default;
+        };
+        static_assert(std::is_trivially_copy_assignable_v<ctor_t> && std::is_trivially_destructible_v<ctor_t>
+                      && not std::is_trivially_copy_constructible_v<ctor_t>);
+        static_assert(std::is_copy_assignable_v<expected<ctor_t, Error>>);
+        static_assert(not std::is_trivially_copy_assignable_v<expected<ctor_t, Error>>);
+        static_assert(not std::is_trivially_move_assignable_v<expected<ctor_t, Error>>);
+        static_assert(std::is_copy_assignable_v<expected<int, ctor_t>>);
+        static_assert(not std::is_trivially_copy_assignable_v<expected<int, ctor_t>>);
+        static_assert(not std::is_trivially_move_assignable_v<expected<int, ctor_t>>);
+        SUCCEED();
+      }
+
+      SECTION("copy and move split")
+      {
+        struct move_split_t { // trivial copy assignment; user-provided move assignment
+          int v;
+          move_split_t(move_split_t const &) = default;
+          move_split_t(move_split_t &&) = default;
+          move_split_t &operator=(move_split_t const &) = default;
+          constexpr move_split_t &operator=(move_split_t &&o)
+          {
+            v = o.v;
+            return *this;
+          }
+        };
+// libc++ (22) does not yet implement the trivial assignment of std::expected
+#if !defined(PFN_TEST_VALIDATION) || !defined(_LIBCPP_VERSION)
+        static_assert(std::is_trivially_copy_assignable_v<expected<move_split_t, Error>>);
+#endif
+        static_assert(not std::is_trivially_move_assignable_v<expected<move_split_t, Error>>);
+
+        struct copy_split_t { // user-provided copy assignment; trivial move assignment
+          int v;
+          copy_split_t(copy_split_t const &) = default;
+          copy_split_t(copy_split_t &&) = default;
+          constexpr copy_split_t &operator=(copy_split_t const &o)
+          {
+            v = o.v;
+            return *this;
+          }
+          copy_split_t &operator=(copy_split_t &&) = default;
+        };
+        static_assert(not std::is_trivially_copy_assignable_v<expected<copy_split_t, Error>>);
+// libc++ (22) does not yet implement the trivial assignment of std::expected
+#if !defined(PFN_TEST_VALIDATION) || !defined(_LIBCPP_VERSION)
+        static_assert(std::is_trivially_move_assignable_v<expected<copy_split_t, Error>>);
+#endif
+        SUCCEED();
+      }
+
+      SECTION("not nothrow move constructible")
+      {
+        // [expected.object.assign] p4: the copy assignment additionally requires
+        // is_nothrow_move_constructible_v of T or E; a trivially copyable type with a
+        // deleted move constructor fails it, and no trivial trait can restore it
+        struct no_move_t {
+          int v;
+          no_move_t(no_move_t const &) = default;
+          no_move_t(no_move_t &&) = delete;
+          no_move_t &operator=(no_move_t const &) = default;
+        };
+        static_assert(std::is_trivially_copy_constructible_v<no_move_t>
+                      && std::is_trivially_copy_assignable_v<no_move_t> && std::is_trivially_destructible_v<no_move_t>);
+        static_assert(not std::is_move_constructible_v<no_move_t>);
+        static_assert(not std::is_copy_assignable_v<expected<no_move_t, no_move_t>>);
+        // one nothrow-move-constructible side restores the operator, in its trivial form
+        static_assert(std::is_copy_assignable_v<expected<no_move_t, Error>>);
+        static_assert(std::is_copy_assignable_v<expected<int, no_move_t>>);
+// libc++ (22) does not yet implement the trivial assignment of std::expected
+#if !defined(PFN_TEST_VALIDATION) || !defined(_LIBCPP_VERSION)
+        static_assert(std::is_trivially_copy_assignable_v<expected<no_move_t, Error>>);
+        static_assert(std::is_trivially_copy_assignable_v<expected<int, no_move_t>>);
+#endif
+        SUCCEED();
+      }
+
+      SECTION("deleted assignment")
+      {
+        struct no_assign_t {
+          int v;
+          no_assign_t(no_assign_t const &) = default;
+          no_assign_t &operator=(no_assign_t const &) = delete;
+        };
+        static_assert(not std::is_copy_assignable_v<expected<no_assign_t, Error>>);
+        static_assert(not std::is_copy_assignable_v<expected<int, no_assign_t>>);
+        SUCCEED();
+      }
+    }
   }
 
   SECTION("emplace")
@@ -4813,6 +5005,167 @@ TEST_CASE("expected void", "[expected_void][polyfill]")
 
           SUCCEED();
         }
+      }
+    }
+
+    SECTION("trivial")
+    {
+      // [expected.void.assign] p4/p9: assignment is trivial iff E is trivially copy/move
+      // constructible, trivially copy/move assignable and trivially destructible
+      SECTION("all trivial")
+      {
+        using T = expected<void, Error>;
+// libc++ (22) does not yet implement the trivial assignment of std::expected
+#if !defined(PFN_TEST_VALIDATION) || !defined(_LIBCPP_VERSION)
+        static_assert(std::is_trivially_copy_assignable_v<T>);
+        static_assert(std::is_trivially_move_assignable_v<T>);
+        static_assert(std::is_trivially_copyable_v<T>);
+#endif
+        static_assert(not extension || std::is_nothrow_copy_assignable_v<T>);
+        static_assert(std::is_nothrow_move_assignable_v<T>);
+
+        // all four state transitions through the trivial assignment
+        static_assert([] {
+          T const a(std::in_place);
+          T b(std::in_place);
+          b = T(unexpect, Error::unknown); // value to error
+          T c(unexpect, Error::unknown);
+          c = a; // error to value
+          T d(std::in_place);
+          d = a; // value to value
+          T e(unexpect, Error::file_not_found);
+          e = T(unexpect, Error::unknown); // error to error
+          return b.error() == Error::unknown && c.has_value() && d.has_value() && e.error() == Error::unknown;
+        }());
+
+        T const a(std::in_place);
+        T b(std::in_place);
+        b = T(unexpect, Error::unknown);
+        CHECK(b.error() == Error::unknown);
+        T c(unexpect, Error::unknown);
+        c = a;
+        CHECK(c.has_value());
+        T d(std::in_place);
+        d = a;
+        CHECK(d.has_value());
+        T e(unexpect, Error::file_not_found);
+        e = T(unexpect, Error::unknown);
+        CHECK(e.error() == Error::unknown);
+      }
+
+      SECTION("non-trivial destructor")
+      {
+        struct dtor_t {
+          int v;
+          dtor_t(dtor_t const &) = default;
+          dtor_t(dtor_t &&) = default;
+          dtor_t &operator=(dtor_t const &) = default;
+          dtor_t &operator=(dtor_t &&) = default;
+          constexpr ~dtor_t() {}
+        };
+        static_assert(std::is_trivially_copy_assignable_v<dtor_t> && not std::is_trivially_destructible_v<dtor_t>);
+        using T = expected<void, dtor_t>;
+        static_assert(std::is_copy_assignable_v<T> && std::is_move_assignable_v<T>);
+        static_assert(not std::is_trivially_copy_assignable_v<T>);
+        static_assert(not std::is_trivially_move_assignable_v<T>);
+        SUCCEED();
+      }
+
+      SECTION("non-trivial assignment")
+      {
+        struct assign_t {
+          int v;
+          assign_t(assign_t const &) = default;
+          assign_t(assign_t &&) = default;
+          constexpr assign_t &operator=(assign_t const &o)
+          {
+            v = o.v;
+            return *this;
+          }
+          constexpr assign_t &operator=(assign_t &&o)
+          {
+            v = o.v;
+            return *this;
+          }
+        };
+        static_assert(std::is_trivially_copy_constructible_v<assign_t> && std::is_trivially_destructible_v<assign_t>
+                      && not std::is_trivially_copy_assignable_v<assign_t>);
+        using T = expected<void, assign_t>;
+        static_assert(std::is_copy_assignable_v<T> && std::is_move_assignable_v<T>);
+        static_assert(not std::is_trivially_copy_assignable_v<T>);
+        static_assert(not std::is_trivially_move_assignable_v<T>);
+        SUCCEED();
+      }
+
+      SECTION("non-trivial construction")
+      {
+        // the value-to-error transition constructs, so a non-trivial copy constructor
+        // alone disqualifies the trivial assignment
+        struct ctor_t {
+          int v;
+          constexpr ctor_t(ctor_t const &o) : v(o.v) {}
+          constexpr ctor_t(ctor_t &&o) : v(o.v) {}
+          ctor_t &operator=(ctor_t const &) = default;
+          ctor_t &operator=(ctor_t &&) = default;
+        };
+        static_assert(std::is_trivially_copy_assignable_v<ctor_t> && std::is_trivially_destructible_v<ctor_t>
+                      && not std::is_trivially_copy_constructible_v<ctor_t>);
+        using T = expected<void, ctor_t>;
+        static_assert(std::is_copy_assignable_v<T> && std::is_move_assignable_v<T>);
+        static_assert(not std::is_trivially_copy_assignable_v<T>);
+        static_assert(not std::is_trivially_move_assignable_v<T>);
+        SUCCEED();
+      }
+
+      SECTION("copy and move split")
+      {
+        struct move_split_t { // trivial copy assignment; user-provided move assignment
+          int v;
+          move_split_t(move_split_t const &) = default;
+          move_split_t(move_split_t &&) = default;
+          move_split_t &operator=(move_split_t const &) = default;
+          constexpr move_split_t &operator=(move_split_t &&o)
+          {
+            v = o.v;
+            return *this;
+          }
+        };
+// libc++ (22) does not yet implement the trivial assignment of std::expected
+#if !defined(PFN_TEST_VALIDATION) || !defined(_LIBCPP_VERSION)
+        static_assert(std::is_trivially_copy_assignable_v<expected<void, move_split_t>>);
+#endif
+        static_assert(not std::is_trivially_move_assignable_v<expected<void, move_split_t>>);
+
+        struct copy_split_t { // user-provided copy assignment; trivial move assignment
+          int v;
+          copy_split_t(copy_split_t const &) = default;
+          copy_split_t(copy_split_t &&) = default;
+          constexpr copy_split_t &operator=(copy_split_t const &o)
+          {
+            v = o.v;
+            return *this;
+          }
+          copy_split_t &operator=(copy_split_t &&) = default;
+        };
+        static_assert(not std::is_trivially_copy_assignable_v<expected<void, copy_split_t>>);
+// libc++ (22) does not yet implement the trivial assignment of std::expected
+#if !defined(PFN_TEST_VALIDATION) || !defined(_LIBCPP_VERSION)
+        static_assert(std::is_trivially_move_assignable_v<expected<void, copy_split_t>>);
+#endif
+        SUCCEED();
+      }
+
+      SECTION("deleted assignment")
+      {
+        struct no_assign_t {
+          int v;
+          no_assign_t(no_assign_t const &) = default;
+          no_assign_t &operator=(no_assign_t const &) = delete;
+        };
+        using T = expected<void, no_assign_t>;
+        static_assert(not std::is_copy_assignable_v<T>);
+        static_assert(not std::is_move_assignable_v<T>);
+        SUCCEED();
       }
     }
   }

--- a/tests/pfn/optional.cpp
+++ b/tests/pfn/optional.cpp
@@ -738,6 +738,158 @@ TEST_CASE("optional", "[optional][polyfill]")
       }
 #endif
     }
+
+    SECTION("trivial")
+    {
+      // [optional.assign] p7/p13: assignment is trivial iff T is trivially copy/move
+      // constructible, trivially copy/move assignable and trivially destructible
+      SECTION("all trivial")
+      {
+        using T = optional<int>;
+        static_assert(std::is_trivially_copy_assignable_v<T>);
+        static_assert(std::is_trivially_move_assignable_v<T>);
+        static_assert(std::is_trivially_copyable_v<T>);
+        static_assert(not extension || std::is_nothrow_copy_assignable_v<T>);
+        static_assert(std::is_nothrow_move_assignable_v<T>);
+
+        // all four engagement transitions through the trivial assignment
+        static_assert([] {
+          T const a(std::in_place, 12);
+          T b(std::in_place, 1);
+          b = a; // engaged to engaged
+          T c(std::nullopt);
+          c = a; // disengaged to engaged
+          T d(std::in_place, 3);
+          d = T(std::nullopt); // engaged to disengaged
+          T e(std::nullopt);
+          e = T(std::nullopt); // disengaged to disengaged
+          return *b == 12 && *c == 12 && not d.has_value() && not e.has_value();
+        }());
+
+        T const a(std::in_place, 12);
+        T b(std::in_place, 1);
+        b = a;
+        CHECK(*b == 12);
+        T c(std::nullopt);
+        c = a;
+        CHECK(*c == 12);
+        T d(std::in_place, 3);
+        d = T(std::nullopt);
+        CHECK(not d.has_value());
+        T e(std::nullopt);
+        e = T(std::nullopt);
+        CHECK(not e.has_value());
+      }
+
+      SECTION("non-trivial destructor")
+      {
+        struct dtor_t {
+          int v;
+          dtor_t(dtor_t const &) = default;
+          dtor_t(dtor_t &&) = default;
+          dtor_t &operator=(dtor_t const &) = default;
+          dtor_t &operator=(dtor_t &&) = default;
+          constexpr ~dtor_t() {}
+        };
+        static_assert(std::is_trivially_copy_assignable_v<dtor_t> && not std::is_trivially_destructible_v<dtor_t>);
+        using T = optional<dtor_t>;
+        static_assert(std::is_copy_assignable_v<T> && std::is_move_assignable_v<T>);
+        static_assert(not std::is_trivially_copy_assignable_v<T>);
+        static_assert(not std::is_trivially_move_assignable_v<T>);
+        SUCCEED();
+      }
+
+      SECTION("non-trivial assignment")
+      {
+        struct assign_t {
+          int v;
+          assign_t(assign_t const &) = default;
+          assign_t(assign_t &&) = default;
+          constexpr assign_t &operator=(assign_t const &o)
+          {
+            v = o.v;
+            return *this;
+          }
+          constexpr assign_t &operator=(assign_t &&o)
+          {
+            v = o.v;
+            return *this;
+          }
+        };
+        static_assert(std::is_trivially_copy_constructible_v<assign_t> && std::is_trivially_destructible_v<assign_t>
+                      && not std::is_trivially_copy_assignable_v<assign_t>);
+        using T = optional<assign_t>;
+        static_assert(std::is_copy_assignable_v<T> && std::is_move_assignable_v<T>);
+        static_assert(not std::is_trivially_copy_assignable_v<T>);
+        static_assert(not std::is_trivially_move_assignable_v<T>);
+        SUCCEED();
+      }
+
+      SECTION("non-trivial construction")
+      {
+        // the disengaged-to-engaged transition constructs, so a non-trivial copy
+        // constructor alone disqualifies the trivial assignment
+        struct ctor_t {
+          int v;
+          constexpr ctor_t(ctor_t const &o) : v(o.v) {}
+          constexpr ctor_t(ctor_t &&o) : v(o.v) {}
+          ctor_t &operator=(ctor_t const &) = default;
+          ctor_t &operator=(ctor_t &&) = default;
+        };
+        static_assert(std::is_trivially_copy_assignable_v<ctor_t> && std::is_trivially_destructible_v<ctor_t>
+                      && not std::is_trivially_copy_constructible_v<ctor_t>);
+        using T = optional<ctor_t>;
+        static_assert(std::is_copy_assignable_v<T> && std::is_move_assignable_v<T>);
+        static_assert(not std::is_trivially_copy_assignable_v<T>);
+        static_assert(not std::is_trivially_move_assignable_v<T>);
+        SUCCEED();
+      }
+
+      SECTION("copy and move split")
+      {
+        struct move_split_t { // trivial copy assignment; user-provided move assignment
+          int v;
+          move_split_t(move_split_t const &) = default;
+          move_split_t(move_split_t &&) = default;
+          move_split_t &operator=(move_split_t const &) = default;
+          constexpr move_split_t &operator=(move_split_t &&o)
+          {
+            v = o.v;
+            return *this;
+          }
+        };
+        static_assert(std::is_trivially_copy_assignable_v<optional<move_split_t>>);
+        static_assert(not std::is_trivially_move_assignable_v<optional<move_split_t>>);
+
+        struct copy_split_t { // user-provided copy assignment; trivial move assignment
+          int v;
+          copy_split_t(copy_split_t const &) = default;
+          copy_split_t(copy_split_t &&) = default;
+          constexpr copy_split_t &operator=(copy_split_t const &o)
+          {
+            v = o.v;
+            return *this;
+          }
+          copy_split_t &operator=(copy_split_t &&) = default;
+        };
+        static_assert(not std::is_trivially_copy_assignable_v<optional<copy_split_t>>);
+        static_assert(std::is_trivially_move_assignable_v<optional<copy_split_t>>);
+        SUCCEED();
+      }
+
+      SECTION("deleted assignment")
+      {
+        struct no_assign_t {
+          int v;
+          no_assign_t(no_assign_t const &) = default;
+          no_assign_t &operator=(no_assign_t const &) = delete;
+        };
+        using T = optional<no_assign_t>;
+        static_assert(not std::is_copy_assignable_v<T>);
+        static_assert(not std::is_move_assignable_v<T>);
+        SUCCEED();
+      }
+    }
   }
 
   SECTION("emplace")
@@ -2022,6 +2174,8 @@ TEST_CASE("optional reference", "[optional_ref][polyfill]")
     static_assert(std::is_nothrow_default_constructible_v<T>);
     static_assert(std::is_copy_constructible_v<T>);
     static_assert(std::is_trivially_copy_constructible_v<T>);
+    static_assert(std::is_trivially_copy_assignable_v<T>);
+    static_assert(std::is_trivially_move_assignable_v<T>);
     static_assert(std::is_nothrow_constructible_v<T, std::nullopt_t>);
     SUCCEED();
   }


### PR DESCRIPTION
Closes #308

`optional` and `expected` were never trivially copy- or move-assignable, for any payload — a conformance defect against [optional.assign], [expected.object.assign] and [expected.void.assign], which mandate a trivial assignment when the contained types are trivially copy/move constructible, trivially assignable and trivially destructible. With the constructors and destructor already conditionally trivial, assignment was the one member keeping these types out of `is_trivially_copyable`.

The fix mirrors `variadic_union`'s shape (#312) at three layers:
- the storage unions (`_optional_union_t`, `_expected_union_t` and its `void` specialization) gain a constrained defaulted `operator=` arm next to the deleted one, gated on the members' own `is_trivially_copy/move_assignable` — per-operation propagation, like their constructor/destructor pairs;
- the shared bases replace their unconditional `= delete` assignment with `noexcept = default`, so deleted-ness propagates from the union member exactly as it already does for the copy/move constructors;
- the public `operator=` in all four wrappers (`pfn`/`fn` × `optional`/`expected`, value and `void`) gains a defaulted trivial arm whose constraint spells the standard's Constraints and triviality Remarks verbatim, with the user-provided arm excluded by the negated triviality conjunction. The one availability atom the six trivial traits do not imply — `expected`'s `is_nothrow_move_constructible_v<T> || is_nothrow_move_constructible_v<E>` — stays in both arms.

Tests extend the assignment sections of `tests/pfn/{optional,expected}.cpp` in place, so they run against `pfn`, `std` (validation TUs) and `fn` (polyfill TUs): an all-trivial battery (traits plus all four state transitions through the trivial arm, runtime and constexpr twins), one fixture per load-bearing atom (non-trivial destructor / assignment / construction, each alone disqualifying), copy/move selector independence, the deleted-assignment converse, and the nothrow-move-disjunction pin. `optional<T&>` gets trivial-assignment pins matching P2988R12, whose synopsis declares its copy assignment `= default`.

Notes:
- `std::expected`'s assignment became trivial late: libstdc++ ships it in GCC 16, libc++ (22) not yet — so the positive `expected` pins run in validation mode only on libstdc++ ≥ 16, each site commented; extend the gate when libc++ ships it.
- Both libstdc++ and libc++ report `std::optional<X>` with a deleted `X::operator=` as not trivially copyable while this implementation reports it trivially copyable — their deleted assignment sits atop a non-trivial base member and the compiler intrinsic does not apply the eligibility rule; the tests deliberately do not pin that aggregate for such types.

Verified on gcc 16 and clang 22 (libc++), Debug and Release, C++20 and C++23-validation (`VALIDATE_CXX23=ON`, 78/78 tests), plus a local MSVC 2022 build of every affected target.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
