### PR TITLE
Add a value `operator=` to `sum` and `choice`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 Design history of libfn, newest first. The living documents — [README.md](README.md), [CONTRIBUTING.md](CONTRIBUTING.md), [docs/](docs/) — describe only the present state of the design; when a decision makes an earlier idea obsolete, this file is where the transition is recorded and explained.
 
+## `sum` and `choice` assign from a value of one alternative — 15 July 2026
+
+- **A value of exactly one alternative now assigns directly** ([#319](https://github.com/libfn/functional/issues/319)): assigned in place through the alternative's own `operator=` when it is the one held, replaced by construction otherwise. `s = v` used to exist only through the converting constructor's temporary sum and the whole-sum assignment, whose constraints let an uninvolved alternative forbid the operation and whose route relocated every value through the temporary. Exact alternative only, as the converting constructors take one — never `std::variant`'s converting-assignment resolution — so a convertible non-alternative stays rejected and interconvertible alternatives never meet in overload resolution.
+
 ## `optional` and `expected` assignment is trivial when the payload permits — 15 July 2026
 
 - **Copy and move assignment of `optional` and `expected` are now trivial exactly under the standard's conditions** ([#308](https://github.com/libfn/functional/issues/308)): the contained types trivially copy/move constructible, trivially assignable and trivially destructible ([optional.assign], [expected.object.assign], [expected.void.assign]). Neither type was ever trivially assignable, in either library — a conformance defect, and with the constructors and destructor already conditionally trivial, assignment was the one member keeping these types out of `is_trivially_copyable`. Like `sum`'s entry below, this lands before the first tagged release because trivially copyable types change ABI.

--- a/include/fn/choice.hpp
+++ b/include/fn/choice.hpp
@@ -202,6 +202,18 @@ struct choice<Ts...> : sum<Ts...> {
     return *this;
   }
 
+  // The delegating value assignment restates sum's for the same name-hiding reason. Sum- and
+  // choice-typed sources are excluded to leave them to the assignments above: for a non-const
+  // lvalue source a forwarding reference would otherwise outrank their `const &` bindings.
+  template <typename U>
+  constexpr choice &operator=(U &&v) //
+      noexcept(::std::is_nothrow_assignable_v<sum<Ts...> &, decltype(v)>)
+    requires(not some_sum<U>) && (not some_choice<U>) && ::std::is_assignable_v<sum<Ts...> &, decltype(v)>
+  {
+    static_cast<sum<Ts...> &>(*this) = FWD(v);
+    return *this;
+  }
+
   /**
    * @brief TODO
    *

--- a/include/fn/sum.hpp
+++ b/include/fn/sum.hpp
@@ -620,6 +620,32 @@ struct sum<Ts...> {
   }
 
   /**
+   * @brief Assignment from a value of one alternative, with the strong exception guarantee
+   *
+   * @param v TODO
+   * @return TODO
+   */
+  // Takes a value of exactly one alternative, as the converting constructors do - never
+  // std::variant's converting-assignment resolution, so a convertible non-alternative stays
+  // rejected and interconvertible alternatives never make a resolution puzzle. The one route
+  // otherwise - converting constructor, then whole-sum assignment - builds a temporary sum and
+  // lets an uninvolved alternative forbid the assignment; this overload consults only the
+  // alternative involved, assigning in place when it is the one held and replacing by
+  // construction otherwise.
+  template <typename U, typename T = ::std::remove_cvref_t<U>>
+  constexpr sum &operator=(U &&v) //
+      noexcept(::std::is_nothrow_assignable_v<T &, decltype(v)> && detail::_nothrow_makeable<data_t, T, decltype(v)>)
+    requires has_type<T> && ::std::is_assignable_v<T &, decltype(v)> && detail::_makeable<data_t, T, decltype(v)>
+             && (detail::_nothrow_makeable<data_t, T, decltype(v)> || detail::_nothrow_makeable<data_t, T, T>)
+  {
+    if (index == detail::type_index<T, Ts...>)
+      this->template _reassign<T>(FWD(v));
+    else
+      this->template _reinit<T>(FWD(v));
+    return *this;
+  }
+
+  /**
    * @brief TODO
    *
    * @tparam T TODO

--- a/tests/fn/choice.cpp
+++ b/tests/fn/choice.cpp
@@ -391,6 +391,50 @@ TEST_CASE("choice non-monadic functionality", "[choice]")
     }
   }
 
+  SECTION("assignment from a value")
+  {
+    // the delegating value assignment, restated for the same name-hiding reason as the widening
+    // pair above; the answer - routing, constraints, noexcept - is sum's
+    constexpr auto battery = [] {
+      choice<bool, int> a{12};
+      a = 42; // the alternative in hand
+      bool ok = a == choice{42};
+      a = true; // a different alternative
+      ok = ok && a == choice{true};
+      int const i = 7;
+      a = i; // by copy
+      return ok && a == choice{7};
+    };
+    CHECK(battery());
+    static_assert(battery());
+
+    SECTION("constraints")
+    {
+      static_assert(std::is_assignable_v<choice<bool, int> &, int>);
+      static_assert(not std::is_assignable_v<choice<bool, int> &, short>); // exact alternative only
+      static_assert(std::is_nothrow_assignable_v<choice<bool, int> &, int>);
+
+      // sum- and choice-typed sources are left to the assignments above, including non-const
+      // lvalues, which a forwarding reference would otherwise capture
+      static_assert(std::is_assignable_v<choice<bool, int> &, choice<bool, int> &>);
+      static_assert(std::is_assignable_v<choice<bool, int> &, choice<int> &>);
+      static_assert(std::is_assignable_v<choice<bool, int> &, fn::sum<int> &>);
+
+      // a sibling's refusal does not hold the value assignment hostage
+      struct Fixed final { // copyable, not assignable
+        constexpr Fixed() noexcept = default;
+        constexpr Fixed(Fixed const &) noexcept = default;
+        constexpr Fixed(Fixed &&) noexcept = default;
+        Fixed &operator=(Fixed const &) = delete;
+        Fixed &operator=(Fixed &&) = delete;
+      };
+      using C = fn::choice_for<Fixed, int>;
+      static_assert(not std::is_copy_assignable_v<C>);
+      static_assert(std::is_assignable_v<C &, int>);
+      SUCCEED();
+    }
+  }
+
   SECTION("forwarding constructors (immovable)")
   {
     choice<NonCopyable> a{std::in_place_type<NonCopyable>, 42};

--- a/tests/fn/sum.cpp
+++ b/tests/fn/sum.cpp
@@ -1161,6 +1161,13 @@ TEST_CASE("sum noexcept", "[sum][noexcept]")
     };
     static_assert(std::is_assignable_v<fn::sum_for<Quiet, Loud> &, sum<Loud> const &>);
     static_assert(not noexcept(std::declval<fn::sum_for<Quiet, Loud> &>() = std::declval<sum<Loud> const &>()));
+
+    // value assignment weighs only the alternative it takes: nothrow when both its delivery and
+    // its own operator= are, throwing when either is not
+    static_assert(std::is_assignable_v<fn::sum_for<Quiet, Throwy> &, Quiet const &>);
+    static_assert(noexcept(std::declval<fn::sum_for<Quiet, Throwy> &>() = std::declval<Quiet const &>()));
+    static_assert(std::is_assignable_v<fn::sum_for<Quiet, Loud> &, Loud const &>);
+    static_assert(not noexcept(std::declval<fn::sum_for<Quiet, Loud> &>() = std::declval<Loud const &>()));
     SUCCEED();
   }
 }
@@ -1880,6 +1887,167 @@ TEST_CASE("sum assignment", "[sum][assignment]")
 
       // a sum it is not a superset of is refused
       static_assert(not std::is_assignable_v<sum<int> &, sum<bool> const &>);
+      SUCCEED();
+    }
+  }
+
+  SECTION("from a value")
+  {
+    // a value of exactly one alternative assigns directly, as the converting constructors take
+    // one: assigned in place when it is the alternative held, replacing it by construction
+    // otherwise - `*this = sum{v}` with the temporary elided
+    constexpr auto basic = [] {
+      sum<bool, int> a{12};
+      a = 42; // the alternative in hand
+      bool ok = a == sum{42};
+      a = true; // a different alternative
+      ok = ok && a == sum{true};
+      int const i = 7;
+      a = i; // and back, from a const lvalue
+      return ok && a == sum{7};
+    };
+    CHECK(basic());
+    static_assert(basic());
+
+    SECTION("no hidden temporary")
+    {
+      // the route this overload replaces - converting constructor, then whole-sum assignment -
+      // relocated every value through a temporary sum; the direct delivery is one relocation
+      // into place, or none at all
+      struct Reloc final {
+        int v;
+        int *copied;
+        int *moved;
+        int *assigned;
+        constexpr Reloc(int i, int *c, int *m, int *a) noexcept : v(i), copied(c), moved(m), assigned(a) {}
+        constexpr Reloc(Reloc const &o) noexcept : v(o.v), copied(o.copied), moved(o.moved), assigned(o.assigned)
+        {
+          ++*copied;
+        }
+        constexpr Reloc(Reloc &&o) noexcept : v(o.v), copied(o.copied), moved(o.moved), assigned(o.assigned)
+        {
+          ++*moved;
+        }
+        constexpr Reloc &operator=(Reloc const &o) noexcept
+        {
+          v = o.v;
+          ++*assigned;
+          return *this;
+        }
+        constexpr Reloc &operator=(Reloc &&o) noexcept
+        {
+          v = o.v;
+          ++*assigned;
+          return *this;
+        }
+      };
+      constexpr auto counts = [] {
+        int copied = 0;
+        int moved = 0;
+        int assigned = 0;
+        using W = fn::sum_for<Reloc, int>;
+        Reloc n{42, &copied, &moved, &assigned};
+        Reloc m{9, &copied, &moved, &assigned};
+
+        W a{12};
+        copied = moved = assigned = 0;
+        a = std::as_const(n); // a different alternative, by copy: one copy, straight into place
+        bool ok = copied == 1 && moved == 0 && assigned == 0 && a.get_ptr<Reloc>()->v == 42;
+
+        copied = moved = assigned = 0;
+        a = std::as_const(n); // the alternative in hand: assigned with its own operator=, no relocation
+        ok = ok && copied == 0 && moved == 0 && assigned == 1;
+
+        a = W{12};
+        copied = moved = assigned = 0;
+        a = std::move(m); // a different alternative, by move: one move, nothing else
+        return ok && copied == 0 && moved == 1 && assigned == 0 && a.get_ptr<Reloc>()->v == 9;
+      };
+      CHECK(counts());
+      static_assert(counts());
+    }
+
+    SECTION("not hostage to a sibling alternative")
+    {
+      // the defect this overload fixes: through the temporary route, the whole-sum assignment's
+      // constraints let an uninvolved alternative forbid the operation
+      struct Fixed final { // copyable, not assignable
+        constexpr Fixed() noexcept = default;
+        constexpr Fixed(Fixed const &) noexcept = default;
+        constexpr Fixed(Fixed &&) noexcept = default;
+        Fixed &operator=(Fixed const &) = delete;
+        Fixed &operator=(Fixed &&) = delete;
+      };
+      using S = fn::sum_for<Fixed, int>;
+      static_assert(not std::is_copy_assignable_v<S>);             // the whole type still refuses
+      static_assert(std::is_assignable_v<S &, int>);               // its sibling is not hostage
+      static_assert(not std::is_assignable_v<S &, Fixed const &>); // the alternative's own refusal holds
+      constexpr auto witness = [] {
+        S s{std::in_place_type<Fixed>};
+        s = 42; // the non-assignable alternative is replaced by construction
+        return s.has_value(std::in_place_type<int>);
+      };
+      CHECK(witness());
+      static_assert(witness());
+    }
+
+    SECTION("exact alternative only")
+    {
+      // never std::variant's converting-assignment resolution: a convertible non-alternative is
+      // rejected - conversions keep their explicit spellings - and interconvertible alternatives
+      // never meet in overload resolution
+      static_assert(std::is_assignable_v<fn::sum_for<double, int> &, int>);
+      static_assert(std::is_assignable_v<fn::sum_for<double, int> &, double>);
+      static_assert(not std::is_assignable_v<fn::sum_for<double, int> &, short>);
+      static_assert(not std::is_assignable_v<fn::sum_for<double, int> &, float>);
+      constexpr auto exact = [] {
+        fn::sum_for<double, int> s{1.5};
+        s = 42; // int lands on int, not on double
+        return s.has_value(std::in_place_type<int>);
+      };
+      CHECK(exact());
+      static_assert(exact());
+    }
+
+    SECTION("constraints")
+    {
+      // each conjunct refuses on its own, and the gate follows the incoming value category,
+      // collapsing to the widening assignment's copy gate for an lvalue and its move gate for
+      // an rvalue
+      struct MoveAssign final { // move-assignable only: the copy form declines, the move form serves
+        constexpr MoveAssign() noexcept = default;
+        constexpr MoveAssign(MoveAssign const &) noexcept = default;
+        constexpr MoveAssign(MoveAssign &&) noexcept = default;
+        MoveAssign &operator=(MoveAssign const &) = delete;
+        constexpr MoveAssign &operator=(MoveAssign &&) noexcept = default;
+      };
+      using S = fn::sum_for<MoveAssign, int>;
+      static_assert(std::is_assignable_v<S &, MoveAssign>);
+      // ... while the constructor route survives where the direct overload declines: a temporary
+      // sum, then whole-type move assignment, with the old costs and the old gating
+      static_assert(std::is_assignable_v<S &, MoveAssign const &>);
+
+      struct NoCopy final { // assignable, not copy-deliverable: the copy form has no route at all
+        constexpr NoCopy() noexcept = default;
+        NoCopy(NoCopy const &) = delete;
+        constexpr NoCopy(NoCopy &&) noexcept = default;
+        constexpr NoCopy &operator=(NoCopy const &) noexcept = default;
+        constexpr NoCopy &operator=(NoCopy &&) noexcept = default;
+      };
+      using S2 = fn::sum_for<NoCopy, int>;
+      static_assert(not std::is_assignable_v<S2 &, NoCopy const &>);
+      static_assert(std::is_assignable_v<S2 &, NoCopy>);
+
+      struct Skittish final { // assignable, but no arm can deliver it without throwing
+        constexpr Skittish() noexcept = default;
+        Skittish(Skittish const &) noexcept(false) {}
+        Skittish(Skittish &&) noexcept(false) {}
+        Skittish &operator=(Skittish const &) noexcept { return *this; }
+        Skittish &operator=(Skittish &&) noexcept { return *this; }
+      };
+      using S3 = fn::sum_for<Skittish, int>;
+      static_assert(not std::is_assignable_v<S3 &, Skittish const &>);
+      static_assert(not std::is_assignable_v<S3 &, Skittish>);
       SUCCEED();
     }
   }


### PR DESCRIPTION
Closes #319

`sum` and `choice` are constructible from a value of one alternative but were not assignable from one: `s = v` existed only through the implicit converting constructor's temporary sum and the whole-sum `operator=` — a hidden relocation ahead of every delivery, and viability gated on the destination's every alternative, so an uninvolved alternative with no safe replacement arm forbade assignments it took no part in (`fn::sum_for<NoAssign, int>` was constructible from `int` but not assignable from it).

The value `operator=` follows the issue's settled design:
- **Exact alternative only** (`has_type<remove_cvref_t<U>>`), as the converting constructors take one — never `std::variant`'s converting-assignment resolution, so a convertible non-alternative stays rejected and interconvertible alternatives never meet in overload resolution;
- the gate is the widening assignment's per-alternative gate generalized over the incoming value category — it collapses to the widening copy gate for `U = T const&` and the widening move gate for `U = T&&` — and the body is the widening dispatch without the dispatch: `_reassign<T>` when `T` is the alternative held, `_reinit<T>` otherwise, strong exception guarantee on both paths, `noexcept` computed from the alternative's own `operator=` and its delivery;
- **`choice` pays the name-hiding tax again**: a delegating overload alongside the widening delegators, excluding both sum- and choice-typed sources (`some_sum` alone would not cover `choice`, which is matched by specialization) — for a non-const lvalue source the forwarding reference would otherwise outrank the delegators' `const&` bindings.

Tests, extended in place per the issue's list: the decoupling witness (`Fixed` sibling: whole-sum assignment deleted, `s = 42` well-formed, the alternative's own refusal kept); the `Reloc` counter battery pinning one-relocation-or-none and assigned-in-place-with-no-relocation across value categories; exact-alternative negatives with their converses; per-conjunct constraint kills (`NoCopy` for deliverability, `Skittish` for nothrow-deliverability); value-form `noexcept` pins (`Quiet`/`Throwy`/`Loud`); and the mirroring `choice` battery with delegator-boundary positives. The two-tier fact recurs from #317 and is pinned the same way: for a copy-deleted, move-assignable alternative the direct copy form declines while `s = const_value` still compiles through the converting constructor's temporary plus whole-type move assignment, with the old costs and the old gating.

Verified on gcc 16 and clang 22 (libc++), Debug and Release, C++20 and C++23-validation, plus a local MSVC 2022 build of the affected targets.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
