### PR TITLE
Add `emplace` to `sum` and `choice`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 Design history of libfn, newest first. The living documents — [README.md](README.md), [CONTRIBUTING.md](CONTRIBUTING.md), [docs/](docs/) — describe only the present state of the design; when a decision makes an earlier idea obsolete, this file is where the transition is recorded and explained.
 
+## `sum` and `choice` gained `emplace` — 15 July 2026
+
+- **`emplace<T>(args...)` is the mutation path for alternatives that do not support assignment** ([#318](https://github.com/libfn/functional/issues/318)): destroy-and-reconstruct requested at the call site by name, so senders and reference-holding packs — whose assignment `operator=` rightly refuses — can change the alternative held by an existing object again. Always reconstructs, also for the alternative already held, and the constraint asks about `T` alone: no sibling alternative is consulted. Unlike `std::expected::emplace` (nothrow constructions only, unconditionally `noexcept`) a throwing construction is admitted through an internalized temporary; unlike `std::variant::emplace` (unconstrained, valueless when construction throws) the case with no safe arm is constrained away — strong guarantee, never valueless, conditionally `noexcept`.
+
 ## `sum` and `choice` assign from a value of one alternative — 15 July 2026
 
 - **A value of exactly one alternative now assigns directly** ([#319](https://github.com/libfn/functional/issues/319)): assigned in place through the alternative's own `operator=` when it is the one held, replaced by construction otherwise. `s = v` used to exist only through the converting constructor's temporary sum and the whole-sum assignment, whose constraints let an uninvolved alternative forbid the operation and whose route relocated every value through the temporary. Exact alternative only, as the converting constructors take one — never `std::variant`'s converting-assignment resolution — so a convertible non-alternative stays rejected and interconvertible alternatives never meet in overload resolution.

--- a/include/fn/sum.hpp
+++ b/include/fn/sum.hpp
@@ -646,6 +646,31 @@ struct sum<Ts...> {
   }
 
   /**
+   * @brief Destroys the alternative held and constructs a `T` from the arguments, with the strong
+   *        exception guarantee
+   *
+   * @tparam T TODO
+   * @param args TODO
+   * @return Reference to the new alternative
+   */
+  // The mutation path for alternatives that do not support assignment: destroy-and-reconstruct,
+  // requested at the call site by name, constructing a new `T` rather than claiming an assignment
+  // the type refused. Always reconstructs, also when `T` is the alternative already held -
+  // assign-when-same is `operator=`'s meaning and stays there - so the constraint asks about `T`
+  // alone: the outgoing alternative is only destroyed, whatever its own traits. Arguments that
+  // refer into the alternative held will dangle, as with std::optional's and std::variant's
+  // emplace.
+  template <typename T>
+  constexpr T &emplace(auto &&...args) //
+      noexcept(detail::_nothrow_makeable<data_t, T, decltype(args)...>)
+    requires has_type<T> && detail::_makeable<data_t, T, decltype(args)...>
+             && (detail::_nothrow_makeable<data_t, T, decltype(args)...> || detail::_nothrow_makeable<data_t, T, T>)
+  {
+    this->template _reinit<T>(FWD(args)...);
+    return *detail::ptr_variadic_union<T, data_t>(this->data);
+  }
+
+  /**
    * @brief TODO
    *
    * @tparam T TODO

--- a/tests/fn/choice.cpp
+++ b/tests/fn/choice.cpp
@@ -47,6 +47,9 @@ struct Throwing final {
 template <typename S, typename T, typename... Args>
 concept can_in_place = requires(Args... args) { S{std::in_place_type<T>, args...}; };
 
+template <typename S, typename T, typename... Args>
+concept can_emplace = requires(S &s, Args &&...args) { s.template emplace<T>(static_cast<Args &&>(args)...); };
+
 template <typename S, typename Fn>
 concept can_transform = requires(S s, Fn fn) { FWD(s).transform(fn); };
 
@@ -918,6 +921,39 @@ TEST_CASE("choice assignment", "[choice][assignment]")
     }());
     SUCCEED();
   }
+}
+
+TEST_CASE("choice emplace", "[choice][emplace]")
+{
+  using fn::choice;
+
+  // sum::emplace is inherited - a named member, so the name hiding that forces choice to restate
+  // every operator= does not apply
+  struct Sender final { // not assignable, nothrow-move-constructible
+    int target;
+    constexpr explicit Sender(int t) noexcept : target(t) {}
+    constexpr Sender(Sender &&) noexcept = default;
+    Sender(Sender const &) = delete;
+    Sender &operator=(Sender const &) = delete;
+    Sender &operator=(Sender &&) = delete;
+  };
+  using C = fn::choice_for<Sender, int>;
+  static_assert(not std::is_copy_assignable_v<C>);
+  static_assert(not std::is_move_assignable_v<C>);
+  static_assert(can_emplace<C, Sender, int>);
+  static_assert(not can_emplace<C, double, double>); // not an alternative
+  static_assert(std::same_as<decltype(std::declval<C &>().emplace<int>(1)), int &>);
+  static_assert(noexcept(std::declval<C &>().emplace<int>(1)));
+
+  constexpr auto battery = [] {
+    C c{42};
+    Sender &r = c.emplace<Sender>(9);
+    bool ok = r.target == 9 && c.has_value(std::in_place_type<Sender>);
+    int &i = c.emplace<int>(5);
+    return ok && i == 5 && c.has_value(std::in_place_type<int>);
+  };
+  CHECK(battery());
+  static_assert(battery());
 }
 
 TEST_CASE("choice special members", "[choice]")

--- a/tests/fn/sum.cpp
+++ b/tests/fn/sum.cpp
@@ -94,6 +94,9 @@ concept can_ne = requires { std::declval<L const &>() != std::declval<R const &>
 template <typename S, typename T, typename... Args>
 concept can_in_place = requires(Args... args) { S{std::in_place_type<T>, args...}; };
 
+template <typename S, typename T, typename... Args>
+concept can_emplace = requires(S &s, Args &&...args) { s.template emplace<T>(static_cast<Args &&>(args)...); };
+
 template <typename T, typename... Args>
 concept can_as_sum = requires(Args... args) { fn::as_sum(std::in_place_type<T>, args...); };
 
@@ -2285,5 +2288,155 @@ TEST_CASE("sum assignment", "[sum][assignment]")
     static_assert(not std::is_nothrow_copy_assignable_v<Mixed>); // QuietMove's copy can throw
     static_assert(std::is_move_assignable_v<Mixed>);             // the copy assignment takes the rvalue ...
     static_assert(not std::is_nothrow_move_assignable_v<Mixed>); // ... and says that it can throw
+  }
+}
+
+TEST_CASE("sum emplace", "[sum][emplace]")
+{
+  using fn::sum;
+
+  // the mutation path for alternatives that do not support assignment: destroy-and-reconstruct,
+  // requested at the call site by name, so the constraint asks about the incoming alternative
+  // alone - the outgoing one is only destroyed, whatever its own traits
+  struct Sender final { // the motivating archetype: not assignable, nothrow-move-constructible
+    int target;
+    constexpr explicit Sender(int t) noexcept : target(t) {}
+    constexpr Sender(Sender &&) noexcept = default;
+    Sender(Sender const &) = delete;
+    Sender &operator=(Sender const &) = delete;
+    Sender &operator=(Sender &&) = delete;
+  };
+  using S = fn::sum_for<Sender, int>;
+  static_assert(not std::is_copy_assignable_v<S>);
+  static_assert(not std::is_move_assignable_v<S>);
+  static_assert(not std::is_assignable_v<S &, Sender>); // even the value operator= declines
+
+  SECTION("re-targets a sum of senders")
+  {
+    constexpr auto battery = [] {
+      S s{std::in_place_type<Sender>, 1};
+      Sender &r = s.emplace<Sender>(42);
+      bool ok = r.target == 42 && s.has_value(std::in_place_type<Sender>);
+      int &i = s.emplace<int>(7); // a different alternative
+      ok = ok && i == 7 && s.has_value(std::in_place_type<int>);
+      s.emplace<Sender>(3); // and back
+      return ok && s.has_value(std::in_place_type<Sender>);
+    };
+    CHECK(battery());
+    static_assert(battery());
+    static_assert(std::same_as<decltype(std::declval<S &>().emplace<int>(1)), int &>);
+  }
+
+  SECTION("always destroys and reconstructs")
+  {
+    // also when T is the alternative already held: assign-when-same is operator='s meaning and
+    // stays there, and unconditional reconstruction is what serves non-assignable types
+    struct Counter final {
+      int v;
+      int *constructed;
+      int *destroyed;
+      int *assigned;
+      constexpr Counter(int i, int *c, int *d, int *a) noexcept : v(i), constructed(c), destroyed(d), assigned(a)
+      {
+        ++*constructed;
+      }
+      constexpr Counter(Counter &&o) noexcept
+          : v(o.v), constructed(o.constructed), destroyed(o.destroyed), assigned(o.assigned)
+      {
+      }
+      constexpr Counter &operator=(Counter &&o) noexcept
+      {
+        v = o.v;
+        ++*assigned;
+        return *this;
+      }
+      constexpr ~Counter() { ++*destroyed; }
+    };
+    constexpr auto counts = [] {
+      int constructed = 0;
+      int destroyed = 0;
+      int assigned = 0;
+      using T = fn::sum_for<Counter, int>;
+      T s{std::in_place_type<Counter>, 7, &constructed, &destroyed, &assigned};
+
+      constructed = destroyed = assigned = 0;
+      Counter &r = s.emplace<Counter>(9, &constructed, &destroyed, &assigned);
+      return r.v == 9 && constructed == 1 && destroyed == 1 && assigned == 0;
+    };
+    CHECK(counts());
+    static_assert(counts());
+  }
+
+  SECTION("arm selection")
+  {
+    // nothrow construction goes straight into storage; a throwing construction is built into a
+    // temporary first - the storage untouched until it cannot throw - and delivered by exactly
+    // one nothrow move
+    struct Fragile final {
+      int v;
+      int *moved;
+      constexpr Fragile(int i, int *m) noexcept(false) : v(i), moved(m) {}
+      constexpr Fragile(Fragile &&o) noexcept : v(o.v), moved(o.moved) { ++*moved; }
+    };
+    constexpr auto arms = [] {
+      int moved = 0;
+      using T = fn::sum_for<Fragile, int>;
+      T s{12};
+      Fragile &r = s.emplace<Fragile>(5, &moved); // arm 2: one move
+      bool ok = r.v == 5 && moved == 1;
+      moved = 0;
+      int &i = s.emplace<int>(3); // arm 1: nothing relocates
+      return ok && i == 3 && moved == 0;
+    };
+    CHECK(arms());
+    static_assert(arms());
+
+    // noexcept is the first arm's, exactly
+    using T = fn::sum_for<Fragile, int>;
+    static_assert(noexcept(std::declval<T &>().emplace<int>(1)));
+    static_assert(not noexcept(std::declval<T &>().emplace<Fragile>(1, std::declval<int *>())));
+    SUCCEED();
+  }
+
+  SECTION("re-points a reference")
+  {
+    // sum<pack<int, int&>> has no assignment at all - the pack deletes it because C++ cannot
+    // rebind a reference - and emplace is the explicit spelling of that mutation
+    using P = fn::pack<int, int &>;
+    using R = sum<P>;
+    static_assert(not std::is_copy_assignable_v<R>);
+    static_assert(not std::is_move_assignable_v<R>);
+    static_assert(can_emplace<R, P, int, int &>);
+    constexpr auto repoint = [] {
+      int x = 1;
+      int y = 2;
+      R s{std::in_place_type<P>, 5, x};
+      s.emplace<P>(6, y);
+      using std::get;
+      P *p = s.get_ptr<P>();
+      return p != nullptr && &get<1>(*p) == &y && get<0>(*p) == 6;
+    };
+    CHECK(repoint());
+    static_assert(repoint());
+  }
+
+  SECTION("constraints")
+  {
+    static_assert(can_emplace<S, Sender, int>);
+    static_assert(can_emplace<S, int, int>);
+    static_assert(not can_emplace<S, double, double>);       // not an alternative
+    static_assert(not can_emplace<S, Sender, char const *>); // not makeable from the arguments
+
+    // a type that can be neither built nor moved without throwing leaves no safe arm; its
+    // sibling is not held hostage
+    struct ThrowingBoth final {
+      ThrowingBoth() = default;
+      ThrowingBoth(ThrowingBoth const &) noexcept(false) {}
+      ThrowingBoth(ThrowingBoth &&) noexcept(false) {}
+    };
+    using T = fn::sum_for<ThrowingBoth, int>;
+    static_assert(not can_emplace<T, ThrowingBoth, ThrowingBoth const &>);
+    static_assert(can_emplace<T, int, int>);
+    SUCCEED();
   }
 }


### PR DESCRIPTION
Closes #318

Assignment on `sum` and `choice` requires every alternative to be assignable and uses the alternative's own `operator=` (#311) — correct semantics that left non-assignable types with no way to change the alternative held by an existing object. Senders (`std::execution`) are the motivating example: typically not assignable yet nothrow-move-constructible, so a `sum` of senders could not be re-targeted after construction; `pack<int, int&>` deletes assignment because C++ cannot rebind a reference, leaving deliberately no mutation path at all. `emplace<T>(args...)` is the honest spelling for both: destroy-and-reconstruct requested at the call site by name, constructing a new `T` rather than claiming an assignment the type refused.

The engine already existed — `_reinit` is variadic and implements exactly the two arms, each with the strong exception guarantee and no valueless state — so `emplace` surfaces its gate: `has_type<T>`, brace-deliverability from the arguments (`_makeable`, never `is_constructible`), and a nothrow arm to deliver through. Per the issue's settled decisions: always reconstructs, also when `T` is the alternative already held (assign-when-same is `operator=`'s meaning and stays there); the constraint asks about `T` alone — no fold over sibling alternatives, since the outgoing alternative is only destroyed, and only once the replacement is certain; returns `T&`; no `initializer_list` or tag-parameter forms; no ref-qualifiers; `choice` inherits it (a named member — the name hiding that forces `choice` to restate `operator=` does not apply); `fn::optional`/`fn::expected` unchanged.

Deliberate divergences, recorded in the CHANGELOG entry: vs `std::expected::emplace`, which admits nothrow constructions only and is unconditionally `noexcept`, this admits a throwing construction through an internalized temporary and is conditionally `noexcept` — strictly wider availability, same invariant; vs `std::variant::emplace`, which is unconstrained and goes valueless when construction throws, the case with no safe arm is constrained away instead.

Tests, per the issue's list: the sender archetype pinning that the whole assignment family refuses (including #319's value form) while `emplace` serves; destroy-and-reconstruct pinned by counters (same-alternative: one construction, one destruction, `operator=` never called); arm selection pinned by counters (arm 1 relocates nothing, arm 2 exactly one nothrow move) with per-arm `noexcept` probes; `sum<pack<int, int&>>` re-pointed — element-wise, since `_makeable` asks the aggregate's brace-init — with the new referent pinned by address; constraint negatives through a named `can_emplace` concept (non-alternative, non-makeable arguments, a type failing both nothrow disjuncts with its sibling unaffected); constexpr twins throughout; and a `choice` battery witnessing the inheritance.

Verified on gcc 16 and clang 22 (libc++), Debug and Release, C++20 and C++23-validation, plus a local MSVC 2022 build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
