### PR TITLE
Add the C++26 `apply` trait family to `pfn`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 Design history of libfn, newest first. The living documents — [README.md](README.md), [CONTRIBUTING.md](CONTRIBUTING.md), [docs/](docs/) — describe only the present state of the design; when a decision makes an earlier idea obsolete, this file is where the transition is recorded and explained.
 
+## `pfn` grew the C++26 `apply` trait family — 15 July 2026
+
+- **`pfn/tuple.hpp` polyfills P1317R2** ([#325](https://github.com/libfn/functional/issues/325)): `is_applicable`/`is_nothrow_applicable`, the SFINAE-friendly `apply_result`/`apply_result_t`, and `apply` in its C++26 shape — a declared return type where C++20's deduced return is a hard error outside the immediate context, and a computed exception specification. The suite's own probes demonstrated the defect being fixed: an unqualified negative probe over std arguments finds C++20's `std::apply` through ADL and hard-errors where the C++26 shape substitutes away. Groundwork for #84: `fn`'s multidispatch verbs rename onto `std::apply`'s vocabulary, extending a conforming polyfill.
+
 ## `sum` and `choice` gained `emplace` — 15 July 2026
 
 - **`emplace<T>(args...)` is the mutation path for alternatives that do not support assignment** ([#318](https://github.com/libfn/functional/issues/318)): destroy-and-reconstruct requested at the call site by name, so senders and reference-holding packs — whose assignment `operator=` rightly refuses — can change the alternative held by an existing object again. Always reconstructs, also for the alternative already held, and the constraint asks about `T` alone: no sibling alternative is consulted. Unlike `std::expected::emplace` (nothrow constructions only, unconditionally `noexcept`) a throwing construction is admitted through an internalized temporary; unlike `std::variant::emplace` (unconstrained, valueless when construction throws) the case with no safe arm is constrained away — strong guarantee, never valueless, conditionally `noexcept`.

--- a/include/CMakeLists.txt
+++ b/include/CMakeLists.txt
@@ -13,6 +13,7 @@ set(INCLUDE_PFN_HEADERS
     pfn/expected.hpp
     pfn/functional.hpp
     pfn/optional.hpp
+    pfn/tuple.hpp
     pfn/utility.hpp
 )
 

--- a/include/pfn/tuple.hpp
+++ b/include/pfn/tuple.hpp
@@ -1,0 +1,95 @@
+// Copyright (c) 2026 Bronek Kozicki
+//
+// Distributed under the ISC License. See accompanying file LICENSE.md
+// or copy at https://opensource.org/licenses/ISC
+
+#ifndef INCLUDE_PFN_TUPLE
+#define INCLUDE_PFN_TUPLE
+
+#include <array>
+#include <complex>
+#include <cstddef>
+#include <functional>
+#include <ranges>
+#include <tuple>
+#include <type_traits>
+#include <utility>
+
+namespace pfn {
+namespace detail {
+
+// [tuple.like] is enumerative - a specialization of array, complex, pair, tuple or
+// ranges::subrange - not the tuple protocol: a user type modelling the protocol does not qualify.
+template <typename T> constexpr bool _is_tuple_like_specialization = false;
+template <typename T, ::std::size_t N> constexpr bool _is_tuple_like_specialization<::std::array<T, N>> = true;
+template <typename T> constexpr bool _is_tuple_like_specialization<::std::complex<T>> = true;
+template <typename T, typename U> constexpr bool _is_tuple_like_specialization<::std::pair<T, U>> = true;
+template <typename... Ts> constexpr bool _is_tuple_like_specialization<::std::tuple<Ts...>> = true;
+template <typename It, typename S, ::std::ranges::subrange_kind K>
+constexpr bool _is_tuple_like_specialization<::std::ranges::subrange<It, S, K>> = true;
+
+template <typename Tuple>
+concept _tuple_like = _is_tuple_like_specialization<::std::remove_cvref_t<Tuple>>;
+
+// `complex` is enumerated tuple-like, but its tuple protocol is C++26 (P2819): where the
+// underlying standard library does not provide it, the traits below answer false rather than
+// error, and open up when it appears.
+template <typename Tuple>
+constexpr bool _tuple_sized = requires { ::std::tuple_size<::std::remove_reference_t<Tuple>>::value; };
+
+template <typename Fn, typename Tuple, typename Ix> struct _apply_probe;
+template <typename Fn, typename Tuple, ::std::size_t... Ix>
+struct _apply_probe<Fn, Tuple, ::std::index_sequence<Ix...>> {
+  static constexpr bool _applicable = ::std::is_invocable_v<Fn, decltype(::std::get<Ix>(::std::declval<Tuple>()))...>;
+  static constexpr bool _nothrow
+      = ::std::is_nothrow_invocable_v<Fn, decltype(::std::get<Ix>(::std::declval<Tuple>()))...>;
+  using _apply_result = ::std::invoke_result<Fn, decltype(::std::get<Ix>(::std::declval<Tuple>()))...>;
+};
+
+template <bool, typename Fn, typename Tuple> struct _apply_gate { // not tuple-like, or protocol unavailable
+  static constexpr bool _applicable = false;
+  static constexpr bool _nothrow = false;
+  struct _apply_result {}; // no member `type`, [meta.trans.other]
+};
+template <typename Fn, typename Tuple>
+struct _apply_gate<true, Fn, Tuple>
+    : _apply_probe<Fn, Tuple, ::std::make_index_sequence<::std::tuple_size_v<::std::remove_reference_t<Tuple>>>> {};
+
+template <typename Fn, typename Tuple>
+using _apply_traits = _apply_gate<_tuple_like<Tuple> && _tuple_sized<Tuple>, Fn, Tuple>;
+
+template <typename Fn, typename Tuple, ::std::size_t... Ix>
+constexpr decltype(auto) _apply_impl(Fn &&fn, Tuple &&t, ::std::index_sequence<Ix...>) //
+    noexcept(noexcept(::std::invoke(::std::forward<Fn>(fn), ::std::get<Ix>(::std::forward<Tuple>(t))...)))
+{
+  return ::std::invoke(::std::forward<Fn>(fn), ::std::get<Ix>(::std::forward<Tuple>(t))...);
+}
+
+} // namespace detail
+
+// [meta.rel] and [meta.trans.other], as adopted for C++26 by P1317R2
+template <typename Fn, typename Tuple>
+struct is_applicable : ::std::bool_constant<detail::_apply_traits<Fn, Tuple>::_applicable> {};
+template <typename Fn, typename Tuple> constexpr inline bool is_applicable_v = is_applicable<Fn, Tuple>::value;
+
+template <typename Fn, typename Tuple>
+struct is_nothrow_applicable : ::std::bool_constant<detail::_apply_traits<Fn, Tuple>::_nothrow> {};
+template <typename Fn, typename Tuple>
+constexpr inline bool is_nothrow_applicable_v = is_nothrow_applicable<Fn, Tuple>::value;
+
+template <typename Fn, typename Tuple> struct apply_result : detail::_apply_traits<Fn, Tuple>::_apply_result {};
+template <typename Fn, typename Tuple> using apply_result_t = typename apply_result<Fn, Tuple>::type;
+
+// [tuple.apply] in its C++26 shape: the declared return type makes the overload SFINAE-friendly
+// where C++20's deduced return is a hard error outside the immediate context, and the exception
+// specification is the trait's answer.
+template <typename Fn, detail::_tuple_like Tuple>
+constexpr apply_result_t<Fn, Tuple> apply(Fn &&fn, Tuple &&t) noexcept(is_nothrow_applicable_v<Fn, Tuple>)
+{
+  return detail::_apply_impl(::std::forward<Fn>(fn), ::std::forward<Tuple>(t),
+                             ::std::make_index_sequence<::std::tuple_size_v<::std::remove_reference_t<Tuple>>>{});
+}
+
+} // namespace pfn
+
+#endif // INCLUDE_PFN_TUPLE

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -47,8 +47,10 @@ endforeach()
 set(TESTS_PFN_SOURCES
     pfn/expected.cpp
     pfn/optional.cpp
+    pfn/tuple.cpp
     pfn/expected_validation.cpp
     pfn/optional_validation.cpp
+    pfn/tuple_validation.cpp
     pfn/functional.cpp
     pfn/utility.cpp
 )

--- a/tests/pfn/tuple.cpp
+++ b/tests/pfn/tuple.cpp
@@ -1,0 +1,212 @@
+// Copyright (c) 2026 Bronek Kozicki
+//
+// Distributed under the ISC License. See accompanying file LICENSE.md
+// or copy at https://opensource.org/licenses/ISC
+
+#include "catch2/catch_test_macros.hpp"
+
+#ifndef PFN_TEST_NESTED
+
+#include <pfn/tuple.hpp>
+
+namespace subject = pfn;
+
+#endif
+// When nested via PFN_TEST_NESTED (e.g. tuple_validation.cpp), the wrapper TU already includes
+// the necessary header(s) and defines the `subject` namespace alias to select the right set of
+// entities as the subject under test. A namespace alias rather than the sibling TUs'
+// using-declarations: an unqualified `apply` on std arguments would find C++20's std::apply
+// through ADL, whose deduced return type is a hard error - not a substitution failure - for
+// every negative probe below. That is the defect P1317R2 fixes, and qualification dodges it.
+
+#include <catch2/catch_all.hpp>
+
+#include <array>
+#include <complex>
+#include <concepts>
+#include <memory>
+#include <ranges>
+#include <tuple>
+#include <type_traits>
+#include <utility>
+#include <vector>
+
+namespace {
+template <typename Fn, typename Tuple>
+concept has_apply_result = requires { typename subject::apply_result_t<Fn, Tuple>; };
+
+template <typename Fn, typename Tuple>
+concept can_apply = requires(Fn &&fn, Tuple &&t) { subject::apply(static_cast<Fn &&>(fn), static_cast<Tuple &&>(t)); };
+
+template <typename T> constexpr bool has_tuple_size = requires { std::tuple_size<T>::value; };
+
+// Models the tuple protocol without being one of [tuple.like]'s enumerated specializations:
+// the boundary witness that tuple-like is an enumeration, not the protocol.
+struct protocol_t {
+  int v;
+};
+template <std::size_t I> constexpr int get(protocol_t const &p) noexcept { return p.v; }
+} // anonymous namespace
+
+template <> struct std::tuple_size<protocol_t> : std::integral_constant<std::size_t, 1> {};
+template <> struct std::tuple_element<0, protocol_t> {
+  using type = int;
+};
+
+namespace {
+using F2 = int (*)(int, int);
+constexpr auto quiet = [](int a, int b) noexcept { return a + b; };
+constexpr auto loud = [](int a, int b) { return a + b; };
+struct rval_only_t {
+  void operator()(int &&) const noexcept;
+};
+} // anonymous namespace
+
+TEST_CASE("is_applicable", "[tuple][polyfill][is_applicable]")
+{
+  SECTION("enumerated tuple-like types")
+  {
+    static_assert(subject::is_applicable_v<F2, std::tuple<int, int>>);
+    static_assert(subject::is_applicable_v<F2, std::pair<int, int>>);
+    static_assert(subject::is_applicable_v<F2, std::array<int, 2>>);
+    static_assert(subject::is_applicable_v<F2, std::array<int, 2> const &>);
+    using sub_t = std::ranges::subrange<std::vector<int>::iterator>;
+    struct from_iters_t {
+      void operator()(std::vector<int>::iterator, std::vector<int>::iterator) const;
+    };
+    static_assert(subject::is_applicable_v<from_iters_t, sub_t>);
+
+    static_assert(not subject::is_applicable_v<F2, std::tuple<int>>);         // arity mismatch
+    static_assert(not subject::is_applicable_v<F2, std::tuple<char *, int>>); // type mismatch
+    static_assert(not subject::is_applicable_v<F2, std::array<char *, 2>>);
+    SUCCEED();
+  }
+
+  SECTION("not tuple-like")
+  {
+    static_assert(not subject::is_applicable_v<F2, int>);
+    static_assert(not subject::is_applicable_v<int (*)(), void>);
+
+    // the tuple protocol does not qualify: [tuple.like] is an enumeration
+    static_assert(has_tuple_size<protocol_t>);
+    static_assert(not subject::is_applicable_v<void (*)(int), protocol_t>);
+    SUCCEED();
+  }
+
+  SECTION("value categories")
+  {
+    // the elements carry the tuple's value category, as get does
+    static_assert(subject::is_applicable_v<rval_only_t, std::tuple<int>>);
+    static_assert(subject::is_applicable_v<rval_only_t, std::tuple<int> &&>);
+    static_assert(not subject::is_applicable_v<rval_only_t, std::tuple<int> &>);
+    static_assert(not subject::is_applicable_v<rval_only_t, std::tuple<int> const &>);
+    static_assert(not subject::is_applicable_v<rval_only_t, std::tuple<int> const &&>);
+    SUCCEED();
+  }
+
+  SECTION("complex")
+  {
+    // enumerated tuple-like, but its tuple protocol is C++26 (P2819): the trait's answer opens
+    // with the underlying standard library
+    struct f2d_t {
+      void operator()(double, double) const;
+    };
+    static_assert(subject::is_applicable_v<f2d_t, std::complex<double> &> == has_tuple_size<std::complex<double>>);
+    static_assert(not subject::is_applicable_v<F2, std::complex<double> &>); // wrong callable regardless
+    SUCCEED();
+  }
+}
+
+TEST_CASE("is_nothrow_applicable", "[tuple][polyfill][is_nothrow_applicable]")
+{
+  static_assert(subject::is_nothrow_applicable_v<decltype(quiet), std::tuple<int, int>>);
+  static_assert(not subject::is_nothrow_applicable_v<decltype(loud), std::tuple<int, int>>);
+  // false, not an error, where is_applicable is false
+  static_assert(not subject::is_nothrow_applicable_v<decltype(quiet), std::tuple<int>>);
+  static_assert(not subject::is_nothrow_applicable_v<decltype(quiet), int>);
+  SUCCEED();
+}
+
+TEST_CASE("apply_result", "[tuple][polyfill][apply_result]")
+{
+  static_assert(std::same_as<subject::apply_result_t<F2, std::tuple<int, int>>, int>);
+  static_assert(std::same_as<subject::apply_result_t<decltype(quiet), std::pair<int, int>>, int>);
+
+  struct ref_result_t {
+    int &operator()(int &) const;
+  };
+  static_assert(std::same_as<subject::apply_result_t<ref_result_t, std::tuple<int &>>, int &>);
+
+  // SFINAE-friendly: no member type, no hard error - the reason P1317R2 exists
+  static_assert(has_apply_result<F2, std::tuple<int, int>>);
+  static_assert(not has_apply_result<F2, std::tuple<int>>);
+  static_assert(not has_apply_result<F2, int>);
+  static_assert(not has_apply_result<F2, protocol_t>);
+  SUCCEED();
+}
+
+TEST_CASE("apply", "[tuple][polyfill][apply]")
+{
+  SECTION("basic")
+  {
+    CHECK(subject::apply(quiet, std::tuple{2, 3}) == 5);
+    CHECK(subject::apply(quiet, std::pair{2, 3}) == 5);
+    CHECK(subject::apply(quiet, std::array{2, 3}) == 5);
+    static_assert(subject::apply(quiet, std::tuple{2, 3}) == 5);
+    static_assert(subject::apply(quiet, std::pair{2, 3}) == 5);
+    static_assert(subject::apply(quiet, std::array{2, 3}) == 5);
+
+    constexpr auto lval = [] {
+      auto t = std::tuple{2, 3};
+      return subject::apply(quiet, t) == 5;
+    };
+    CHECK(lval());
+    static_assert(lval());
+
+    constexpr auto empty = [] { return subject::apply([]() { return 7; }, std::tuple<>{}) == 7; };
+    CHECK(empty());
+    static_assert(empty());
+  }
+
+  SECTION("value categories")
+  {
+    // a reference result refers into the tuple's element
+    constexpr auto through = [] {
+      int x = 1;
+      std::tuple<int &> t{x};
+      subject::apply([](int &r) -> int & { return r; }, t) = 7;
+      return x == 7;
+    };
+    CHECK(through());
+    static_assert(through());
+
+    // move-only elements are delivered from an rvalue tuple
+    auto q = subject::apply([](std::unique_ptr<int> &&v) { return std::move(v); },
+                            std::tuple<std::unique_ptr<int>>{std::make_unique<int>(42)});
+    CHECK(q != nullptr);
+    CHECK(*q == 42);
+  }
+
+  SECTION("subrange")
+  {
+    std::vector<int> v{1, 2, 3};
+    auto const sub = std::ranges::subrange(v.begin(), v.end());
+    CHECK(subject::apply([](auto b, auto e) { return static_cast<int>(e - b); }, sub) == 3);
+  }
+
+  SECTION("noexcept")
+  {
+    static_assert(noexcept(subject::apply(quiet, std::declval<std::tuple<int, int> &>()))); // required
+    static_assert(not noexcept(subject::apply(loud, std::declval<std::tuple<int, int> &>())));
+    SUCCEED();
+  }
+
+  SECTION("constraints")
+  {
+    static_assert(can_apply<decltype(quiet), std::tuple<int, int>>);
+    static_assert(not can_apply<decltype(quiet), std::tuple<int>>); // a substitution failure, not an error
+    static_assert(not can_apply<decltype(quiet), int>);
+    static_assert(not can_apply<decltype(quiet), protocol_t>);
+    SUCCEED();
+  }
+}

--- a/tests/pfn/tuple_validation.cpp
+++ b/tests/pfn/tuple_validation.cpp
@@ -1,0 +1,31 @@
+// Copyright (c) 2026 Bronek Kozicki
+//
+// Distributed under the ISC License. See accompanying file LICENSE.md
+// or copy at https://opensource.org/licenses/ISC
+
+#include <version>
+
+#if defined(__cpp_lib_apply) && __cpp_lib_apply >= 202603L
+
+#include <tuple>
+#include <type_traits>
+
+namespace subject = std;
+
+#define PFN_TEST_VALIDATION
+#define PFN_TEST_NESTED
+#include "tuple.cpp"
+
+#else
+
+#include "catch2/catch_test_macros.hpp"
+
+// Placeholder so the binary is not empty; Catch2 fails when no tests run. P1317R2's traits carry
+// __cpp_lib_apply 202603L; no standard library ships them yet, and the C++23 validation modes
+// never will - this activates per stdlib once a C++26 validation lane exists.
+TEST_CASE("tuple validation", "[tuple][validation]") //
+{
+  SUCCEED("tuple validation is skipped without P1317R2 library support");
+}
+
+#endif


### PR DESCRIPTION
Closes #325

C++26 removed `std::apply`'s return-type deduction (P1317R2, adopted Sofia 2025-06): `apply` is declared through the new SFINAE-friendly `apply_result_t` with `noexcept(is_nothrow_applicable_v<F, Tuple>)`, on the new trait family in [meta.trans.other] and [meta.rel]. C++20 — pfn's export surface — has none of it, and the gap sits on #84's critical path: `fn`'s multidispatch verbs rename onto `std::apply`'s vocabulary, and `fn` extends what `pfn` polyfills.

`include/pfn/tuple.hpp` provides the family, wording-faithful:
- `is_applicable` / `is_nothrow_applicable` — [meta.rel]'s conditions: `tuple-like<Tuple>` and `INVOKE` over `get<I>(declval<Tuple>())...`, so elements carry the tuple's value category;
- `apply_result` / `apply_result_t` — member `type` exactly under the same condition, no member otherwise ([meta.trans.other]);
- `apply` in the C++26 shape — the issue left this half open, and it is included as the natural completion: the declared return type is what makes the overload SFINAE-friendly, and the exception specification is the trait's answer. Trivially dropped if traits-only is preferred.
- `tuple-like` is the draft's *enumeration* (`array`, `complex`, `pair`, `tuple`, `ranges::subrange`), not the tuple protocol — a protocol-modelling user type answers false, pinned by a test witness. `complex` is handled adaptively: enumerated as tuple-like, but its tuple protocol is C++26 (P2819), so the traits answer false until the underlying standard library ships it, then open automatically.

All machinery is partial-specialization type computation (the MSVC-robust probe shape); no `FWD` macro dance — three uses of `::std::forward`.

Tests: one TEST_CASE per entity — enumeration positives/negatives with converses, the protocol-boundary witness, element value-category flow across all five cv-ref shapes of the tuple, SFINAE-friendliness pins, computed `noexcept`, and runtime+constexpr `apply` behaviour (reference results, move-only elements from rvalue tuples, empty tuple, subrange). Two war stories the suite now records: a naked requires-expression over concrete types is a hard error ([expr.prim.req]/5), and — fittingly — an unqualified negative probe over std arguments finds C++20's `std::apply` through ADL and hard-errors exactly as P1317R2's motivation describes, so the TU names its subject through a `namespace subject` alias rather than using-declarations.

The validation TU gates on `__cpp_lib_apply >= 202603L`: no installed standard library ships P1317 yet and the C++23 validation modes never will, so the std oracle is dormant by construction and activates per stdlib once a C++26 validation lane exists.

Verified on gcc 16 and clang 22 (libc++ and libstdc++), Debug and Release, C++20 and C++23-validation, plus a local MSVC 2022 build of all three new targets.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
