### PR TITLE
Rename `invoke` to `apply`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 Design history of libfn, newest first. The living documents — [README.md](README.md), [CONTRIBUTING.md](CONTRIBUTING.md), [docs/](docs/) — describe only the present state of the design; when a decision makes an earlier idea obsolete, this file is where the transition is recorded and explained.
 
+## `invoke` became `apply` — 15 July 2026
+
+- **The multidispatch verb and its whole vocabulary renamed** ([#84](https://github.com/libfn/functional/issues/84)): `fn::apply`/`apply_r`, the members on `sum`, `choice` and `pack`, the `apply_result`/`is_applicable` traits and the `applicable`/`typelist_applicable` concepts. The dispatch — unpack packs, dispatch sums, fold several operands into one — extends `std::apply`'s mechanism, not `std::invoke`'s: the implementation reaches `std::invoke` at the bottom, which is precisely why the old name overpromised. Type-indexed internals and true `std::invoke`-level names keep theirs.
+- **`fn::apply` serves `std::apply`'s own domain too**: a lone tuple-like argument unpacks through the machinery shared with `pfn::apply` (#325), so the two agree on the entire std domain by construction — and the elements are terminal: a sum element is handed over whole, never dispatched. A generic callable therefore unpacks where it used to receive the tuple whole; a callable viable only for the whole tuple is still served, and a tuple-like among further arguments still passes whole.
+
 ## `pfn` grew the C++26 `apply` trait family — 15 July 2026
 
 - **`pfn/tuple.hpp` polyfills P1317R2** ([#325](https://github.com/libfn/functional/issues/325)): `is_applicable`/`is_nothrow_applicable`, the SFINAE-friendly `apply_result`/`apply_result_t`, and `apply` in its C++26 shape — a declared return type where C++20's deduced return is a hard error outside the immediate context, and a computed exception specification. The suite's own probes demonstrated the defect being fixed: an unqualified negative probe over std arguments finds C++20's `std::apply` through ADL and hard-errors where the C++26 shape substitutes away. Groundwork for #84: `fn`'s multidispatch verbs rename onto `std::apply`'s vocabulary, extending a conforming polyfill.

--- a/examples/calculator/calculator.hpp
+++ b/examples/calculator/calculator.hpp
@@ -206,7 +206,7 @@ constexpr inline auto execute = fn::overload{
     [](auto x, Dup) -> Results { return {fn::pack<decltype(x), decltype(x)>{x, x}}; },
     [](auto, Drop) -> Results { return {fn::pack<>{}}; },
     // a Push carries a runtime Number; one more dispatch unwraps it into a raw pack
-    [](Push p) -> Results { return p.value.invoke([](auto v) -> Results { return {fn::pack<decltype(v)>{v}}; }); }};
+    [](Push p) -> Results { return p.value.apply([](auto v) -> Results { return {fn::pack<decltype(v)>{v}}; }); }};
 
 // One token = one step: look the operation up, pop as many operands as it declares (folding them and
 // the operation itself into one cartesian sum of packs), execute the matching arm, store what it returns

--- a/examples/calculator/main.cpp
+++ b/examples/calculator/main.cpp
@@ -17,13 +17,13 @@ void print(calc::Stack const &stack)
 {
   std::cout << "[";
   for (calc::Number const &n : stack)
-    n.invoke([](auto v) { std::cout << ' ' << v; });
+    n.apply([](auto v) { std::cout << ' ' << v; });
   std::cout << " ]\n";
 }
 
 void report(calc::Error const &error)
 {
-  std::cout << error.invoke( //
+  std::cout << error.apply( //
       fn::overload{[](calc::ParseError) { return "not a number or a known operation"; },
                    [](calc::StackError) { return "not enough operands on the stack"; },
                    [](calc::MathError e) {

--- a/examples/simple/main.cpp
+++ b/examples/simple/main.cpp
@@ -501,7 +501,7 @@ TEST_CASE("Demo choice and graded monad", "[choice][and_then][inspect][transform
   enum NetworkError { ConnectError, ProtocolError, Unknown };
 
   static constexpr auto convert = []<typename T>(std::in_place_type_t<T>, std::string_view v) {
-    return parse(v).invoke([](auto &&v) -> fn::expected<T, InputError> {
+    return parse(v).apply([](auto &&v) -> fn::expected<T, InputError> {
       if constexpr (std::is_same_v<std::decay_t<decltype(v)>, T>) {
         return {FWD(v)};
       } else

--- a/include/fn/and_then.hpp
+++ b/include/fn/and_then.hpp
@@ -23,32 +23,32 @@ namespace fn {
  * @tparam V The monadic type
  */
 template <typename Fn, typename V>
-concept invocable_and_then //
+concept applicable_and_then //
     = (some_expected_non_void<V> && requires(Fn &&fn, V &&v) {
         {
-          ::fn::invoke(FWD(fn), FWD(v).value())
+          ::fn::apply(FWD(fn), FWD(v).value())
         } -> same_kind<V>;
       }) || (some_expected_non_void<V> //
          && some_sum<typename ::std::remove_cvref_t<V>::error_type> && requires(Fn &&fn, V &&v) {
         {
-          ::fn::invoke(FWD(fn), FWD(v).value())
+          ::fn::apply(FWD(fn), FWD(v).value())
         } -> some_expected;
       }) || (some_expected_void<V> && requires(Fn &&fn) {
         {
-          ::fn::invoke(FWD(fn))
+          ::fn::apply(FWD(fn))
         } -> same_kind<V>;
       }) || (some_expected_void<V> //
          && some_sum<typename ::std::remove_cvref_t<V>::error_type> && requires(Fn &&fn, V &&v) {
         {
-          ::fn::invoke(FWD(fn))
+          ::fn::apply(FWD(fn))
         } -> some_expected;
       }) || (some_optional<V> && requires(Fn &&fn, V &&v) {
         {
-          ::fn::invoke(FWD(fn), FWD(v).value())
+          ::fn::apply(FWD(fn), FWD(v).value())
         } -> same_kind<V>;
       }) || (some_choice<V> && requires(Fn &&fn, V &&v) {
         {
-          ::fn::invoke(FWD(fn), FWD(v).value())
+          ::fn::apply(FWD(fn), FWD(v).value())
         } -> same_kind<V>;
       });
 
@@ -83,7 +83,7 @@ struct and_then_t::apply final {
   [[nodiscard]] constexpr auto operator()(V &&v, Fn &&fn) const //
       noexcept(noexcept(FWD(v).and_then(FWD(fn))))              //
       -> same_kind<V &&> auto
-    requires invocable_and_then<Fn &&, V &&>
+    requires applicable_and_then<Fn &&, V &&>
   {
     return FWD(v).and_then(FWD(fn));
   }

--- a/include/fn/choice.hpp
+++ b/include/fn/choice.hpp
@@ -250,14 +250,14 @@ struct choice<Ts...> : sum<Ts...> {
    * @return TODO
    */
   template <typename Fn>
-  [[nodiscard]] constexpr auto invoke(Fn &&fn) & noexcept(
-      detail::_is_nothrow_rts_invocable<
-          typename detail::_sum_invoke_result<detail::_invoke_autodetect_tag, decltype(fn), choice &>::type, Fn &&,
+  [[nodiscard]] constexpr auto apply(Fn &&fn) & noexcept(
+      detail::_is_nothrow_rts_applicable<
+          typename detail::_sum_apply_result<detail::_apply_autodetect_tag, decltype(fn), choice &>::type, Fn &&,
           choice &>)
-    requires typelist_invocable<Fn, choice &>
+    requires typelist_applicable<Fn, choice &>
   {
-    using type = detail::_sum_invoke_result<detail::_invoke_autodetect_tag, decltype(fn), choice &>::type;
-    return detail::invoke_variadic_union<type, typename _impl::data_t>(_impl::data, _impl::index, FWD(fn));
+    using type = detail::_sum_apply_result<detail::_apply_autodetect_tag, decltype(fn), choice &>::type;
+    return detail::apply_variadic_union<type, typename _impl::data_t>(_impl::data, _impl::index, FWD(fn));
   }
 
   /**
@@ -268,14 +268,14 @@ struct choice<Ts...> : sum<Ts...> {
    * @return TODO
    */
   template <typename Fn>
-  [[nodiscard]] constexpr auto invoke(Fn &&fn) const & noexcept(
-      detail::_is_nothrow_rts_invocable<
-          typename detail::_sum_invoke_result<detail::_invoke_autodetect_tag, decltype(fn), choice const &>::type,
-          Fn &&, choice const &>)
-    requires typelist_invocable<Fn, choice const &>
+  [[nodiscard]] constexpr auto apply(Fn &&fn) const & noexcept(
+      detail::_is_nothrow_rts_applicable<
+          typename detail::_sum_apply_result<detail::_apply_autodetect_tag, decltype(fn), choice const &>::type, Fn &&,
+          choice const &>)
+    requires typelist_applicable<Fn, choice const &>
   {
-    using type = detail::_sum_invoke_result<detail::_invoke_autodetect_tag, decltype(fn), choice const &>::type;
-    return detail::invoke_variadic_union<type, typename _impl::data_t>(_impl::data, _impl::index, FWD(fn));
+    using type = detail::_sum_apply_result<detail::_apply_autodetect_tag, decltype(fn), choice const &>::type;
+    return detail::apply_variadic_union<type, typename _impl::data_t>(_impl::data, _impl::index, FWD(fn));
   }
 
   /**
@@ -286,14 +286,14 @@ struct choice<Ts...> : sum<Ts...> {
    * @return TODO
    */
   template <typename Fn>
-  [[nodiscard]] constexpr auto invoke(Fn &&fn) && noexcept(
-      detail::_is_nothrow_rts_invocable<
-          typename detail::_sum_invoke_result<detail::_invoke_autodetect_tag, decltype(fn), choice &&>::type, Fn &&,
+  [[nodiscard]] constexpr auto apply(Fn &&fn) && noexcept(
+      detail::_is_nothrow_rts_applicable<
+          typename detail::_sum_apply_result<detail::_apply_autodetect_tag, decltype(fn), choice &&>::type, Fn &&,
           choice &&>)
-    requires typelist_invocable<Fn, choice &&>
+    requires typelist_applicable<Fn, choice &&>
   {
-    using type = detail::_sum_invoke_result<detail::_invoke_autodetect_tag, decltype(fn), choice &&>::type;
-    return detail::invoke_variadic_union<type, typename _impl::data_t>(::std::move(_impl::data), _impl::index, FWD(fn));
+    using type = detail::_sum_apply_result<detail::_apply_autodetect_tag, decltype(fn), choice &&>::type;
+    return detail::apply_variadic_union<type, typename _impl::data_t>(::std::move(_impl::data), _impl::index, FWD(fn));
   }
 
   /**
@@ -304,14 +304,14 @@ struct choice<Ts...> : sum<Ts...> {
    * @return TODO
    */
   template <typename Fn>
-  [[nodiscard]] constexpr auto invoke(Fn &&fn) const && noexcept(
-      detail::_is_nothrow_rts_invocable<
-          typename detail::_sum_invoke_result<detail::_invoke_autodetect_tag, decltype(fn), choice const &&>::type,
-          Fn &&, choice const &&>)
-    requires typelist_invocable<Fn, choice const &&>
+  [[nodiscard]] constexpr auto apply(Fn &&fn) const && noexcept(
+      detail::_is_nothrow_rts_applicable<
+          typename detail::_sum_apply_result<detail::_apply_autodetect_tag, decltype(fn), choice const &&>::type, Fn &&,
+          choice const &&>)
+    requires typelist_applicable<Fn, choice const &&>
   {
-    using type = detail::_sum_invoke_result<detail::_invoke_autodetect_tag, decltype(fn), choice const &&>::type;
-    return detail::invoke_variadic_union<type, typename _impl::data_t>(::std::move(_impl::data), _impl::index, FWD(fn));
+    using type = detail::_sum_apply_result<detail::_apply_autodetect_tag, decltype(fn), choice const &&>::type;
+    return detail::apply_variadic_union<type, typename _impl::data_t>(::std::move(_impl::data), _impl::index, FWD(fn));
   }
 
   /**
@@ -323,13 +323,13 @@ struct choice<Ts...> : sum<Ts...> {
    * @return TODO
    */
   template <typename T, typename Fn>
-  [[nodiscard]] constexpr auto invoke_r(Fn &&fn) & noexcept(
-      detail::_is_nothrow_rts_invocable<typename detail::_sum_invoke_result<T, decltype(fn), choice &>::type, Fn &&,
-                                        choice &>)
-    requires typelist_invocable<Fn, choice &>
+  [[nodiscard]] constexpr auto apply_r(Fn &&fn) & noexcept(
+      detail::_is_nothrow_rts_applicable<typename detail::_sum_apply_result<T, decltype(fn), choice &>::type, Fn &&,
+                                         choice &>)
+    requires typelist_applicable<Fn, choice &>
   {
-    using type = detail::_sum_invoke_result<T, decltype(fn), choice &>::type;
-    return detail::invoke_variadic_union<type, typename _impl::data_t>(_impl::data, _impl::index, FWD(fn));
+    using type = detail::_sum_apply_result<T, decltype(fn), choice &>::type;
+    return detail::apply_variadic_union<type, typename _impl::data_t>(_impl::data, _impl::index, FWD(fn));
   }
 
   /**
@@ -341,13 +341,13 @@ struct choice<Ts...> : sum<Ts...> {
    * @return TODO
    */
   template <typename T, typename Fn>
-  [[nodiscard]] constexpr auto invoke_r(Fn &&fn) const & noexcept(
-      detail::_is_nothrow_rts_invocable<typename detail::_sum_invoke_result<T, decltype(fn), choice const &>::type,
-                                        Fn &&, choice const &>)
-    requires typelist_invocable<Fn, choice const &>
+  [[nodiscard]] constexpr auto apply_r(Fn &&fn) const & noexcept(
+      detail::_is_nothrow_rts_applicable<typename detail::_sum_apply_result<T, decltype(fn), choice const &>::type,
+                                         Fn &&, choice const &>)
+    requires typelist_applicable<Fn, choice const &>
   {
-    using type = detail::_sum_invoke_result<T, decltype(fn), choice const &>::type;
-    return detail::invoke_variadic_union<type, typename _impl::data_t>(_impl::data, _impl::index, FWD(fn));
+    using type = detail::_sum_apply_result<T, decltype(fn), choice const &>::type;
+    return detail::apply_variadic_union<type, typename _impl::data_t>(_impl::data, _impl::index, FWD(fn));
   }
 
   /**
@@ -359,13 +359,13 @@ struct choice<Ts...> : sum<Ts...> {
    * @return TODO
    */
   template <typename T, typename Fn>
-  [[nodiscard]] constexpr auto invoke_r(Fn &&fn) && noexcept(
-      detail::_is_nothrow_rts_invocable<typename detail::_sum_invoke_result<T, decltype(fn), choice &&>::type, Fn &&,
-                                        choice &&>)
-    requires typelist_invocable<Fn, choice &&>
+  [[nodiscard]] constexpr auto apply_r(Fn &&fn) && noexcept(
+      detail::_is_nothrow_rts_applicable<typename detail::_sum_apply_result<T, decltype(fn), choice &&>::type, Fn &&,
+                                         choice &&>)
+    requires typelist_applicable<Fn, choice &&>
   {
-    using type = detail::_sum_invoke_result<T, decltype(fn), choice &&>::type;
-    return detail::invoke_variadic_union<type, typename _impl::data_t>(::std::move(_impl::data), _impl::index, FWD(fn));
+    using type = detail::_sum_apply_result<T, decltype(fn), choice &&>::type;
+    return detail::apply_variadic_union<type, typename _impl::data_t>(::std::move(_impl::data), _impl::index, FWD(fn));
   }
 
   /**
@@ -377,13 +377,13 @@ struct choice<Ts...> : sum<Ts...> {
    * @return TODO
    */
   template <typename T, typename Fn>
-  [[nodiscard]] constexpr auto invoke_r(Fn &&fn) const && noexcept(
-      detail::_is_nothrow_rts_invocable<typename detail::_sum_invoke_result<T, decltype(fn), choice const &&>::type,
-                                        Fn &&, choice const &&>)
-    requires typelist_invocable<Fn, choice const &&>
+  [[nodiscard]] constexpr auto apply_r(Fn &&fn) const && noexcept(
+      detail::_is_nothrow_rts_applicable<typename detail::_sum_apply_result<T, decltype(fn), choice const &&>::type,
+                                         Fn &&, choice const &&>)
+    requires typelist_applicable<Fn, choice const &&>
   {
-    using type = detail::_sum_invoke_result<T, decltype(fn), choice const &&>::type;
-    return detail::invoke_variadic_union<type, typename _impl::data_t>(::std::move(_impl::data), _impl::index, FWD(fn));
+    using type = detail::_sum_apply_result<T, decltype(fn), choice const &&>::type;
+    return detail::apply_variadic_union<type, typename _impl::data_t>(::std::move(_impl::data), _impl::index, FWD(fn));
   }
 
   // NOTE Monadic operations, only `and_then` and `transform` are supported
@@ -396,13 +396,13 @@ struct choice<Ts...> : sum<Ts...> {
    */
   template <typename Fn>
   [[nodiscard]] constexpr auto transform(Fn &&fn) & noexcept(
-      detail::_is_nothrow_rts_invocable<
-          typename detail::_sum_invoke_result<detail::_collapsing_sum_tag, decltype(fn), choice &>::type, Fn &&,
-          choice &>) -> typename detail::_sum_invoke_result<detail::_collapsing_sum_tag, Fn &&, choice &>::type
-    requires typelist_invocable<Fn, choice &>
+      detail::_is_nothrow_rts_applicable<
+          typename detail::_sum_apply_result<detail::_collapsing_sum_tag, decltype(fn), choice &>::type, Fn &&,
+          choice &>) -> typename detail::_sum_apply_result<detail::_collapsing_sum_tag, Fn &&, choice &>::type
+    requires typelist_applicable<Fn, choice &>
   {
-    using type = detail::_sum_invoke_result<detail::_collapsing_sum_tag, decltype(fn), choice &>::type;
-    return detail::invoke_variadic_union<type, typename _impl::data_t>(_impl::data, _impl::index, FWD(fn));
+    using type = detail::_sum_apply_result<detail::_collapsing_sum_tag, decltype(fn), choice &>::type;
+    return detail::apply_variadic_union<type, typename _impl::data_t>(_impl::data, _impl::index, FWD(fn));
   }
 
   /**
@@ -414,14 +414,14 @@ struct choice<Ts...> : sum<Ts...> {
    */
   template <typename Fn>
   [[nodiscard]] constexpr auto transform(Fn &&fn) const & noexcept(
-      detail::_is_nothrow_rts_invocable<
-          typename detail::_sum_invoke_result<detail::_collapsing_sum_tag, decltype(fn), choice const &>::type, Fn &&,
+      detail::_is_nothrow_rts_applicable<
+          typename detail::_sum_apply_result<detail::_collapsing_sum_tag, decltype(fn), choice const &>::type, Fn &&,
           choice const &>) ->
-      typename detail::_sum_invoke_result<detail::_collapsing_sum_tag, Fn &&, choice const &>::type
-    requires typelist_invocable<Fn, choice const &>
+      typename detail::_sum_apply_result<detail::_collapsing_sum_tag, Fn &&, choice const &>::type
+    requires typelist_applicable<Fn, choice const &>
   {
-    using type = detail::_sum_invoke_result<detail::_collapsing_sum_tag, decltype(fn), choice const &>::type;
-    return detail::invoke_variadic_union<type, typename _impl::data_t>(_impl::data, _impl::index, FWD(fn));
+    using type = detail::_sum_apply_result<detail::_collapsing_sum_tag, decltype(fn), choice const &>::type;
+    return detail::apply_variadic_union<type, typename _impl::data_t>(_impl::data, _impl::index, FWD(fn));
   }
 
   /**
@@ -433,13 +433,13 @@ struct choice<Ts...> : sum<Ts...> {
    */
   template <typename Fn>
   [[nodiscard]] constexpr auto transform(Fn &&fn) && noexcept(
-      detail::_is_nothrow_rts_invocable<
-          typename detail::_sum_invoke_result<detail::_collapsing_sum_tag, decltype(fn), choice &&>::type, Fn &&,
-          choice &&>) -> typename detail::_sum_invoke_result<detail::_collapsing_sum_tag, Fn &&, choice &&>::type
-    requires typelist_invocable<Fn, choice &&>
+      detail::_is_nothrow_rts_applicable<
+          typename detail::_sum_apply_result<detail::_collapsing_sum_tag, decltype(fn), choice &&>::type, Fn &&,
+          choice &&>) -> typename detail::_sum_apply_result<detail::_collapsing_sum_tag, Fn &&, choice &&>::type
+    requires typelist_applicable<Fn, choice &&>
   {
-    using type = detail::_sum_invoke_result<detail::_collapsing_sum_tag, decltype(fn), choice &&>::type;
-    return detail::invoke_variadic_union<type, typename _impl::data_t>(::std::move(_impl::data), _impl::index, FWD(fn));
+    using type = detail::_sum_apply_result<detail::_collapsing_sum_tag, decltype(fn), choice &&>::type;
+    return detail::apply_variadic_union<type, typename _impl::data_t>(::std::move(_impl::data), _impl::index, FWD(fn));
   }
 
   /**
@@ -451,14 +451,14 @@ struct choice<Ts...> : sum<Ts...> {
    */
   template <typename Fn>
   [[nodiscard]] constexpr auto transform(Fn &&fn) const && noexcept(
-      detail::_is_nothrow_rts_invocable<
-          typename detail::_sum_invoke_result<detail::_collapsing_sum_tag, decltype(fn), choice const &&>::type, Fn &&,
+      detail::_is_nothrow_rts_applicable<
+          typename detail::_sum_apply_result<detail::_collapsing_sum_tag, decltype(fn), choice const &&>::type, Fn &&,
           choice const &&>) ->
-      typename detail::_sum_invoke_result<detail::_collapsing_sum_tag, Fn &&, choice const &&>::type
-    requires typelist_invocable<Fn, choice const &&>
+      typename detail::_sum_apply_result<detail::_collapsing_sum_tag, Fn &&, choice const &&>::type
+    requires typelist_applicable<Fn, choice const &&>
   {
-    using type = detail::_sum_invoke_result<detail::_collapsing_sum_tag, decltype(fn), choice const &&>::type;
-    return detail::invoke_variadic_union<type, typename _impl::data_t>(::std::move(_impl::data), _impl::index, FWD(fn));
+    using type = detail::_sum_apply_result<detail::_collapsing_sum_tag, decltype(fn), choice const &&>::type;
+    return detail::apply_variadic_union<type, typename _impl::data_t>(::std::move(_impl::data), _impl::index, FWD(fn));
   }
 
   /**
@@ -469,10 +469,10 @@ struct choice<Ts...> : sum<Ts...> {
    * @return TODO
    */
   template <typename Fn>
-  constexpr auto and_then(Fn &&fn) & noexcept(noexcept(this->invoke(FWD(fn)))) -> decltype(this->invoke(FWD(fn)))
+  constexpr auto and_then(Fn &&fn) & noexcept(noexcept(this->apply(FWD(fn)))) -> decltype(this->apply(FWD(fn)))
   {
-    static_assert(some_choice<decltype(this->invoke(FWD(fn)))>);
-    return this->invoke(FWD(fn));
+    static_assert(some_choice<decltype(this->apply(FWD(fn)))>);
+    return this->apply(FWD(fn));
   }
 
   /**
@@ -483,10 +483,10 @@ struct choice<Ts...> : sum<Ts...> {
    * @return TODO
    */
   template <typename Fn>
-  constexpr auto and_then(Fn &&fn) const & noexcept(noexcept(this->invoke(FWD(fn)))) -> decltype(this->invoke(FWD(fn)))
+  constexpr auto and_then(Fn &&fn) const & noexcept(noexcept(this->apply(FWD(fn)))) -> decltype(this->apply(FWD(fn)))
   {
-    static_assert(some_choice<decltype(this->invoke(FWD(fn)))>);
-    return this->invoke(FWD(fn));
+    static_assert(some_choice<decltype(this->apply(FWD(fn)))>);
+    return this->apply(FWD(fn));
   }
 
   /**
@@ -497,11 +497,11 @@ struct choice<Ts...> : sum<Ts...> {
    * @return TODO
    */
   template <typename Fn>
-  constexpr auto and_then(Fn &&fn) && noexcept(noexcept(::std::move(*this).invoke(FWD(fn))))
-      -> decltype(::std::move(*this).invoke(FWD(fn)))
+  constexpr auto and_then(Fn &&fn) && noexcept(noexcept(::std::move(*this).apply(FWD(fn))))
+      -> decltype(::std::move(*this).apply(FWD(fn)))
   {
-    static_assert(some_choice<decltype(::std::move(*this).invoke(FWD(fn)))>);
-    return ::std::move(*this).invoke(FWD(fn));
+    static_assert(some_choice<decltype(::std::move(*this).apply(FWD(fn)))>);
+    return ::std::move(*this).apply(FWD(fn));
   }
 
   /**
@@ -512,11 +512,11 @@ struct choice<Ts...> : sum<Ts...> {
    * @return TODO
    */
   template <typename Fn>
-  constexpr auto and_then(Fn &&fn) const && noexcept(noexcept(::std::move(*this).invoke(FWD(fn))))
-      -> decltype(::std::move(*this).invoke(FWD(fn)))
+  constexpr auto and_then(Fn &&fn) const && noexcept(noexcept(::std::move(*this).apply(FWD(fn))))
+      -> decltype(::std::move(*this).apply(FWD(fn)))
   {
-    static_assert(some_choice<decltype(::std::move(*this).invoke(FWD(fn)))>);
-    return ::std::move(*this).invoke(FWD(fn));
+    static_assert(some_choice<decltype(::std::move(*this).apply(FWD(fn)))>);
+    return ::std::move(*this).apply(FWD(fn));
   }
 };
 

--- a/include/fn/detail/functional.hpp
+++ b/include/fn/detail/functional.hpp
@@ -116,14 +116,14 @@ template <typename Lh, typename Rh>
 }
 } // namespace _fold_detail
 
-namespace _invoke_detail {
+namespace _apply_detail {
 // Each overload's noexcept is the noexcept of what it does: `std::invoke` at the bottom, the pack's
-// or sum's own `invoke` when dispatching into one, and folding-then-recursing when several operands
+// or sum's own `apply` when dispatching into one, and folding-then-recursing when several operands
 // must be joined first (that fold constructs a pack, which can throw). The chain terminates because
 // every step strictly reduces the number of pack/sum operands.
 template <typename Fn, typename... Args>
   requires(not(... || (_some_pack<Args> || _some_sum<Args>))) && ::std::is_invocable_v<Fn, Args...>
-[[nodiscard]] constexpr auto invoke(Fn &&fn, Args &&...args) noexcept(::std::is_nothrow_invocable_v<Fn, Args...>)
+[[nodiscard]] constexpr auto apply(Fn &&fn, Args &&...args) noexcept(::std::is_nothrow_invocable_v<Fn, Args...>)
     -> DEDUCED_RETURN(::std::invoke(FWD(fn), FWD(args)...))
 {
   return ::std::invoke(FWD(fn), FWD(args)...);
@@ -132,33 +132,33 @@ template <typename Fn, typename... Args>
 template <typename Fn, typename Arg, typename... Args>
   requires(_some_pack<Arg> || _some_sum<Arg>)
           && ((sizeof...(Args) == 0) || (not(... || (_some_pack<Args> || _some_sum<Args>))))
-          && requires(Fn &&fn, Arg &&arg, Args &&...args) { FWD(arg).invoke(FWD(fn), FWD(args)...); }
-[[nodiscard]] constexpr auto invoke(Fn &&fn, Arg &&arg, Args &&...args) //
-    noexcept(noexcept(FWD(arg).invoke(FWD(fn), FWD(args)...))) -> DEDUCED_RETURN(FWD(arg).invoke(FWD(fn), FWD(args)...))
+          && requires(Fn &&fn, Arg &&arg, Args &&...args) { FWD(arg).apply(FWD(fn), FWD(args)...); }
+[[nodiscard]] constexpr auto apply(Fn &&fn, Arg &&arg, Args &&...args) //
+    noexcept(noexcept(FWD(arg).apply(FWD(fn), FWD(args)...))) -> DEDUCED_RETURN(FWD(arg).apply(FWD(fn), FWD(args)...))
 {
-  return FWD(arg).invoke(FWD(fn), FWD(args)...);
+  return FWD(arg).apply(FWD(fn), FWD(args)...);
 }
 
 template <typename Fn, typename Arg, typename Arg0, typename... Args>
   requires((_some_pack<Arg0> || _some_sum<Arg0>) || ... || (_some_pack<Args> || _some_sum<Args>))
           && requires(Fn &&fn, Arg &&arg, Arg0 &&arg0, Args &&...args) {
-               invoke<Fn, decltype(::fn::detail::_fold_detail::fold<Arg, Arg0>(FWD(arg), FWD(arg0))), Args...>(
+               apply<Fn, decltype(::fn::detail::_fold_detail::fold<Arg, Arg0>(FWD(arg), FWD(arg0))), Args...>(
                    FWD(fn), ::fn::detail::_fold_detail::fold<Arg, Arg0>(FWD(arg), FWD(arg0)), FWD(args)...);
              }
 // Deduced return: a trailing return type is substituted before constraints are checked, so an
 // explicit one would instantiate `fold` for non-viable candidates and static_assert (a `pack` of
 // rvalue refs). The body's `using type` alias is inlined only to dodge MSVC's body-local-alias leak.
-[[nodiscard]] constexpr auto invoke(Fn &&fn, Arg &&arg, Arg0 &&arg0, Args &&...args) //
-    noexcept(noexcept(invoke<Fn, decltype(::fn::detail::_fold_detail::fold<Arg, Arg0>(FWD(arg), FWD(arg0))), Args...>(
+[[nodiscard]] constexpr auto apply(Fn &&fn, Arg &&arg, Arg0 &&arg0, Args &&...args) //
+    noexcept(noexcept(apply<Fn, decltype(::fn::detail::_fold_detail::fold<Arg, Arg0>(FWD(arg), FWD(arg0))), Args...>(
         FWD(fn), ::fn::detail::_fold_detail::fold<Arg, Arg0>(FWD(arg), FWD(arg0)), FWD(args)...))) -> decltype(auto)
 {
-  return invoke<Fn, decltype(::fn::detail::_fold_detail::fold<Arg, Arg0>(FWD(arg), FWD(arg0))), Args...>(
+  return apply<Fn, decltype(::fn::detail::_fold_detail::fold<Arg, Arg0>(FWD(arg), FWD(arg0))), Args...>(
       FWD(fn), ::fn::detail::_fold_detail::fold<Arg, Arg0>(FWD(arg), FWD(arg0)), FWD(args)...);
 }
 
 template <typename Ret, typename Fn, typename... Args>
   requires(not(... || (_some_pack<Args> || _some_sum<Args>))) && ::std::is_invocable_r_v<Ret, Fn, Args...>
-[[nodiscard]] constexpr auto invoke_r(Fn &&fn, Args &&...args) //
+[[nodiscard]] constexpr auto apply_r(Fn &&fn, Args &&...args) //
     noexcept(::std::is_nothrow_invocable_r_v<Ret, Fn, Args...>)
         -> DEDUCED_RETURN(::pfn::invoke_r<Ret>(FWD(fn), FWD(args)...))
 {
@@ -168,177 +168,177 @@ template <typename Ret, typename Fn, typename... Args>
 template <typename Ret, typename Fn, typename Arg, typename... Args>
   requires(_some_pack<Arg> || _some_sum<Arg>)
           && ((sizeof...(Args) == 0) || (not(... || (_some_pack<Args> || _some_sum<Args>))))
-          && requires(Fn &&fn, Arg &&arg, Args &&...args) { FWD(arg).template invoke_r<Ret>(FWD(fn), FWD(args)...); }
-[[nodiscard]] constexpr auto invoke_r(Fn &&fn, Arg &&arg, Args &&...args) //
-    noexcept(noexcept(FWD(arg).template invoke_r<Ret>(FWD(fn), FWD(args)...)))
-        -> DEDUCED_RETURN(FWD(arg).template invoke_r<Ret>(FWD(fn), FWD(args)...))
+          && requires(Fn &&fn, Arg &&arg, Args &&...args) { FWD(arg).template apply_r<Ret>(FWD(fn), FWD(args)...); }
+[[nodiscard]] constexpr auto apply_r(Fn &&fn, Arg &&arg, Args &&...args) //
+    noexcept(noexcept(FWD(arg).template apply_r<Ret>(FWD(fn), FWD(args)...)))
+        -> DEDUCED_RETURN(FWD(arg).template apply_r<Ret>(FWD(fn), FWD(args)...))
 {
-  return FWD(arg).template invoke_r<Ret>(FWD(fn), FWD(args)...);
+  return FWD(arg).template apply_r<Ret>(FWD(fn), FWD(args)...);
 }
 
 template <typename Ret, typename Fn, typename Arg, typename Arg0, typename... Args>
   requires((_some_pack<Arg0> || _some_sum<Arg0>) || ... || (_some_pack<Args> || _some_sum<Args>))
           && requires(Fn &&fn, Arg &&arg, Arg0 &&arg0, Args &&...args) {
-               invoke_r<Ret, Fn, decltype(::fn::detail::_fold_detail::fold<Arg, Arg0>(FWD(arg), FWD(arg0))), Args...>(
+               apply_r<Ret, Fn, decltype(::fn::detail::_fold_detail::fold<Arg, Arg0>(FWD(arg), FWD(arg0))), Args...>(
                    FWD(fn), ::fn::detail::_fold_detail::fold<Arg, Arg0>(FWD(arg), FWD(arg0)), FWD(args)...);
              }
-// Same as the fold-recursing `invoke` above: deduced return, alias inlined.
-[[nodiscard]] constexpr auto invoke_r(Fn &&fn, Arg &&arg, Arg0 &&arg0, Args &&...args) //
+// Same as the fold-recursing `apply` above: deduced return, alias inlined.
+[[nodiscard]] constexpr auto apply_r(Fn &&fn, Arg &&arg, Arg0 &&arg0, Args &&...args) //
     noexcept(
-        noexcept(invoke_r<Ret, Fn, decltype(::fn::detail::_fold_detail::fold<Arg, Arg0>(FWD(arg), FWD(arg0))), Args...>(
+        noexcept(apply_r<Ret, Fn, decltype(::fn::detail::_fold_detail::fold<Arg, Arg0>(FWD(arg), FWD(arg0))), Args...>(
             FWD(fn), ::fn::detail::_fold_detail::fold<Arg, Arg0>(FWD(arg), FWD(arg0)), FWD(args)...))) -> decltype(auto)
 {
-  return invoke_r<Ret, Fn, decltype(::fn::detail::_fold_detail::fold<Arg, Arg0>(FWD(arg), FWD(arg0))), Args...>(
+  return apply_r<Ret, Fn, decltype(::fn::detail::_fold_detail::fold<Arg, Arg0>(FWD(arg), FWD(arg0))), Args...>(
       FWD(fn), ::fn::detail::_fold_detail::fold<Arg, Arg0>(FWD(arg), FWD(arg0)), FWD(args)...);
 }
-} // namespace _invoke_detail
+} // namespace _apply_detail
 
-// invoke_result
+// apply_result
 template <typename Fn, typename... Args>
-constexpr auto _invoke_result_result(Fn &&, Args &&...)
-    -> ::std::type_identity<decltype(_invoke_detail::invoke(::std::declval<Fn>(), ::std::declval<Args>()...))>;
-template <typename Fn, typename... Args> constexpr auto _invoke_result_result(auto &&...) -> ::std::type_identity<void>;
+constexpr auto _apply_result_result(Fn &&, Args &&...)
+    -> ::std::type_identity<decltype(_apply_detail::apply(::std::declval<Fn>(), ::std::declval<Args>()...))>;
+template <typename Fn, typename... Args> constexpr auto _apply_result_result(auto &&...) -> ::std::type_identity<void>;
 
-template <typename Fn, typename... Args> struct _invoke_result {
-  using type = decltype(_invoke_result_result<Fn, Args...>(::std::declval<Fn>(), ::std::declval<Args>()...))::type;
+template <typename Fn, typename... Args> struct _apply_result {
+  using type = decltype(_apply_result_result<Fn, Args...>(::std::declval<Fn>(), ::std::declval<Args>()...))::type;
 };
 
-// is_invocable
+// is_applicable
 template <typename Fn, typename... Args>
-constexpr auto _is_invocable_result(Fn &&, Args &&...,
-                                    ::std::type_identity<decltype(::fn::detail::_invoke_detail::invoke<Fn, Args...>(
-                                        ::std::declval<Fn>(), ::std::declval<Args>()...))> = {}) -> ::std::true_type;
-template <typename Fn, typename... Args> constexpr auto _is_invocable_result(auto &&...) -> ::std::false_type;
+constexpr auto _is_applicable_result(Fn &&, Args &&...,
+                                     ::std::type_identity<decltype(::fn::detail::_apply_detail::apply<Fn, Args...>(
+                                         ::std::declval<Fn>(), ::std::declval<Args>()...))> = {}) -> ::std::true_type;
+template <typename Fn, typename... Args> constexpr auto _is_applicable_result(auto &&...) -> ::std::false_type;
 
-template <typename Fn, typename... Args> struct _is_invocable {
+template <typename Fn, typename... Args> struct _is_applicable {
   static constexpr bool value
-      = decltype(_is_invocable_result<Fn, Args...>(::std::declval<Fn>(), ::std::declval<Args>()...))::value;
+      = decltype(_is_applicable_result<Fn, Args...>(::std::declval<Fn>(), ::std::declval<Args>()...))::value;
 };
 
-// Partial-specialization gate around `_is_invocable`: MSVC doesn't short-circuit a requires-clause
-// `&&`, so a guarded `_is_invocable<Fn, sum>` conjunct gets instantiated even when an earlier guard
+// Partial-specialization gate around `_is_applicable`: MSVC doesn't short-circuit a requires-clause
+// `&&`, so a guarded `_is_applicable<Fn, sum>` conjunct gets instantiated even when an earlier guard
 // is already false, tripping sum's uniform-result static_assert; selecting the false_type primary
 // keeps the probe out of its reach (no-op on compilers that do short-circuit).
-template <bool Enable, typename Fn, typename... Args> struct _is_invocable_if : ::std::false_type {};
-template <typename Fn, typename... Args> struct _is_invocable_if<true, Fn, Args...> : _is_invocable<Fn, Args...> {};
+template <bool Enable, typename Fn, typename... Args> struct _is_applicable_if : ::std::false_type {};
+template <typename Fn, typename... Args> struct _is_applicable_if<true, Fn, Args...> : _is_applicable<Fn, Args...> {};
 
-// is_invocable_r
+// is_applicable_r
 template <typename Ret, typename Fn, typename... Args>
-constexpr auto _is_invocable_r_result(
+constexpr auto _is_applicable_r_result(
     Fn &&, Args &&...,
-    ::std::type_identity<decltype(_invoke_detail::invoke_r<Ret>(::std::declval<Fn>(), ::std::declval<Args>()...))> = {})
+    ::std::type_identity<decltype(_apply_detail::apply_r<Ret>(::std::declval<Fn>(), ::std::declval<Args>()...))> = {})
     -> ::std::true_type;
 template <typename Ret, typename Fn, typename... Args>
-constexpr auto _is_invocable_r_result(auto &&...) -> ::std::false_type;
-template <typename Ret, typename Fn, typename... Args> struct _is_invocable_r {
+constexpr auto _is_applicable_r_result(auto &&...) -> ::std::false_type;
+template <typename Ret, typename Fn, typename... Args> struct _is_applicable_r {
   static constexpr bool value
-      = decltype(_is_invocable_r_result<Ret, Fn, Args...>(::std::declval<Fn>(), ::std::declval<Args>()...))::value;
+      = decltype(_is_applicable_r_result<Ret, Fn, Args...>(::std::declval<Fn>(), ::std::declval<Args>()...))::value;
 };
 
-// is_nothrow_invocable and is_nothrow_invocable_v. The invoke chain above carries its own spec, so
+// is_nothrow_applicable and is_nothrow_applicable_v. The apply chain above carries its own spec, so
 // the question is asked of the call itself and composes through pack and sum dispatch: the answer
 // for a sum operand is that every alternative's call is nothrow, and for a pack that the call over
 // its elements is. The bool parameter keeps the noexcept operand out of reach when the call is not
 // viable at all, where it would be ill-formed rather than false.
-template <bool Enable, typename Fn, typename... Args> struct _is_nothrow_invocable_impl : ::std::false_type {};
+template <bool Enable, typename Fn, typename... Args> struct _is_nothrow_applicable_impl : ::std::false_type {};
 template <typename Fn, typename... Args>
-struct _is_nothrow_invocable_impl<true, Fn, Args...>
-    : ::std::bool_constant<noexcept(_invoke_detail::invoke(::std::declval<Fn>(), ::std::declval<Args>()...))> {};
+struct _is_nothrow_applicable_impl<true, Fn, Args...>
+    : ::std::bool_constant<noexcept(_apply_detail::apply(::std::declval<Fn>(), ::std::declval<Args>()...))> {};
 
 template <typename Fn, typename... Args>
-struct _is_nothrow_invocable : _is_nothrow_invocable_impl<_is_invocable<Fn, Args...>::value, Fn, Args...> {};
+struct _is_nothrow_applicable : _is_nothrow_applicable_impl<_is_applicable<Fn, Args...>::value, Fn, Args...> {};
 
-// is_nothrow_invocable_r and is_nothrow_invocable_r_v
+// is_nothrow_applicable_r and is_nothrow_applicable_r_v
 template <bool Enable, typename Ret, typename Fn, typename... Args>
-struct _is_nothrow_invocable_r_impl : ::std::false_type {};
+struct _is_nothrow_applicable_r_impl : ::std::false_type {};
 template <typename Ret, typename Fn, typename... Args>
-struct _is_nothrow_invocable_r_impl<true, Ret, Fn, Args...>
-    : ::std::bool_constant<noexcept(_invoke_detail::invoke_r<Ret>(::std::declval<Fn>(), ::std::declval<Args>()...))> {};
+struct _is_nothrow_applicable_r_impl<true, Ret, Fn, Args...>
+    : ::std::bool_constant<noexcept(_apply_detail::apply_r<Ret>(::std::declval<Fn>(), ::std::declval<Args>()...))> {};
 
 template <typename Ret, typename Fn, typename... Args>
-struct _is_nothrow_invocable_r
-    : _is_nothrow_invocable_r_impl<_is_invocable_r<Ret, Fn, Args...>::value, Ret, Fn, Args...> {};
+struct _is_nothrow_applicable_r
+    : _is_nothrow_applicable_r_impl<_is_applicable_r<Ret, Fn, Args...>::value, Ret, Fn, Args...> {};
 
-// invoke
+// apply
 template <typename Fn, typename... Args>
-  requires(_is_invocable<Fn, Args...>::value)
-constexpr auto _invoke(Fn &&fn, Args &&...args) noexcept(_is_nothrow_invocable<Fn, Args...>::value)
-    -> _invoke_result<Fn, Args...>::type
+  requires(_is_applicable<Fn, Args...>::value)
+constexpr auto _apply(Fn &&fn, Args &&...args) noexcept(_is_nothrow_applicable<Fn, Args...>::value)
+    -> _apply_result<Fn, Args...>::type
 {
-  return _invoke_detail::invoke(FWD(fn), FWD(args)...);
+  return _apply_detail::apply(FWD(fn), FWD(args)...);
 }
 
-// invoke_r
+// apply_r
 template <typename Ret, typename Fn, typename... Args>
-  requires(_is_invocable_r<Ret, Fn, Args...>::value)
-constexpr auto _invoke_r(Fn &&fn, Args &&...args) noexcept(_is_nothrow_invocable_r<Ret, Fn, Args...>::value) -> Ret
+  requires(_is_applicable_r<Ret, Fn, Args...>::value)
+constexpr auto _apply_r(Fn &&fn, Args &&...args) noexcept(_is_nothrow_applicable_r<Ret, Fn, Args...>::value) -> Ret
 {
-  return _invoke_detail::invoke_r<Ret>(FWD(fn), FWD(args)...);
+  return _apply_detail::apply_r<Ret>(FWD(fn), FWD(args)...);
 }
 
-template <typename Fn, typename T, typename... Tx> constexpr inline bool _is_ts_invocable = false;
+template <typename Fn, typename T, typename... Tx> constexpr inline bool _is_ts_applicable = false;
 template <typename Fn, template <typename...> typename Tpl, typename... Ts, typename... Tx>
-constexpr inline bool _is_ts_invocable<Fn, Tpl<Ts...> &, Tx...> = (... && _is_invocable<Fn, Ts &, Tx...>::value);
+constexpr inline bool _is_ts_applicable<Fn, Tpl<Ts...> &, Tx...> = (... && _is_applicable<Fn, Ts &, Tx...>::value);
 template <typename Fn, template <typename...> typename Tpl, typename... Ts, typename... Tx>
-constexpr inline bool _is_ts_invocable<Fn, Tpl<Ts...> const &, Tx...>
-    = (... && _is_invocable<Fn, Ts const &, Tx...>::value);
+constexpr inline bool _is_ts_applicable<Fn, Tpl<Ts...> const &, Tx...>
+    = (... && _is_applicable<Fn, Ts const &, Tx...>::value);
 template <typename Fn, template <typename...> typename Tpl, typename... Ts, typename... Tx>
-constexpr inline bool _is_ts_invocable<Fn, Tpl<Ts...> &&, Tx...> = (... && _is_invocable<Fn, Ts &&, Tx...>::value);
+constexpr inline bool _is_ts_applicable<Fn, Tpl<Ts...> &&, Tx...> = (... && _is_applicable<Fn, Ts &&, Tx...>::value);
 template <typename Fn, template <typename...> typename Tpl, typename... Ts, typename... Tx>
-constexpr inline bool _is_ts_invocable<Fn, Tpl<Ts...> const &&, Tx...>
-    = (... && _is_invocable<Fn, Ts const &&, Tx...>::value);
+constexpr inline bool _is_ts_applicable<Fn, Tpl<Ts...> const &&, Tx...>
+    = (... && _is_applicable<Fn, Ts const &&, Tx...>::value);
 template <typename Fn, typename T, typename... Tx>
-concept _typelist_invocable = _is_ts_invocable<Fn, T &&, Tx...>;
+concept _typelist_applicable = _is_ts_applicable<Fn, T &&, Tx...>;
 
-template <typename R, typename Fn, typename T, typename... Tx> constexpr inline bool _is_rts_invocable = false;
+template <typename R, typename Fn, typename T, typename... Tx> constexpr inline bool _is_rts_applicable = false;
 template <typename R, typename Fn, template <typename...> typename Tpl, typename... Ts, typename... Tx>
-constexpr inline bool _is_rts_invocable<R, Fn, Tpl<Ts...> &, Tx...>
-    = (... && _is_invocable_r<R, Fn, Ts &, Tx...>::value);
+constexpr inline bool _is_rts_applicable<R, Fn, Tpl<Ts...> &, Tx...>
+    = (... && _is_applicable_r<R, Fn, Ts &, Tx...>::value);
 template <typename R, typename Fn, template <typename...> typename Tpl, typename... Ts, typename... Tx>
-constexpr inline bool _is_rts_invocable<R, Fn, Tpl<Ts...> const &, Tx...>
-    = (... && _is_invocable_r<R, Fn, Ts const &, Tx...>::value);
+constexpr inline bool _is_rts_applicable<R, Fn, Tpl<Ts...> const &, Tx...>
+    = (... && _is_applicable_r<R, Fn, Ts const &, Tx...>::value);
 template <typename R, typename Fn, template <typename...> typename Tpl, typename... Ts, typename... Tx>
-constexpr inline bool _is_rts_invocable<R, Fn, Tpl<Ts...> &&, Tx...>
-    = (... && _is_invocable_r<R, Fn, Ts &&, Tx...>::value);
+constexpr inline bool _is_rts_applicable<R, Fn, Tpl<Ts...> &&, Tx...>
+    = (... && _is_applicable_r<R, Fn, Ts &&, Tx...>::value);
 template <typename R, typename Fn, template <typename...> typename Tpl, typename... Ts, typename... Tx>
-constexpr inline bool _is_rts_invocable<R, Fn, Tpl<Ts...> const &&, Tx...>
-    = (... && _is_invocable_r<R, Fn, Ts const &&, Tx...>::value);
+constexpr inline bool _is_rts_applicable<R, Fn, Tpl<Ts...> const &&, Tx...>
+    = (... && _is_applicable_r<R, Fn, Ts const &&, Tx...>::value);
 template <typename R, typename Fn, typename T, typename... Tx>
-concept _typelist_invocable_r = _is_rts_invocable<R, Fn, T &&, Tx...>;
+concept _typelist_applicable_r = _is_rts_applicable<R, Fn, T &&, Tx...>;
 
 // Nothrow twins of the two folds above: a dispatch over a typelist can throw unless every
 // alternative's call is nothrow, since which one runs is not known until run time.
-template <typename Fn, typename T, typename... Tx> constexpr inline bool _is_nothrow_ts_invocable = false;
+template <typename Fn, typename T, typename... Tx> constexpr inline bool _is_nothrow_ts_applicable = false;
 template <typename Fn, template <typename...> typename Tpl, typename... Ts, typename... Tx>
-constexpr inline bool _is_nothrow_ts_invocable<Fn, Tpl<Ts...> &, Tx...>
-    = (... && _is_nothrow_invocable<Fn, Ts &, Tx...>::value);
+constexpr inline bool _is_nothrow_ts_applicable<Fn, Tpl<Ts...> &, Tx...>
+    = (... && _is_nothrow_applicable<Fn, Ts &, Tx...>::value);
 template <typename Fn, template <typename...> typename Tpl, typename... Ts, typename... Tx>
-constexpr inline bool _is_nothrow_ts_invocable<Fn, Tpl<Ts...> const &, Tx...>
-    = (... && _is_nothrow_invocable<Fn, Ts const &, Tx...>::value);
+constexpr inline bool _is_nothrow_ts_applicable<Fn, Tpl<Ts...> const &, Tx...>
+    = (... && _is_nothrow_applicable<Fn, Ts const &, Tx...>::value);
 template <typename Fn, template <typename...> typename Tpl, typename... Ts, typename... Tx>
-constexpr inline bool _is_nothrow_ts_invocable<Fn, Tpl<Ts...> &&, Tx...>
-    = (... && _is_nothrow_invocable<Fn, Ts &&, Tx...>::value);
+constexpr inline bool _is_nothrow_ts_applicable<Fn, Tpl<Ts...> &&, Tx...>
+    = (... && _is_nothrow_applicable<Fn, Ts &&, Tx...>::value);
 template <typename Fn, template <typename...> typename Tpl, typename... Ts, typename... Tx>
-constexpr inline bool _is_nothrow_ts_invocable<Fn, Tpl<Ts...> const &&, Tx...>
-    = (... && _is_nothrow_invocable<Fn, Ts const &&, Tx...>::value);
+constexpr inline bool _is_nothrow_ts_applicable<Fn, Tpl<Ts...> const &&, Tx...>
+    = (... && _is_nothrow_applicable<Fn, Ts const &&, Tx...>::value);
 template <typename Fn, typename T, typename... Tx>
-concept _typelist_nothrow_invocable = _is_nothrow_ts_invocable<Fn, T &&, Tx...>;
+concept _typelist_nothrow_applicable = _is_nothrow_ts_applicable<Fn, T &&, Tx...>;
 
-template <typename R, typename Fn, typename T, typename... Tx> constexpr inline bool _is_nothrow_rts_invocable = false;
+template <typename R, typename Fn, typename T, typename... Tx> constexpr inline bool _is_nothrow_rts_applicable = false;
 template <typename R, typename Fn, template <typename...> typename Tpl, typename... Ts, typename... Tx>
-constexpr inline bool _is_nothrow_rts_invocable<R, Fn, Tpl<Ts...> &, Tx...>
-    = (... && _is_nothrow_invocable_r<R, Fn, Ts &, Tx...>::value);
+constexpr inline bool _is_nothrow_rts_applicable<R, Fn, Tpl<Ts...> &, Tx...>
+    = (... && _is_nothrow_applicable_r<R, Fn, Ts &, Tx...>::value);
 template <typename R, typename Fn, template <typename...> typename Tpl, typename... Ts, typename... Tx>
-constexpr inline bool _is_nothrow_rts_invocable<R, Fn, Tpl<Ts...> const &, Tx...>
-    = (... && _is_nothrow_invocable_r<R, Fn, Ts const &, Tx...>::value);
+constexpr inline bool _is_nothrow_rts_applicable<R, Fn, Tpl<Ts...> const &, Tx...>
+    = (... && _is_nothrow_applicable_r<R, Fn, Ts const &, Tx...>::value);
 template <typename R, typename Fn, template <typename...> typename Tpl, typename... Ts, typename... Tx>
-constexpr inline bool _is_nothrow_rts_invocable<R, Fn, Tpl<Ts...> &&, Tx...>
-    = (... && _is_nothrow_invocable_r<R, Fn, Ts &&, Tx...>::value);
+constexpr inline bool _is_nothrow_rts_applicable<R, Fn, Tpl<Ts...> &&, Tx...>
+    = (... && _is_nothrow_applicable_r<R, Fn, Ts &&, Tx...>::value);
 template <typename R, typename Fn, template <typename...> typename Tpl, typename... Ts, typename... Tx>
-constexpr inline bool _is_nothrow_rts_invocable<R, Fn, Tpl<Ts...> const &&, Tx...>
-    = (... && _is_nothrow_invocable_r<R, Fn, Ts const &&, Tx...>::value);
+constexpr inline bool _is_nothrow_rts_applicable<R, Fn, Tpl<Ts...> const &&, Tx...>
+    = (... && _is_nothrow_applicable_r<R, Fn, Ts const &&, Tx...>::value);
 template <typename R, typename Fn, typename T, typename... Tx>
-concept _typelist_nothrow_invocable_r = _is_nothrow_rts_invocable<R, Fn, T &&, Tx...>;
+concept _typelist_nothrow_applicable_r = _is_nothrow_rts_applicable<R, Fn, T &&, Tx...>;
 
 } // namespace fn::detail
 

--- a/include/fn/detail/functional.hpp
+++ b/include/fn/detail/functional.hpp
@@ -11,6 +11,7 @@
 #include <fn/detail/macro_fwd.hpp>
 #include <fn/detail/meta.hpp>
 #include <pfn/functional.hpp>
+#include <pfn/tuple.hpp>
 
 #include <functional>
 #include <type_traits>
@@ -129,6 +130,21 @@ template <typename Fn, typename... Args>
   return ::std::invoke(FWD(fn), FWD(args)...);
 }
 
+// A lone tuple-like argument takes std::apply's meaning, through the machinery shared with
+// pfn::apply - so fn::apply and pfn::apply agree on the entire std domain by construction, and
+// the elements are terminal: they do not re-enter pack or sum dispatch (a sum element is handed
+// over whole). Exactly std::apply's shape - one tuple-like argument, nothing else; composition
+// with packs, sums or further arguments is not offered. Where both this and the pass-whole
+// terminal above are viable (a generic callable), this non-variadic overload wins partial
+// ordering: std::apply's meaning prevails on std::apply's own domain.
+template <typename Fn, typename Arg>
+  requires ::pfn::detail::_tuple_like<Arg> && (::pfn::is_applicable_v<Fn, Arg>)
+[[nodiscard]] constexpr auto apply(Fn &&fn, Arg &&arg) noexcept(::pfn::is_nothrow_applicable_v<Fn, Arg>)
+    -> ::pfn::apply_result_t<Fn, Arg>
+{
+  return ::pfn::apply(FWD(fn), FWD(arg));
+}
+
 template <typename Fn, typename Arg, typename... Args>
   requires(_some_pack<Arg> || _some_sum<Arg>)
           && ((sizeof...(Args) == 0) || (not(... || (_some_pack<Args> || _some_sum<Args>))))
@@ -163,6 +179,30 @@ template <typename Ret, typename Fn, typename... Args>
         -> DEDUCED_RETURN(::pfn::invoke_r<Ret>(FWD(fn), FWD(args)...))
 {
   return ::pfn::invoke_r<Ret>(FWD(fn), FWD(args)...);
+}
+
+// The tuple-like arm of apply_r, mirroring apply's: INVOKE<R> over the elements. Constrained so
+// a non-viable call is a substitution failure before the noexcept-specifier can instantiate.
+template <typename Ret, typename Fn, typename Tuple, ::std::size_t... Ix>
+  requires ::std::is_invocable_r_v<Ret, Fn, decltype(::std::get<Ix>(::std::declval<Tuple>()))...>
+constexpr Ret _apply_r_elems(Fn &&fn, Tuple &&t, ::std::index_sequence<Ix...>) //
+    noexcept(noexcept(::pfn::invoke_r<Ret>(FWD(fn), ::std::get<Ix>(FWD(t))...)))
+{
+  return ::pfn::invoke_r<Ret>(FWD(fn), ::std::get<Ix>(FWD(t))...);
+}
+
+template <typename Ret, typename Fn, typename Arg>
+  requires ::pfn::detail::_tuple_like<Arg> //
+           && requires(Fn &&fn, Arg &&arg) {
+                _apply_r_elems<Ret>(FWD(fn), FWD(arg),
+                                    ::std::make_index_sequence<::std::tuple_size_v<::std::remove_reference_t<Arg>>>{});
+              }
+[[nodiscard]] constexpr auto apply_r(Fn &&fn, Arg &&arg) //
+    noexcept(noexcept(_apply_r_elems<Ret>(
+        FWD(fn), FWD(arg), ::std::make_index_sequence<::std::tuple_size_v<::std::remove_reference_t<Arg>>>{}))) -> Ret
+{
+  return _apply_r_elems<Ret>(FWD(fn), FWD(arg),
+                             ::std::make_index_sequence<::std::tuple_size_v<::std::remove_reference_t<Arg>>>{});
 }
 
 template <typename Ret, typename Fn, typename Arg, typename... Args>

--- a/include/fn/detail/pack_impl.hpp
+++ b/include/fn/detail/pack_impl.hpp
@@ -102,21 +102,21 @@ struct pack_impl<::std::index_sequence<Is...>, Ts...> : _element<Is, Ts>... {
   template <typename Self, typename Fn, typename... Args>
     requires(not(... || (_some_pack<Args> || _some_sum<Args>)))
   static constexpr auto _invoke(Self &&self, Fn &&fn, Args &&...args) //
-      noexcept(_is_nothrow_invocable<Fn &&, apply_const_lvalue_t<Self, Ts &&>..., Args &&...>::value)
-          -> _invoke_result<Fn &&, apply_const_lvalue_t<Self, Ts &&>..., Args &&...>::type
-    requires(_is_invocable<Fn &&, apply_const_lvalue_t<Self, Ts &&>..., Args && ...>::value)
+      noexcept(_is_nothrow_applicable<Fn &&, apply_const_lvalue_t<Self, Ts &&>..., Args &&...>::value)
+          -> _apply_result<Fn &&, apply_const_lvalue_t<Self, Ts &&>..., Args &&...>::type
+    requires(_is_applicable<Fn &&, apply_const_lvalue_t<Self, Ts &&>..., Args && ...>::value)
   {
-    return ::fn::detail::_invoke(
+    return ::fn::detail::_apply(
         FWD(fn), static_cast<apply_const_lvalue_t<Self, Ts &&>>(FWD(self)._element<Is, Ts>::v)..., FWD(args)...);
   }
 
   template <typename Ret, typename Self, typename Fn, typename... Args>
     requires(not(... || (_some_pack<Args> || _some_sum<Args>)))
-  static constexpr auto _invoke_r(Self &&self, Fn &&fn, Args &&...args) //
-      noexcept(_is_nothrow_invocable_r<Ret, Fn &&, apply_const_lvalue_t<Self, Ts &&>..., Args &&...>::value) -> Ret
-    requires(_is_invocable_r<Ret, Fn &&, apply_const_lvalue_t<Self, Ts &&>..., Args && ...>::value)
+  static constexpr auto _apply_r(Self &&self, Fn &&fn, Args &&...args) //
+      noexcept(_is_nothrow_applicable_r<Ret, Fn &&, apply_const_lvalue_t<Self, Ts &&>..., Args &&...>::value) -> Ret
+    requires(_is_applicable_r<Ret, Fn &&, apply_const_lvalue_t<Self, Ts &&>..., Args && ...>::value)
   {
-    return ::fn::detail::_invoke_r<Ret>(
+    return ::fn::detail::_apply_r<Ret>(
         FWD(fn), static_cast<apply_const_lvalue_t<Self, Ts &&>>(FWD(self)._element<Is, Ts>::v)..., FWD(args)...);
   }
 

--- a/include/fn/detail/pack_impl.hpp
+++ b/include/fn/detail/pack_impl.hpp
@@ -101,7 +101,7 @@ struct pack_impl<::std::index_sequence<Is...>, Ts...> : _element<Is, Ts>... {
 
   template <typename Self, typename Fn, typename... Args>
     requires(not(... || (_some_pack<Args> || _some_sum<Args>)))
-  static constexpr auto _invoke(Self &&self, Fn &&fn, Args &&...args) //
+  static constexpr auto _apply(Self &&self, Fn &&fn, Args &&...args) //
       noexcept(_is_nothrow_applicable<Fn &&, apply_const_lvalue_t<Self, Ts &&>..., Args &&...>::value)
           -> _apply_result<Fn &&, apply_const_lvalue_t<Self, Ts &&>..., Args &&...>::type
     requires(_is_applicable<Fn &&, apply_const_lvalue_t<Self, Ts &&>..., Args && ...>::value)
@@ -160,7 +160,7 @@ struct pack_impl<::std::index_sequence<Is...>, Ts...> : _element<Is, Ts>... {
   _relocatable<decltype(other)>
   {
     using type = _pack_append<::std::remove_cvref_t<T>, Ts...>::impl;
-    return FWD(other)._invoke(FWD(other), [&self](auto &&...args) {
+    return FWD(other)._apply(FWD(other), [&self](auto &&...args) {
       return type{static_cast<apply_const_lvalue_t<Self, Ts &&>>(FWD(self)._element<Is, Ts>::v)..., FWD(args)...};
     });
   }

--- a/include/fn/detail/variadic_union.hpp
+++ b/include/fn/detail/variadic_union.hpp
@@ -40,7 +40,7 @@ template <typename T, typename Fn, typename... Args> struct _is_type_invocable {
       = decltype(_is_type_invocable_result<T, Fn, Args...>(::std::declval<Fn>(), ::std::declval<Args>()...))::value;
 };
 
-// apply_result
+// invoke_type_result
 template <typename T, typename Fn, typename... Args>
 constexpr auto _invoke_type_result_result(Fn &&, Args &&...)
     -> ::std::type_identity<decltype(_invoke_type<T>(::std::declval<Fn>(), ::std::declval<Args>()...))>;

--- a/include/fn/detail/variadic_union.hpp
+++ b/include/fn/detail/variadic_union.hpp
@@ -40,7 +40,7 @@ template <typename T, typename Fn, typename... Args> struct _is_type_invocable {
       = decltype(_is_type_invocable_result<T, Fn, Args...>(::std::declval<Fn>(), ::std::declval<Args>()...))::value;
 };
 
-// invoke_result
+// apply_result
 template <typename T, typename Fn, typename... Args>
 constexpr auto _invoke_type_result_result(Fn &&, Args &&...)
     -> ::std::type_identity<decltype(_invoke_type<T>(::std::declval<Fn>(), ::std::declval<Args>()...))>;
@@ -533,14 +533,14 @@ template <typename U, typename T, typename... Args>
 concept _nothrow_makeable = requires { requires noexcept(make_variadic_union<T, U>(::std::declval<Args>()...)); };
 
 template <typename R, typename U, typename Fn, typename... Args>
-[[nodiscard]] constexpr auto invoke_variadic_union(some_variadic_union auto &&v, ::std::size_t index, Fn &&fn,
-                                                   Args &&...args)
-  requires ::std::is_same_v<::std::remove_cvref_t<decltype(v)>, U>  //
-           && (U::size == 1) && (not ::std::is_same_v<void, R>)     //
-           && _typelist_invocable_r<R, Fn, decltype(v), Args &&...> //
+[[nodiscard]] constexpr auto apply_variadic_union(some_variadic_union auto &&v, ::std::size_t index, Fn &&fn,
+                                                  Args &&...args)
+  requires ::std::is_same_v<::std::remove_cvref_t<decltype(v)>, U>   //
+           && (U::size == 1) && (not ::std::is_same_v<void, R>)      //
+           && _typelist_applicable_r<R, Fn, decltype(v), Args &&...> //
 {
   if (index == 0)
-    return static_cast<R>(_invoke(FWD(fn), FWD(v).v0, FWD(args)...));
+    return static_cast<R>(_apply(FWD(fn), FWD(v).v0, FWD(args)...));
   ::pfn::unreachable(); // LCOV_EXCL_LINE
 }
 
@@ -560,13 +560,13 @@ template <typename R, typename U, typename Fn>
 }
 
 template <typename R, typename U, typename Fn, typename... Args>
-constexpr void invoke_variadic_union(some_variadic_union auto &&v, ::std::size_t index, Fn &&fn, Args &&...args)
+constexpr void apply_variadic_union(some_variadic_union auto &&v, ::std::size_t index, Fn &&fn, Args &&...args)
   requires ::std::is_same_v<::std::remove_cvref_t<decltype(v)>, U> //
            && (U::size == 1) && (::std::is_same_v<void, R>)        //
-           && _typelist_invocable<Fn, decltype(v), Args &&...>     //
+           && _typelist_applicable<Fn, decltype(v), Args &&...>    //
 {
   if (index == 0)
-    return (void)_invoke(FWD(fn), FWD(v).v0, FWD(args)...);
+    return (void)_apply(FWD(fn), FWD(v).v0, FWD(args)...);
   ::pfn::unreachable(); // LCOV_EXCL_LINE
 }
 
@@ -582,16 +582,16 @@ constexpr void invoke_type_variadic_union(some_variadic_union auto &&v, ::std::s
 }
 
 template <typename R, typename U, typename Fn, typename... Args>
-[[nodiscard]] constexpr auto invoke_variadic_union(some_variadic_union auto &&v, ::std::size_t index, Fn &&fn,
-                                                   Args &&...args)
-  requires ::std::is_same_v<::std::remove_cvref_t<decltype(v)>, U>  //
-           && (U::size == 2) && (not ::std::is_same_v<void, R>)     //
-           && _typelist_invocable_r<R, Fn, decltype(v), Args &&...> //
+[[nodiscard]] constexpr auto apply_variadic_union(some_variadic_union auto &&v, ::std::size_t index, Fn &&fn,
+                                                  Args &&...args)
+  requires ::std::is_same_v<::std::remove_cvref_t<decltype(v)>, U>   //
+           && (U::size == 2) && (not ::std::is_same_v<void, R>)      //
+           && _typelist_applicable_r<R, Fn, decltype(v), Args &&...> //
 {
   if (index == 0)
-    return static_cast<R>(_invoke(FWD(fn), FWD(v).v0, FWD(args)...));
+    return static_cast<R>(_apply(FWD(fn), FWD(v).v0, FWD(args)...));
   else if (index == 1)
-    return static_cast<R>(_invoke(FWD(fn), FWD(v).v1, FWD(args)...));
+    return static_cast<R>(_apply(FWD(fn), FWD(v).v1, FWD(args)...));
   ::pfn::unreachable(); // LCOV_EXCL_LINE
 }
 
@@ -609,15 +609,15 @@ template <typename R, typename U, typename Fn>
 }
 
 template <typename R, typename U, typename Fn, typename... Args>
-constexpr void invoke_variadic_union(some_variadic_union auto &&v, ::std::size_t index, Fn &&fn, Args &&...args)
+constexpr void apply_variadic_union(some_variadic_union auto &&v, ::std::size_t index, Fn &&fn, Args &&...args)
   requires ::std::is_same_v<::std::remove_cvref_t<decltype(v)>, U> //
            && (U::size == 2) && (::std::is_same_v<void, R>)        //
-           && _typelist_invocable<Fn, decltype(v), Args &&...>     //
+           && _typelist_applicable<Fn, decltype(v), Args &&...>    //
 {
   if (index == 0)
-    return (void)_invoke(FWD(fn), FWD(v).v0, FWD(args)...);
+    return (void)_apply(FWD(fn), FWD(v).v0, FWD(args)...);
   else if (index == 1)
-    return (void)_invoke(FWD(fn), FWD(v).v1, FWD(args)...);
+    return (void)_apply(FWD(fn), FWD(v).v1, FWD(args)...);
   ::pfn::unreachable(); // LCOV_EXCL_LINE
 }
 
@@ -635,18 +635,18 @@ constexpr void invoke_type_variadic_union(some_variadic_union auto &&v, ::std::s
 }
 
 template <typename R, typename U, typename Fn, typename... Args>
-[[nodiscard]] constexpr auto invoke_variadic_union(some_variadic_union auto &&v, ::std::size_t index, Fn &&fn,
-                                                   Args &&...args)
-  requires ::std::is_same_v<::std::remove_cvref_t<decltype(v)>, U>  //
-           && (U::size == 3) && (not ::std::is_same_v<void, R>)     //
-           && _typelist_invocable_r<R, Fn, decltype(v), Args &&...> //
+[[nodiscard]] constexpr auto apply_variadic_union(some_variadic_union auto &&v, ::std::size_t index, Fn &&fn,
+                                                  Args &&...args)
+  requires ::std::is_same_v<::std::remove_cvref_t<decltype(v)>, U>   //
+           && (U::size == 3) && (not ::std::is_same_v<void, R>)      //
+           && _typelist_applicable_r<R, Fn, decltype(v), Args &&...> //
 {
   if (index == 0)
-    return static_cast<R>(_invoke(FWD(fn), FWD(v).v0, FWD(args)...));
+    return static_cast<R>(_apply(FWD(fn), FWD(v).v0, FWD(args)...));
   else if (index == 1)
-    return static_cast<R>(_invoke(FWD(fn), FWD(v).v1, FWD(args)...));
+    return static_cast<R>(_apply(FWD(fn), FWD(v).v1, FWD(args)...));
   else if (index == 2)
-    return static_cast<R>(_invoke(FWD(fn), FWD(v).v2, FWD(args)...));
+    return static_cast<R>(_apply(FWD(fn), FWD(v).v2, FWD(args)...));
   ::pfn::unreachable(); // LCOV_EXCL_LINE
 }
 
@@ -666,17 +666,17 @@ template <typename R, typename U, typename Fn>
 }
 
 template <typename R, typename U, typename Fn, typename... Args>
-constexpr void invoke_variadic_union(some_variadic_union auto &&v, ::std::size_t index, Fn &&fn, Args &&...args)
+constexpr void apply_variadic_union(some_variadic_union auto &&v, ::std::size_t index, Fn &&fn, Args &&...args)
   requires ::std::is_same_v<::std::remove_cvref_t<decltype(v)>, U> //
            && (U::size == 3) && (::std::is_same_v<void, R>)        //
-           && _typelist_invocable<Fn, decltype(v), Args &&...>     //
+           && _typelist_applicable<Fn, decltype(v), Args &&...>    //
 {
   if (index == 0)
-    return (void)_invoke(FWD(fn), FWD(v).v0, FWD(args)...);
+    return (void)_apply(FWD(fn), FWD(v).v0, FWD(args)...);
   else if (index == 1)
-    return (void)_invoke(FWD(fn), FWD(v).v1, FWD(args)...);
+    return (void)_apply(FWD(fn), FWD(v).v1, FWD(args)...);
   else if (index == 2)
-    return (void)_invoke(FWD(fn), FWD(v).v2, FWD(args)...);
+    return (void)_apply(FWD(fn), FWD(v).v2, FWD(args)...);
   ::pfn::unreachable(); // LCOV_EXCL_LINE
 }
 
@@ -696,20 +696,20 @@ constexpr void invoke_type_variadic_union(some_variadic_union auto &&v, ::std::s
 }
 
 template <typename R, typename U, typename Fn, typename... Args>
-[[nodiscard]] constexpr auto invoke_variadic_union(some_variadic_union auto &&v, ::std::size_t index, Fn &&fn,
-                                                   Args &&...args)
-  requires ::std::is_same_v<::std::remove_cvref_t<decltype(v)>, U>  //
-           && (U::size == 4) && (not ::std::is_same_v<void, R>)     //
-           && _typelist_invocable_r<R, Fn, decltype(v), Args &&...> //
+[[nodiscard]] constexpr auto apply_variadic_union(some_variadic_union auto &&v, ::std::size_t index, Fn &&fn,
+                                                  Args &&...args)
+  requires ::std::is_same_v<::std::remove_cvref_t<decltype(v)>, U>   //
+           && (U::size == 4) && (not ::std::is_same_v<void, R>)      //
+           && _typelist_applicable_r<R, Fn, decltype(v), Args &&...> //
 {
   if (index == 0)
-    return static_cast<R>(_invoke(FWD(fn), FWD(v).v0, FWD(args)...));
+    return static_cast<R>(_apply(FWD(fn), FWD(v).v0, FWD(args)...));
   else if (index == 1)
-    return static_cast<R>(_invoke(FWD(fn), FWD(v).v1, FWD(args)...));
+    return static_cast<R>(_apply(FWD(fn), FWD(v).v1, FWD(args)...));
   else if (index == 2)
-    return static_cast<R>(_invoke(FWD(fn), FWD(v).v2, FWD(args)...));
+    return static_cast<R>(_apply(FWD(fn), FWD(v).v2, FWD(args)...));
   else if (index == 3)
-    return static_cast<R>(_invoke(FWD(fn), FWD(v).v3, FWD(args)...));
+    return static_cast<R>(_apply(FWD(fn), FWD(v).v3, FWD(args)...));
   ::pfn::unreachable(); // LCOV_EXCL_LINE
 }
 
@@ -731,19 +731,19 @@ template <typename R, typename U, typename Fn>
 }
 
 template <typename R, typename U, typename Fn, typename... Args>
-constexpr void invoke_variadic_union(some_variadic_union auto &&v, ::std::size_t index, Fn &&fn, Args &&...args)
+constexpr void apply_variadic_union(some_variadic_union auto &&v, ::std::size_t index, Fn &&fn, Args &&...args)
   requires ::std::is_same_v<::std::remove_cvref_t<decltype(v)>, U> //
            && (U::size == 4) && (::std::is_same_v<void, R>)        //
-           && _typelist_invocable<Fn, decltype(v), Args &&...>     //
+           && _typelist_applicable<Fn, decltype(v), Args &&...>    //
 {
   if (index == 0)
-    return (void)_invoke(FWD(fn), FWD(v).v0, FWD(args)...);
+    return (void)_apply(FWD(fn), FWD(v).v0, FWD(args)...);
   else if (index == 1)
-    return (void)_invoke(FWD(fn), FWD(v).v1, FWD(args)...);
+    return (void)_apply(FWD(fn), FWD(v).v1, FWD(args)...);
   else if (index == 2)
-    return (void)_invoke(FWD(fn), FWD(v).v2, FWD(args)...);
+    return (void)_apply(FWD(fn), FWD(v).v2, FWD(args)...);
   else if (index == 3)
-    return (void)_invoke(FWD(fn), FWD(v).v3, FWD(args)...);
+    return (void)_apply(FWD(fn), FWD(v).v3, FWD(args)...);
   ::pfn::unreachable(); // LCOV_EXCL_LINE
 }
 
@@ -765,22 +765,22 @@ constexpr void invoke_type_variadic_union(some_variadic_union auto &&v, ::std::s
 }
 
 template <typename R, typename U, typename Fn, typename... Args>
-[[nodiscard]] constexpr auto invoke_variadic_union(some_variadic_union auto &&v, ::std::size_t index, Fn &&fn,
-                                                   Args &&...args)
-  requires ::std::is_same_v<::std::remove_cvref_t<decltype(v)>, U>  //
-           && (U::size > 4) && (not ::std::is_same_v<void, R>)      //
-           && _typelist_invocable_r<R, Fn, decltype(v), Args &&...> //
+[[nodiscard]] constexpr auto apply_variadic_union(some_variadic_union auto &&v, ::std::size_t index, Fn &&fn,
+                                                  Args &&...args)
+  requires ::std::is_same_v<::std::remove_cvref_t<decltype(v)>, U>   //
+           && (U::size > 4) && (not ::std::is_same_v<void, R>)       //
+           && _typelist_applicable_r<R, Fn, decltype(v), Args &&...> //
 {
   if (index == 0)
-    return static_cast<R>(_invoke(FWD(fn), FWD(v).v0, FWD(args)...));
+    return static_cast<R>(_apply(FWD(fn), FWD(v).v0, FWD(args)...));
   else if (index == 1)
-    return static_cast<R>(_invoke(FWD(fn), FWD(v).v1, FWD(args)...));
+    return static_cast<R>(_apply(FWD(fn), FWD(v).v1, FWD(args)...));
   else if (index == 2)
-    return static_cast<R>(_invoke(FWD(fn), FWD(v).v2, FWD(args)...));
+    return static_cast<R>(_apply(FWD(fn), FWD(v).v2, FWD(args)...));
   else if (index == 3)
-    return static_cast<R>(_invoke(FWD(fn), FWD(v).v3, FWD(args)...));
+    return static_cast<R>(_apply(FWD(fn), FWD(v).v3, FWD(args)...));
   else
-    return invoke_variadic_union<R, typename U::more_t>(FWD(v).more, index - 4, FWD(fn), FWD(args)...);
+    return apply_variadic_union<R, typename U::more_t>(FWD(v).more, index - 4, FWD(fn), FWD(args)...);
 }
 
 template <typename R, typename U, typename Fn>
@@ -802,21 +802,21 @@ template <typename R, typename U, typename Fn>
 }
 
 template <typename R, typename U, typename Fn, typename... Args>
-constexpr void invoke_variadic_union(some_variadic_union auto &&v, ::std::size_t index, Fn &&fn, Args &&...args)
+constexpr void apply_variadic_union(some_variadic_union auto &&v, ::std::size_t index, Fn &&fn, Args &&...args)
   requires ::std::is_same_v<::std::remove_cvref_t<decltype(v)>, U> //
            && (U::size > 4) && (::std::is_same_v<void, R>)         //
-           && _typelist_invocable<Fn, decltype(v), Args &&...>     //
+           && _typelist_applicable<Fn, decltype(v), Args &&...>    //
 {
   if (index == 0)
-    return (void)_invoke(FWD(fn), FWD(v).v0, FWD(args)...);
+    return (void)_apply(FWD(fn), FWD(v).v0, FWD(args)...);
   else if (index == 1)
-    return (void)_invoke(FWD(fn), FWD(v).v1, FWD(args)...);
+    return (void)_apply(FWD(fn), FWD(v).v1, FWD(args)...);
   else if (index == 2)
-    return (void)_invoke(FWD(fn), FWD(v).v2, FWD(args)...);
+    return (void)_apply(FWD(fn), FWD(v).v2, FWD(args)...);
   else if (index == 3)
-    return (void)_invoke(FWD(fn), FWD(v).v3, FWD(args)...);
+    return (void)_apply(FWD(fn), FWD(v).v3, FWD(args)...);
   else
-    return invoke_variadic_union<R, typename U::more_t>(FWD(v).more, index - 4, FWD(fn), FWD(args)...);
+    return apply_variadic_union<R, typename U::more_t>(FWD(v).more, index - 4, FWD(fn), FWD(args)...);
 }
 
 template <typename R, typename U, typename Fn>

--- a/include/fn/expected.hpp
+++ b/include/fn/expected.hpp
@@ -149,9 +149,9 @@ struct _nothrow_or_else<T, Fn, ErrArg, ValArg> {
 // that materialise their result via `expected_policy::template type<U, G>`.
 // The transform/transform_error helpers hand pfn's _expected_from_invoke constructors a
 // zero-argument thunk, so the result's member is direct-non-list-initialized from fn's own
-// _invoke (or sum::transform) result: no extra move, and immovable result types work.
+// _apply (or sum::transform) result: no extra move, and immovable result types work.
 // The statics carry the same extension noexcept as pfn's, computed through fn's own machinery: the
-// callback of a sum/pack dispatch is invoked through `_invoke`, not called directly, so it is
+// callback of a sum/pack dispatch is invoked through `_apply`, not called directly, so it is
 // `_is_nothrow_applicable` - not the std trait, which is false for a callable that is not directly
 // applicable on a sum or a pack - that answers for it, and the widening arms are weighed by the
 // traits above.

--- a/include/fn/expected.hpp
+++ b/include/fn/expected.hpp
@@ -85,28 +85,28 @@ constexpr inline bool _nothrow_carry_value<Type, Src> = _nothrow_initializable<T
 template <typename E, typename Fn, typename ErrArg, typename... ValArg> struct _nothrow_and_then : ::std::false_type {};
 
 template <typename E, typename Fn, typename ErrArg, typename... ValArg>
-  requires _is_some_expected<::std::remove_cvref_t<typename _invoke_result<Fn, ValArg...>::type> &>
-           && ::std::is_same_v<typename _expected_types<
-                                   ::std::remove_cvref_t<typename _invoke_result<Fn, ValArg...>::type>>::error_type,
-                               E>
+  requires _is_some_expected<::std::remove_cvref_t<typename _apply_result<Fn, ValArg...>::type> &>
+           && ::std::is_same_v<
+               typename _expected_types<::std::remove_cvref_t<typename _apply_result<Fn, ValArg...>::type>>::error_type,
+               E>
 struct _nothrow_and_then<E, Fn, ErrArg, ValArg...>
     : ::std::bool_constant<
-          _is_nothrow_invocable<Fn, ValArg...>::value // the callback
-              && ::std::is_nothrow_constructible_v<::std::remove_cvref_t<typename _invoke_result<Fn, ValArg...>::type>,
+          _is_nothrow_applicable<Fn, ValArg...>::value // the callback
+              && ::std::is_nothrow_constructible_v<::std::remove_cvref_t<typename _apply_result<Fn, ValArg...>::type>,
                                                    ::fn::unexpect_t, ErrArg>> {}; // lifting self's error
 
 template <typename E, typename Fn, typename ErrArg, typename... ValArg>
-  requires _is_some_expected<::std::remove_cvref_t<typename _invoke_result<Fn, ValArg...>::type> &>
-           && (not ::std::is_same_v<typename _expected_types<::std::remove_cvref_t<
-                                        typename _invoke_result<Fn, ValArg...>::type>>::error_type,
-                                    E>)
+  requires _is_some_expected<::std::remove_cvref_t<typename _apply_result<Fn, ValArg...>::type> &>
+           && (not ::std::is_same_v<
+               typename _expected_types<::std::remove_cvref_t<typename _apply_result<Fn, ValArg...>::type>>::error_type,
+               E>)
 struct _nothrow_and_then<E, Fn, ErrArg, ValArg...> {
-  using type = ::std::remove_cvref_t<typename _invoke_result<Fn, ValArg...>::type>;
+  using type = ::std::remove_cvref_t<typename _apply_result<Fn, ValArg...>::type>;
   using new_type = ::fn::expected<typename type::value_type, sum_for<E, typename type::error_type>>;
 
   static constexpr bool value
-      = _is_nothrow_invocable<Fn, ValArg...>::value // the callback
-        && _nothrow_carry_value<new_type, type>     // carrying its value across
+      = _is_nothrow_applicable<Fn, ValArg...>::value // the callback
+        && _nothrow_carry_value<new_type, type>      // carrying its value across
         && _nothrow_initializable<new_type, ::fn::unexpect_t,
                                   decltype(::std::declval<type>().error())> // widening its error
         && _nothrow_error_arm<E, new_type, ::fn::unexpect_t, ErrArg>;       // widening self's error
@@ -117,28 +117,27 @@ struct _nothrow_and_then<E, Fn, ErrArg, ValArg...> {
 template <typename T, typename Fn, typename ErrArg, typename ValArg> struct _nothrow_or_else : ::std::false_type {};
 
 template <typename T, typename Fn, typename ErrArg, typename ValArg>
-  requires _is_some_expected<::std::remove_cvref_t<typename _invoke_result<Fn, ErrArg>::type> &>
+  requires _is_some_expected<::std::remove_cvref_t<typename _apply_result<Fn, ErrArg>::type> &>
            && ::std::is_same_v<
-               typename _expected_types<::std::remove_cvref_t<typename _invoke_result<Fn, ErrArg>::type>>::value_type,
-               T>
+               typename _expected_types<::std::remove_cvref_t<typename _apply_result<Fn, ErrArg>::type>>::value_type, T>
 struct _nothrow_or_else<T, Fn, ErrArg, ValArg>
     : ::std::bool_constant<
-          _is_nothrow_invocable<Fn, ErrArg>::value // the callback
+          _is_nothrow_applicable<Fn, ErrArg>::value // the callback
           && (::std::is_void_v<T>
-              || _nothrow_initializable<::std::remove_cvref_t<typename _invoke_result<Fn, ErrArg>::type>,
+              || _nothrow_initializable<::std::remove_cvref_t<typename _apply_result<Fn, ErrArg>::type>,
                                         ::std::in_place_t, ValArg>)> {}; // carrying self's value
 
 template <typename T, typename Fn, typename ErrArg, typename ValArg>
-  requires _is_some_expected<::std::remove_cvref_t<typename _invoke_result<Fn, ErrArg>::type> &>
+  requires _is_some_expected<::std::remove_cvref_t<typename _apply_result<Fn, ErrArg>::type> &>
            && (not ::std::is_same_v<
-               typename _expected_types<::std::remove_cvref_t<typename _invoke_result<Fn, ErrArg>::type>>::value_type,
+               typename _expected_types<::std::remove_cvref_t<typename _apply_result<Fn, ErrArg>::type>>::value_type,
                T>)
 struct _nothrow_or_else<T, Fn, ErrArg, ValArg> {
-  using type = ::std::remove_cvref_t<typename _invoke_result<Fn, ErrArg>::type>;
+  using type = ::std::remove_cvref_t<typename _apply_result<Fn, ErrArg>::type>;
   using new_type = ::fn::expected<sum_for<T, typename type::value_type>, typename type::error_type>;
 
   static constexpr bool value
-      = _is_nothrow_invocable<Fn, ErrArg>::value                       // the callback
+      = _is_nothrow_applicable<Fn, ErrArg>::value                      // the callback
         && _nothrow_initializable<new_type, ::std::in_place_t, ValArg> // widening self's value
         && _nothrow_carry_value<new_type, type>                        // widening its value
         && _nothrow_initializable<new_type, ::fn::unexpect_t,
@@ -153,8 +152,8 @@ struct _nothrow_or_else<T, Fn, ErrArg, ValArg> {
 // _invoke (or sum::transform) result: no extra move, and immovable result types work.
 // The statics carry the same extension noexcept as pfn's, computed through fn's own machinery: the
 // callback of a sum/pack dispatch is invoked through `_invoke`, not called directly, so it is
-// `_is_nothrow_invocable` - not the std trait, which is false for a callable that is not directly
-// invocable on a sum or a pack - that answers for it, and the widening arms are weighed by the
+// `_is_nothrow_applicable` - not the std trait, which is false for a callable that is not directly
+// applicable on a sum or a pack - that answers for it, and the widening arms are weighed by the
 // traits above.
 template <typename T, typename E> struct _expected_base : ::pfn::detail::_expected_base<T, E, expected_policy> {
   using _pfn_base = ::pfn::detail::_expected_base<T, E, expected_policy>;
@@ -165,22 +164,22 @@ template <typename T, typename E> struct _expected_base : ::pfn::detail::_expect
   static constexpr auto _and_then(Self &&self, Fn &&fn) //
       noexcept(::fn::detail::_nothrow_and_then<E, Fn, decltype(_pfn_base::_error(FWD(self))),
                                                decltype(_pfn_base::_value(FWD(self)))>::value) // extension
-    requires(not ::std::is_void_v<T>) && ::fn::detail::_is_invocable<Fn, decltype(_pfn_base::_value(FWD(self)))>::value
+    requires(not ::std::is_void_v<T>) && ::fn::detail::_is_applicable<Fn, decltype(_pfn_base::_value(FWD(self)))>::value
             && ::std::is_constructible_v<E, decltype(_pfn_base::_error(FWD(self)))>
   {
-    using type = typename ::fn::detail::_invoke_result<Fn, decltype(_pfn_base::_value(FWD(self)))>::type;
+    using type = typename ::fn::detail::_apply_result<Fn, decltype(_pfn_base::_value(FWD(self)))>::type;
     static_assert(_is_some_expected<type &>);
     static_assert(::std::is_same_v<typename type::error_type, E> || some_sum<E>);
     if constexpr (::std::is_same_v<typename type::error_type, E>) {
       if (self.has_value())
-        return ::fn::detail::_invoke(FWD(fn), _pfn_base::_value(FWD(self)));
+        return ::fn::detail::_apply(FWD(fn), _pfn_base::_value(FWD(self)));
       else
         return type(::fn::unexpect, _pfn_base::_error(FWD(self)));
     } else {
       using new_error_type = sum_for<E, typename type::error_type>;
       using new_type = ::fn::expected<typename type::value_type, new_error_type>;
       if (self.has_value()) {
-        auto t = ::fn::detail::_invoke(FWD(fn), _pfn_base::_value(FWD(self)));
+        auto t = ::fn::detail::_apply(FWD(fn), _pfn_base::_value(FWD(self)));
         if (t.has_value())
           if constexpr (not ::std::is_void_v<typename new_type::value_type>)
             return new_type{::std::in_place, ::std::move(t).value()};
@@ -201,22 +200,22 @@ template <typename T, typename E> struct _expected_base : ::pfn::detail::_expect
   template <typename Self, typename Fn>
   static constexpr auto _and_then(Self &&self, Fn &&fn)                                               //
       noexcept(::fn::detail::_nothrow_and_then<E, Fn, decltype(_pfn_base::_error(FWD(self)))>::value) // extension
-    requires(::std::is_void_v<T>) && ::fn::detail::_is_invocable<Fn>::value
+    requires(::std::is_void_v<T>) && ::fn::detail::_is_applicable<Fn>::value
             && ::std::is_constructible_v<E, decltype(_pfn_base::_error(FWD(self)))>
   {
-    using type = typename ::fn::detail::_invoke_result<Fn>::type;
+    using type = typename ::fn::detail::_apply_result<Fn>::type;
     static_assert(_is_some_expected<type &>);
     static_assert(::std::is_same_v<typename type::error_type, E> || some_sum<E>);
     if constexpr (::std::is_same_v<typename type::error_type, E>) {
       if (self.has_value())
-        return ::fn::detail::_invoke(FWD(fn));
+        return ::fn::detail::_apply(FWD(fn));
       else
         return type(::fn::unexpect, _pfn_base::_error(FWD(self)));
     } else {
       using new_error_type = sum_for<E, typename type::error_type>;
       using new_type = ::fn::expected<typename type::value_type, new_error_type>;
       if (self.has_value()) {
-        auto t = ::fn::detail::_invoke(FWD(fn));
+        auto t = ::fn::detail::_apply(FWD(fn));
         if (t.has_value())
           if constexpr (not ::std::is_void_v<typename new_type::value_type>)
             return new_type{::std::in_place, ::std::move(t).value()};
@@ -241,10 +240,10 @@ template <typename T, typename E> struct _expected_base : ::pfn::detail::_expect
   static constexpr auto _or_else(Self &&self, Fn &&fn) //
       noexcept(::fn::detail::_nothrow_or_else<T, Fn, decltype(_pfn_base::_error(FWD(self))),
                                               ::fn::apply_const_lvalue_t<Self, typename _pfn_base::_value_t &&>>::value)
-    requires ::fn::detail::_is_invocable<Fn, decltype(_pfn_base::_error(FWD(self)))>::value
+    requires ::fn::detail::_is_applicable<Fn, decltype(_pfn_base::_error(FWD(self)))>::value
              && (::std::is_void_v<T> || ::std::is_constructible_v<T, decltype(_pfn_base::_value(FWD(self)))>)
   {
-    using type = typename ::fn::detail::_invoke_result<Fn, decltype(_pfn_base::_error(FWD(self)))>::type;
+    using type = typename ::fn::detail::_apply_result<Fn, decltype(_pfn_base::_error(FWD(self)))>::type;
     static_assert(_is_some_expected<type &>);
     static_assert(::std::is_same_v<typename type::value_type, T> || some_sum<T>);
     if constexpr (::std::is_same_v<typename type::value_type, T>) {
@@ -268,7 +267,7 @@ template <typename T, typename E> struct _expected_base : ::pfn::detail::_expect
 #endif
         }
       else
-        return ::fn::detail::_invoke(FWD(fn), _pfn_base::_error(FWD(self)));
+        return ::fn::detail::_apply(FWD(fn), _pfn_base::_error(FWD(self)));
     } else {
       static_assert(not ::std::is_void_v<typename type::value_type>);
       using new_value_type = sum_for<T, typename type::value_type>;
@@ -276,7 +275,7 @@ template <typename T, typename E> struct _expected_base : ::pfn::detail::_expect
       if (self.has_value())
         return new_type{::std::in_place, _pfn_base::_value(FWD(self))};
       else {
-        auto t = ::fn::detail::_invoke(FWD(fn), _pfn_base::_error(FWD(self)));
+        auto t = ::fn::detail::_apply(FWD(fn), _pfn_base::_error(FWD(self)));
         if (t.has_value())
           return new_type{::std::in_place, ::std::move(t).value()};
         else
@@ -286,25 +285,25 @@ template <typename T, typename E> struct _expected_base : ::pfn::detail::_expect
   }
 
   // transform, non-void value type, not a sum. In the noexcept specs of the transform and
-  // transform_error overloads, only the invoke and copying the untouched side can throw: the
+  // transform_error overloads, only the apply and copying the untouched side can throw: the
   // new value/error is direct-non-list-initialized from the thunk's result (guaranteed elision).
   template <typename Self, typename Fn>
   static constexpr auto _transform(Self &&self, Fn &&fn) //
-      noexcept(::fn::detail::_is_nothrow_invocable<Fn, decltype(_pfn_base::_value(FWD(self)))>::value
+      noexcept(::fn::detail::_is_nothrow_applicable<Fn, decltype(_pfn_base::_value(FWD(self)))>::value
                && ::std::is_nothrow_constructible_v<E, decltype(_pfn_base::_error(FWD(self)))>) // extension
     requires(not ::std::is_void_v<T>) && (not some_sum<T>)
-            && ::fn::detail::_is_invocable_if<not some_sum<T>, Fn, decltype(_pfn_base::_value(FWD(self)))>::value
+            && ::fn::detail::_is_applicable_if<not some_sum<T>, Fn, decltype(_pfn_base::_value(FWD(self)))>::value
             && ::std::is_constructible_v<E, decltype(_pfn_base::_error(FWD(self)))>
   {
-    using new_value_type = typename ::fn::detail::_invoke_result<Fn, decltype(_pfn_base::_value(FWD(self)))>::type;
+    using new_value_type = typename ::fn::detail::_apply_result<Fn, decltype(_pfn_base::_value(FWD(self)))>::type;
     using type = ::fn::expected<new_value_type, E>;
     if (self.has_value())
       if constexpr (::std::is_void_v<new_value_type>) {
-        ::fn::detail::_invoke(FWD(fn), _pfn_base::_value(FWD(self)));
+        ::fn::detail::_apply(FWD(fn), _pfn_base::_value(FWD(self)));
         return type();
       } else
         return type(::pfn::detail::_expected_from_invoke, ::std::in_place, [&fn, &self]() -> decltype(auto) {
-          return ::fn::detail::_invoke(FWD(fn), _pfn_base::_value(FWD(self)));
+          return ::fn::detail::_apply(FWD(fn), _pfn_base::_value(FWD(self)));
         });
     else
       return type(::fn::unexpect, _pfn_base::_error(FWD(self)));
@@ -316,7 +315,7 @@ template <typename T, typename E> struct _expected_base : ::pfn::detail::_expect
   static constexpr auto _transform(Self &&self, Fn &&fn) //
       noexcept(noexcept(_pfn_base::_value(FWD(self)).transform(FWD(fn)))
                && ::std::is_nothrow_constructible_v<E, decltype(_pfn_base::_error(FWD(self)))>) // extension
-    requires some_sum<T> && ::fn::detail::_typelist_invocable<Fn, decltype(_pfn_base::_value(FWD(self)))>
+    requires some_sum<T> && ::fn::detail::_typelist_applicable<Fn, decltype(_pfn_base::_value(FWD(self)))>
              && ::std::is_constructible_v<E, decltype(_pfn_base::_error(FWD(self)))>
   {
     using new_value_type = decltype(_pfn_base::_value(FWD(self)).transform(FWD(fn)));
@@ -335,20 +334,20 @@ template <typename T, typename E> struct _expected_base : ::pfn::detail::_expect
   // transform, void value type
   template <typename Self, typename Fn>
   static constexpr auto _transform(Self &&self, Fn &&fn) //
-      noexcept(::fn::detail::_is_nothrow_invocable<Fn>::value
+      noexcept(::fn::detail::_is_nothrow_applicable<Fn>::value
                && ::std::is_nothrow_constructible_v<E, decltype(_pfn_base::_error(FWD(self)))>) // extension
-    requires(::std::is_void_v<T>) && ::fn::detail::_is_invocable<Fn>::value
+    requires(::std::is_void_v<T>) && ::fn::detail::_is_applicable<Fn>::value
             && ::std::is_constructible_v<E, decltype(_pfn_base::_error(FWD(self)))>
   {
-    using new_value_type = typename ::fn::detail::_invoke_result<Fn>::type;
+    using new_value_type = typename ::fn::detail::_apply_result<Fn>::type;
     using type = ::fn::expected<new_value_type, E>;
     if (self.has_value())
       if constexpr (::std::is_void_v<new_value_type>) {
-        ::fn::detail::_invoke(FWD(fn));
+        ::fn::detail::_apply(FWD(fn));
         return type();
       } else
         return type(::pfn::detail::_expected_from_invoke, ::std::in_place,
-                    [&fn]() -> decltype(auto) { return ::fn::detail::_invoke(FWD(fn)); });
+                    [&fn]() -> decltype(auto) { return ::fn::detail::_apply(FWD(fn)); });
     else
       return type(::fn::unexpect, _pfn_base::_error(FWD(self)));
   }
@@ -357,15 +356,15 @@ template <typename T, typename E> struct _expected_base : ::pfn::detail::_expect
   // apply_const_lvalue_t for the same reason as _or_else's above)
   template <typename Self, typename Fn>
   static constexpr auto _transform_error(Self &&self, Fn &&fn) //
-      noexcept(::fn::detail::_is_nothrow_invocable<Fn, decltype(_pfn_base::_error(FWD(self)))>::value
+      noexcept(::fn::detail::_is_nothrow_applicable<Fn, decltype(_pfn_base::_error(FWD(self)))>::value
                && (::std::is_void_v<T>
                    || ::std::is_nothrow_constructible_v<
                        T, ::fn::apply_const_lvalue_t<Self, typename _pfn_base::_value_t &&>>)) // extension
     requires(not some_sum<E>)
-            && ::fn::detail::_is_invocable_if<not some_sum<E>, Fn, decltype(_pfn_base::_error(FWD(self)))>::value
+            && ::fn::detail::_is_applicable_if<not some_sum<E>, Fn, decltype(_pfn_base::_error(FWD(self)))>::value
             && (::std::is_void_v<T> || ::std::is_constructible_v<T, decltype(_pfn_base::_value(FWD(self)))>)
   {
-    using new_error_type = typename ::fn::detail::_invoke_result<Fn, decltype(_pfn_base::_error(FWD(self)))>::type;
+    using new_error_type = typename ::fn::detail::_apply_result<Fn, decltype(_pfn_base::_error(FWD(self)))>::type;
     using type = ::fn::expected<T, new_error_type>;
     if (self.has_value())
       if constexpr (not ::std::is_void_v<T>)
@@ -374,7 +373,7 @@ template <typename T, typename E> struct _expected_base : ::pfn::detail::_expect
         return type();
     else
       return type(::pfn::detail::_expected_from_invoke, ::fn::unexpect, [&fn, &self]() -> decltype(auto) {
-        return ::fn::detail::_invoke(FWD(fn), _pfn_base::_error(FWD(self)));
+        return ::fn::detail::_apply(FWD(fn), _pfn_base::_error(FWD(self)));
       });
   }
 
@@ -386,7 +385,7 @@ template <typename T, typename E> struct _expected_base : ::pfn::detail::_expect
                && (::std::is_void_v<T>
                    || ::std::is_nothrow_constructible_v<
                        T, ::fn::apply_const_lvalue_t<Self, typename _pfn_base::_value_t &&>>)) // extension
-    requires some_sum<E> && ::fn::detail::_typelist_invocable<Fn, decltype(_pfn_base::_error(FWD(self)))>
+    requires some_sum<E> && ::fn::detail::_typelist_applicable<Fn, decltype(_pfn_base::_error(FWD(self)))>
              && (::std::is_void_v<T> || ::std::is_constructible_v<T, decltype(_pfn_base::_value(FWD(self)))>)
   {
     using new_error_type = decltype(_pfn_base::_error(FWD(self)).transform(FWD(fn)));

--- a/include/fn/fail.hpp
+++ b/include/fn/fail.hpp
@@ -23,17 +23,17 @@ namespace fn {
  * @param v TODO
  */
 template <typename Fn, typename V>
-concept invocable_fail //
+concept applicable_fail //
     = (some_expected_non_void<V> && requires(Fn &&fn, V &&v) {
         {
-          ::fn::invoke(FWD(fn), FWD(v).value())
+          ::fn::apply(FWD(fn), FWD(v).value())
         } -> ::std::convertible_to<typename ::std::remove_cvref_t<V>::error_type>;
         requires detail::_relocatable_error<V>; // the error branch carries the existing error over
       }) || (some_expected_void<V> && requires(Fn &&fn) {
-        { ::fn::invoke(FWD(fn)) } -> ::std::convertible_to<typename ::std::remove_cvref_t<V>::error_type>;
+        { ::fn::apply(FWD(fn)) } -> ::std::convertible_to<typename ::std::remove_cvref_t<V>::error_type>;
         requires detail::_relocatable_error<V>;
       }) || (some_optional<V> && requires(Fn &&fn, V &&v) {
-        { ::fn::invoke(FWD(fn), FWD(v).value()) } -> ::std::same_as<void>;
+        { ::fn::apply(FWD(fn), FWD(v).value()) } -> ::std::same_as<void>;
       });
 
 /**
@@ -63,16 +63,16 @@ struct fail_t::apply final {
   template <some_expected_non_void V, typename Fn>
   [[nodiscard]] constexpr auto operator()(V &&v, Fn &&fn) const //
       noexcept(
-          ::fn::is_nothrow_invocable_v<Fn, decltype(FWD(v).value())>
+          ::fn::is_nothrow_applicable_v<Fn, decltype(FWD(v).value())>
           && ::std::is_nothrow_constructible_v<::std::remove_cvref_t<V>, ::fn::unexpect_t,
-                                               ::fn::invoke_result_t<Fn, decltype(FWD(v).value())>>
+                                               ::fn::apply_result_t<Fn, decltype(FWD(v).value())>>
           && ::std::is_nothrow_constructible_v<::std::remove_cvref_t<V>, ::fn::unexpect_t, decltype(FWD(v).error())>)
           -> ::std::remove_cvref_t<V>
-    requires invocable_fail<Fn &&, V &&>
+    requires applicable_fail<Fn &&, V &&>
   {
     using type = ::std::remove_cvref_t<V>;
     if (v.has_value()) {
-      return type{::fn::unexpect, ::fn::invoke(FWD(fn), FWD(v).value())};
+      return type{::fn::unexpect, ::fn::apply(FWD(fn), FWD(v).value())};
     }
     return type{::fn::unexpect, FWD(v).error()};
   }
@@ -87,15 +87,15 @@ struct fail_t::apply final {
   template <some_expected_void V, typename Fn>
   [[nodiscard]] constexpr auto operator()(V &&v, Fn &&fn) const //
       noexcept(
-          ::fn::is_nothrow_invocable_v<Fn>
-          && ::std::is_nothrow_constructible_v<::std::remove_cvref_t<V>, ::fn::unexpect_t, ::fn::invoke_result_t<Fn>>
+          ::fn::is_nothrow_applicable_v<Fn>
+          && ::std::is_nothrow_constructible_v<::std::remove_cvref_t<V>, ::fn::unexpect_t, ::fn::apply_result_t<Fn>>
           && ::std::is_nothrow_constructible_v<::std::remove_cvref_t<V>, ::fn::unexpect_t, decltype(FWD(v).error())>)
           -> ::std::remove_cvref_t<V>
-    requires invocable_fail<Fn &&, V &&>
+    requires applicable_fail<Fn &&, V &&>
   {
     using type = ::std::remove_cvref_t<V>;
     if (v.has_value()) {
-      return type{::fn::unexpect, ::fn::invoke(FWD(fn))};
+      return type{::fn::unexpect, ::fn::apply(FWD(fn))};
     }
     return type{::fn::unexpect, FWD(v).error()};
   }
@@ -109,14 +109,14 @@ struct fail_t::apply final {
    */
   template <some_optional V, typename Fn>
   [[nodiscard]] constexpr auto operator()(V &&v, Fn &&fn) const //
-      noexcept(::fn::is_nothrow_invocable_v<Fn, decltype(FWD(v).value())>
+      noexcept(::fn::is_nothrow_applicable_v<Fn, decltype(FWD(v).value())>
                && ::std::is_nothrow_constructible_v<::std::remove_cvref_t<V>, ::std::nullopt_t>)
           -> ::std::remove_cvref_t<V>
-    requires invocable_fail<Fn &&, V &&>
+    requires applicable_fail<Fn &&, V &&>
   {
     using type = ::std::remove_cvref_t<V>;
     if (v.has_value()) {
-      ::fn::invoke(FWD(fn), FWD(v).value());
+      ::fn::apply(FWD(fn), FWD(v).value());
     }
     return type{::std::nullopt};
   }

--- a/include/fn/filter.hpp
+++ b/include/fn/filter.hpp
@@ -24,19 +24,19 @@ namespace fn {
 // A rejected operand is returned whole (`return FWD(v)`), and a kept one is rebuilt around its
 // existing value - so both sides must survive the trip.
 template <typename Pred, typename Err, typename V>
-concept invocable_filter //
+concept applicable_filter //
     = (some_expected_non_void<V> && requires(Pred &&pred, Err &&on_err, V &&v) {
-        { ::fn::invoke(FWD(pred), ::std::as_const(v).value()) } -> convertible_to_bool;
+        { ::fn::apply(FWD(pred), ::std::as_const(v).value()) } -> convertible_to_bool;
         {
-          ::fn::invoke(FWD(on_err), FWD(v).value())
+          ::fn::apply(FWD(on_err), FWD(v).value())
         } -> ::std::convertible_to<typename ::std::remove_cvref_t<V>::error_type>;
         requires detail::_relocatable<V> && detail::_relocatable_value<V>;
       }) || (some_expected_void<V> && requires(Pred &&pred, Err &&on_err, V &&v) {
-        { ::fn::invoke(FWD(pred)) } -> convertible_to_bool;
-        { ::fn::invoke(FWD(on_err)) } -> ::std::convertible_to<typename ::std::remove_cvref_t<V>::error_type>;
+        { ::fn::apply(FWD(pred)) } -> convertible_to_bool;
+        { ::fn::apply(FWD(on_err)) } -> ::std::convertible_to<typename ::std::remove_cvref_t<V>::error_type>;
         requires detail::_relocatable<V>;
       }) || (some_optional<V> && ::std::same_as<Err, void> && requires(Pred &&pred, V &&v) {
-        { ::fn::invoke(FWD(pred), ::std::as_const(v).value()) } -> convertible_to_bool;
+        { ::fn::apply(FWD(pred), ::std::as_const(v).value()) } -> convertible_to_bool;
         requires detail::_relocatable<V> && detail::_relocatable_value<V>;
       });
 
@@ -91,19 +91,19 @@ struct filter_t::apply final {
   template <some_expected_non_void V, typename Pred, typename OnErr>
   [[nodiscard]] constexpr auto operator()(V &&v, Pred &&pred, OnErr &&on_err) const //
       noexcept(
-          ::fn::is_nothrow_invocable_v<Pred, decltype(::std::as_const(v).value())>
-          && ::fn::is_nothrow_invocable_v<OnErr, decltype(FWD(v).value())>
+          ::fn::is_nothrow_applicable_v<Pred, decltype(::std::as_const(v).value())>
+          && ::fn::is_nothrow_applicable_v<OnErr, decltype(FWD(v).value())>
           && ::std::is_nothrow_constructible_v<::std::remove_cvref_t<V>, ::std::in_place_t, decltype(FWD(v).value())>
           && ::std::is_nothrow_constructible_v<::std::remove_cvref_t<V>, ::fn::unexpect_t,
-                                               ::fn::invoke_result_t<OnErr, decltype(FWD(v).value())>>
+                                               ::fn::apply_result_t<OnErr, decltype(FWD(v).value())>>
           && ::std::is_nothrow_constructible_v<::std::remove_cvref_t<V>, V>) -> ::std::remove_cvref_t<V>
-    requires invocable_filter<Pred &&, OnErr &&, V &&>
+    requires applicable_filter<Pred &&, OnErr &&, V &&>
   {
     using type = ::std::remove_cvref_t<V>;
     if (::std::as_const(v).has_value()) {
-      bool const keep = ::fn::invoke(FWD(pred), ::std::as_const(v).value());
+      bool const keep = ::fn::apply(FWD(pred), ::std::as_const(v).value());
       return (keep ? type{::std::in_place, FWD(v).value()}
-                   : type{::fn::unexpect, ::fn::invoke(FWD(on_err), FWD(v).value())});
+                   : type{::fn::unexpect, ::fn::apply(FWD(on_err), FWD(v).value())});
     }
     return FWD(v);
   }
@@ -119,17 +119,17 @@ struct filter_t::apply final {
   template <some_expected_void V, typename Pred, typename OnErr>
   [[nodiscard]] constexpr auto operator()(V &&v, Pred &&pred, OnErr &&on_err) const //
       noexcept(
-          ::fn::is_nothrow_invocable_v<Pred> && ::fn::is_nothrow_invocable_v<OnErr>
+          ::fn::is_nothrow_applicable_v<Pred> && ::fn::is_nothrow_applicable_v<OnErr>
           && ::std::is_nothrow_constructible_v<::std::remove_cvref_t<V>, ::std::in_place_t>
-          && ::std::is_nothrow_constructible_v<::std::remove_cvref_t<V>, ::fn::unexpect_t, ::fn::invoke_result_t<OnErr>>
+          && ::std::is_nothrow_constructible_v<::std::remove_cvref_t<V>, ::fn::unexpect_t, ::fn::apply_result_t<OnErr>>
           && ::std::is_nothrow_constructible_v<::std::remove_cvref_t<V>, V>) -> ::std::remove_cvref_t<V>
-    requires invocable_filter<Pred &&, OnErr &&, V &&>
+    requires applicable_filter<Pred &&, OnErr &&, V &&>
   {
     using type = ::std::remove_cvref_t<V>;
     if (::std::as_const(v).has_value()) {
-      bool const keep = ::fn::invoke(FWD(pred));
+      bool const keep = ::fn::apply(FWD(pred));
       return (keep ? type{::std::in_place} //
-                   : type{::fn::unexpect, ::fn::invoke(FWD(on_err))});
+                   : type{::fn::unexpect, ::fn::apply(FWD(on_err))});
     }
     return FWD(v);
   }
@@ -144,15 +144,15 @@ struct filter_t::apply final {
   template <some_optional V, typename Pred>
   [[nodiscard]] constexpr auto operator()(V &&v, Pred &&pred) const //
       noexcept(
-          ::fn::is_nothrow_invocable_v<Pred, decltype(::std::as_const(v).value())>
+          ::fn::is_nothrow_applicable_v<Pred, decltype(::std::as_const(v).value())>
           && ::std::is_nothrow_constructible_v<::std::remove_cvref_t<V>, ::std::in_place_t, decltype(FWD(v).value())>
           && ::std::is_nothrow_constructible_v<::std::remove_cvref_t<V>, ::std::nullopt_t>
           && ::std::is_nothrow_constructible_v<::std::remove_cvref_t<V>, V>) -> ::std::remove_cvref_t<V>
-    requires invocable_filter<Pred &&, void, V &&>
+    requires applicable_filter<Pred &&, void, V &&>
   {
     using type = ::std::remove_cvref_t<V>;
     if (::std::as_const(v).has_value()) {
-      bool const keep = ::fn::invoke(FWD(pred), ::std::as_const(v).value());
+      bool const keep = ::fn::apply(FWD(pred), ::std::as_const(v).value());
       return (keep ? type{::std::in_place, FWD(v).value()} //
                    : type{::std::nullopt});
     }

--- a/include/fn/functional.hpp
+++ b/include/fn/functional.hpp
@@ -10,59 +10,59 @@
 
 namespace fn {
 
-// invoke_result and invoke_result_t
-template <typename Fn, typename... Args> struct invoke_result : detail::_invoke_result<Fn, Args...> {};
-template <typename Fn, typename... Args> using invoke_result_t = typename invoke_result<Fn, Args...>::type;
+// apply_result and apply_result_t
+template <typename Fn, typename... Args> struct apply_result : detail::_apply_result<Fn, Args...> {};
+template <typename Fn, typename... Args> using apply_result_t = typename apply_result<Fn, Args...>::type;
 
-// is_invocable and is_invocable_v
-template <typename Fn, typename... Args> struct is_invocable : detail::_is_invocable<Fn, Args...> {};
-template <typename Fn, typename... Args> constexpr inline bool is_invocable_v = is_invocable<Fn, Args...>::value;
+// is_applicable and is_applicable_v
+template <typename Fn, typename... Args> struct is_applicable : detail::_is_applicable<Fn, Args...> {};
+template <typename Fn, typename... Args> constexpr inline bool is_applicable_v = is_applicable<Fn, Args...>::value;
 
-// is_invocable_r and is_invocable_r_v
+// is_applicable_r and is_applicable_r_v
 template <typename Ret, typename Fn, typename... Args>
-struct is_invocable_r : detail::_is_invocable_r<Ret, Fn, Args...> {};
+struct is_applicable_r : detail::_is_applicable_r<Ret, Fn, Args...> {};
 template <typename Ret, typename Fn, typename... Args>
-constexpr inline bool is_invocable_r_v = is_invocable_r<Ret, Fn, Args...>::value;
+constexpr inline bool is_applicable_r_v = is_applicable_r<Ret, Fn, Args...>::value;
 
-// is_nothrow_invocable and is_nothrow_invocable_v
-template <typename Fn, typename... Args> struct is_nothrow_invocable : detail::_is_nothrow_invocable<Fn, Args...> {};
+// is_nothrow_applicable and is_nothrow_applicable_v
+template <typename Fn, typename... Args> struct is_nothrow_applicable : detail::_is_nothrow_applicable<Fn, Args...> {};
 template <typename Fn, typename... Args>
-constexpr inline bool is_nothrow_invocable_v = is_nothrow_invocable<Fn, Args...>::value;
+constexpr inline bool is_nothrow_applicable_v = is_nothrow_applicable<Fn, Args...>::value;
 
-// is_nothrow_invocable_r and is_nothrow_invocable_r_v
+// is_nothrow_applicable_r and is_nothrow_applicable_r_v
 template <typename Ret, typename Fn, typename... Args>
-struct is_nothrow_invocable_r : detail::_is_nothrow_invocable_r<Ret, Fn, Args...> {};
+struct is_nothrow_applicable_r : detail::_is_nothrow_applicable_r<Ret, Fn, Args...> {};
 template <typename Ret, typename Fn, typename... Args>
-constexpr inline bool is_nothrow_invocable_r_v = is_nothrow_invocable_r<Ret, Fn, Args...>::value;
+constexpr inline bool is_nothrow_applicable_r_v = is_nothrow_applicable_r<Ret, Fn, Args...>::value;
 
-// invoke
+// apply
 template <typename Fn, typename... Args>
-  requires is_invocable_v<Fn, Args...>
-constexpr auto invoke(Fn &&fn, Args &&...args) noexcept(is_nothrow_invocable_v<Fn, Args...>)
-    -> invoke_result_t<Fn, Args...>
+  requires is_applicable_v<Fn, Args...>
+constexpr auto apply(Fn &&fn, Args &&...args) noexcept(is_nothrow_applicable_v<Fn, Args...>)
+    -> apply_result_t<Fn, Args...>
 {
-  return detail::_invoke(FWD(fn), FWD(args)...);
+  return detail::_apply(FWD(fn), FWD(args)...);
 }
 
-// invoke_r
+// apply_r
 template <typename Ret, typename Fn, typename... Args>
-  requires is_invocable_r_v<Ret, Fn, Args...>
-constexpr auto invoke_r(Fn &&fn, Args &&...args) noexcept(is_nothrow_invocable_r_v<Ret, Fn, Args...>) -> Ret
+  requires is_applicable_r_v<Ret, Fn, Args...>
+constexpr auto apply_r(Fn &&fn, Args &&...args) noexcept(is_nothrow_applicable_r_v<Ret, Fn, Args...>) -> Ret
 {
-  return detail::_invoke_r<Ret>(FWD(fn), FWD(args)...);
+  return detail::_apply_r<Ret>(FWD(fn), FWD(args)...);
 }
 
-// invocable and regular_invocable
+// applicable and regular_applicable
 template <typename Fn, typename... Args>
-concept invocable = is_invocable_v<Fn, Args...>;
+concept applicable = is_applicable_v<Fn, Args...>;
 
 template <typename Fn, typename... Args>
-concept regular_invocable = invocable<Fn, Args...>;
+concept regular_applicable = applicable<Fn, Args...>;
 
 template <typename Fn, typename T, typename... Args>
-concept typelist_invocable = detail::_typelist_invocable<Fn, T, Args...>;
+concept typelist_applicable = detail::_typelist_applicable<Fn, T, Args...>;
 template <typename Ret, typename Fn, typename T, typename... Args>
-concept typelist_invocable_r = detail::_typelist_invocable_r<Ret, Fn, T, Args...>;
+concept typelist_applicable_r = detail::_typelist_applicable_r<Ret, Fn, T, Args...>;
 
 } // namespace fn
 

--- a/include/fn/inspect.hpp
+++ b/include/fn/inspect.hpp
@@ -21,15 +21,15 @@ namespace fn {
  * @tparam V TODO
  */
 template <typename Fn, typename V>
-concept invocable_inspect //
+concept applicable_inspect //
     = (some_expected_non_void<V> && requires(Fn &&fn, V &&v) {
-        { ::fn::invoke(FWD(fn), ::std::as_const(v).value()) } -> ::std::same_as<void>;
+        { ::fn::apply(FWD(fn), ::std::as_const(v).value()) } -> ::std::same_as<void>;
       }) || (some_expected_void<V> && requires(Fn &&fn) {
-        { ::fn::invoke(FWD(fn)) } -> ::std::same_as<void>;
+        { ::fn::apply(FWD(fn)) } -> ::std::same_as<void>;
       }) || (some_optional<V> && requires(Fn &&fn, V &&v) {
-        { ::fn::invoke(FWD(fn), ::std::as_const(v).value()) } -> ::std::same_as<void>;
+        { ::fn::apply(FWD(fn), ::std::as_const(v).value()) } -> ::std::same_as<void>;
       }) || (some_choice<V> && requires(Fn &&fn, V &&v) {
-        { ::fn::invoke(FWD(fn), ::std::as_const(v).value()) } -> ::std::same_as<void>;
+        { ::fn::apply(FWD(fn), ::std::as_const(v).value()) } -> ::std::same_as<void>;
       });
 
 /**
@@ -61,11 +61,11 @@ struct inspect_t::apply final {
    */
   template <some_expected_non_void V, typename Fn>
   [[nodiscard]] constexpr auto operator()(V &&v, Fn &&fn) const
-      noexcept(::fn::is_nothrow_invocable_v<Fn, decltype(::std::as_const(v).value())>) -> V &&
-    requires invocable_inspect<Fn &&, V &&>
+      noexcept(::fn::is_nothrow_applicable_v<Fn, decltype(::std::as_const(v).value())>) -> V &&
+    requires applicable_inspect<Fn &&, V &&>
   {
     if (v.has_value()) {
-      ::fn::invoke(FWD(fn), ::std::as_const(v).value()); // side-effects only
+      ::fn::apply(FWD(fn), ::std::as_const(v).value()); // side-effects only
     }
     return FWD(v);
   }
@@ -78,11 +78,11 @@ struct inspect_t::apply final {
    * @return TODO
    */
   template <some_expected_void V, typename Fn>
-  [[nodiscard]] constexpr auto operator()(V &&v, Fn &&fn) const noexcept(::fn::is_nothrow_invocable_v<Fn>) -> V &&
-    requires invocable_inspect<Fn &&, V &&>
+  [[nodiscard]] constexpr auto operator()(V &&v, Fn &&fn) const noexcept(::fn::is_nothrow_applicable_v<Fn>) -> V &&
+    requires applicable_inspect<Fn &&, V &&>
   {
     if (v.has_value()) {
-      ::fn::invoke(FWD(fn)); // side-effects only
+      ::fn::apply(FWD(fn)); // side-effects only
     }
     return FWD(v);
   }
@@ -96,11 +96,11 @@ struct inspect_t::apply final {
    */
   template <some_optional V, typename Fn>
   [[nodiscard]] constexpr auto operator()(V &&v, Fn &&fn) const
-      noexcept(::fn::is_nothrow_invocable_v<Fn, decltype(::std::as_const(v).value())>) -> V &&
-    requires invocable_inspect<Fn &&, V &&>
+      noexcept(::fn::is_nothrow_applicable_v<Fn, decltype(::std::as_const(v).value())>) -> V &&
+    requires applicable_inspect<Fn &&, V &&>
   {
     if (v.has_value()) {
-      ::fn::invoke(FWD(fn), ::std::as_const(v).value()); // side-effects only
+      ::fn::apply(FWD(fn), ::std::as_const(v).value()); // side-effects only
     }
     return FWD(v);
   }
@@ -114,10 +114,10 @@ struct inspect_t::apply final {
    */
   template <some_choice V, typename Fn>
   [[nodiscard]] constexpr auto operator()(V &&v, Fn &&fn) const
-      noexcept(::fn::is_nothrow_invocable_v<Fn, decltype(::std::as_const(v).value())>) -> V &&
-    requires invocable_inspect<Fn &&, V &&>
+      noexcept(::fn::is_nothrow_applicable_v<Fn, decltype(::std::as_const(v).value())>) -> V &&
+    requires applicable_inspect<Fn &&, V &&>
   {
-    ::fn::invoke(FWD(fn), ::std::as_const(v).value()); // side-effects only
+    ::fn::apply(FWD(fn), ::std::as_const(v).value()); // side-effects only
     return FWD(v);
   }
 };

--- a/include/fn/inspect_error.hpp
+++ b/include/fn/inspect_error.hpp
@@ -20,11 +20,11 @@ namespace fn {
  * @tparam V TODO
  */
 template <typename Fn, typename V>
-concept invocable_inspect_error //
+concept applicable_inspect_error //
     = (some_expected<V> && requires(Fn &&fn, V &&v) {
-        { ::fn::invoke(FWD(fn), ::std::as_const(v).error()) } -> ::std::same_as<void>;
+        { ::fn::apply(FWD(fn), ::std::as_const(v).error()) } -> ::std::same_as<void>;
       }) || (some_optional<V> && requires(Fn &&fn) {
-        { ::fn::invoke(FWD(fn)) } -> ::std::same_as<void>;
+        { ::fn::apply(FWD(fn)) } -> ::std::same_as<void>;
       });
 
 /**
@@ -59,11 +59,11 @@ struct inspect_error_t::apply final {
    */
   template <some_expected V, typename Fn>
   [[nodiscard]] constexpr auto operator()(V &&v, Fn &&fn) const
-      noexcept(::fn::is_nothrow_invocable_v<Fn, decltype(::std::as_const(v).error())>) -> V &&
-    requires invocable_inspect_error<Fn &&, V &&>
+      noexcept(::fn::is_nothrow_applicable_v<Fn, decltype(::std::as_const(v).error())>) -> V &&
+    requires applicable_inspect_error<Fn &&, V &&>
   {
     if (not v.has_value()) {
-      ::fn::invoke(FWD(fn), ::std::as_const(v).error()); // side-effects only
+      ::fn::apply(FWD(fn), ::std::as_const(v).error()); // side-effects only
     }
     return FWD(v);
   }
@@ -76,11 +76,11 @@ struct inspect_error_t::apply final {
    * @return TODO
    */
   template <some_optional V, typename Fn>
-  [[nodiscard]] constexpr auto operator()(V &&v, Fn &&fn) const noexcept(::fn::is_nothrow_invocable_v<Fn>) -> V &&
-    requires invocable_inspect_error<Fn &&, V &&>
+  [[nodiscard]] constexpr auto operator()(V &&v, Fn &&fn) const noexcept(::fn::is_nothrow_applicable_v<Fn>) -> V &&
+    requires applicable_inspect_error<Fn &&, V &&>
   {
     if (not v.has_value()) {
-      ::fn::invoke(FWD(fn)); // side-effects only
+      ::fn::apply(FWD(fn)); // side-effects only
     }
     return FWD(v);
   }

--- a/include/fn/optional.hpp
+++ b/include/fn/optional.hpp
@@ -137,20 +137,20 @@ struct optional_policy {
 template <typename T, typename Fn, typename ValArg> struct _nothrow_optional_or_else : ::std::false_type {};
 
 template <typename T, typename Fn, typename ValArg>
-  requires ::std::is_same_v<::std::remove_cvref_t<typename _invoke_result<Fn>::type>, ::fn::optional<T>>
+  requires ::std::is_same_v<::std::remove_cvref_t<typename _apply_result<Fn>::type>, ::fn::optional<T>>
 struct _nothrow_optional_or_else<T, Fn, ValArg>
-    : ::std::bool_constant<_is_nothrow_invocable<Fn>::value
+    : ::std::bool_constant<_is_nothrow_applicable<Fn>::value
                                && ::std::is_nothrow_constructible_v<::fn::optional<T>, ::std::in_place_t, ValArg>> {};
 
 template <typename T, typename Fn, typename ValArg>
-  requires _is_some_optional<::std::remove_cvref_t<typename _invoke_result<Fn>::type> &>
-           && (not ::std::is_same_v<::std::remove_cvref_t<typename _invoke_result<Fn>::type>, ::fn::optional<T>>)
+  requires _is_some_optional<::std::remove_cvref_t<typename _apply_result<Fn>::type> &>
+           && (not ::std::is_same_v<::std::remove_cvref_t<typename _apply_result<Fn>::type>, ::fn::optional<T>>)
 struct _nothrow_optional_or_else<T, Fn, ValArg> {
-  using type = ::std::remove_cvref_t<typename _invoke_result<Fn>::type>;
+  using type = ::std::remove_cvref_t<typename _apply_result<Fn>::type>;
   using new_type = ::fn::optional<sum_for<T, typename type::value_type>>;
 
   static constexpr bool value
-      = _is_nothrow_invocable<Fn>::value                               // the callback
+      = _is_nothrow_applicable<Fn>::value                              // the callback
         && _nothrow_initializable<new_type, ::std::in_place_t, ValArg> // self's value
         && _nothrow_initializable<new_type, ::std::in_place_t, decltype(::std::declval<type>().value())>; // its value
 };
@@ -163,22 +163,22 @@ struct _nothrow_optional_or_else<T, Fn, ValArg> {
 // _invoke (or sum::transform) result: no extra move, and immovable result types work.
 // The statics carry the same extension noexcept as pfn's, computed through fn's own machinery:
 // the callback of a sum/pack dispatch is invoked through `_invoke`, not called directly, so it is
-// `_is_nothrow_invocable` - not the std trait, which is false for a callable that is not directly
-// invocable on a sum or a pack - that answers for it.
+// `_is_nothrow_applicable` - not the std trait, which is false for a callable that is not directly
+// applicable on a sum or a pack - that answers for it.
 template <typename T> struct _optional_base : ::pfn::detail::_optional_base<T, optional_policy> {
   using _pfn_base = ::pfn::detail::_optional_base<T, optional_policy>;
   using _pfn_base::_pfn_base;
 
   // and_then
   template <typename Self, typename Fn>
-  static constexpr auto _and_then(Self &&self, Fn &&fn)                              //
-      noexcept(::fn::detail::_is_nothrow_invocable<Fn, decltype(*FWD(self))>::value) // extension
-    requires ::fn::detail::_is_invocable<Fn, decltype(*FWD(self))>::value
+  static constexpr auto _and_then(Self &&self, Fn &&fn)                               //
+      noexcept(::fn::detail::_is_nothrow_applicable<Fn, decltype(*FWD(self))>::value) // extension
+    requires ::fn::detail::_is_applicable<Fn, decltype(*FWD(self))>::value
   {
-    using type = ::std::remove_cvref_t<typename ::fn::detail::_invoke_result<Fn, decltype(*FWD(self))>::type>;
+    using type = ::std::remove_cvref_t<typename ::fn::detail::_apply_result<Fn, decltype(*FWD(self))>::type>;
     static_assert(_is_some_optional<type &>);
     if (self.has_value())
-      return ::fn::detail::_invoke(FWD(fn), *FWD(self));
+      return ::fn::detail::_apply(FWD(fn), *FWD(self));
     else {
 #if defined(__clang__) && __clang_major__ <= 18
       // clang 15-18 miscompile the prvalue return below for three of the four Self ref-qualifier
@@ -200,9 +200,9 @@ template <typename T> struct _optional_base : ::pfn::detail::_optional_base<T, o
   template <typename Self, typename Fn>
   static constexpr auto _or_else(Self &&self, Fn &&fn)                                      //
       noexcept(::fn::detail::_nothrow_optional_or_else<T, Fn, decltype(*FWD(self))>::value) // extension
-    requires ::fn::detail::_is_invocable<Fn>::value && ::std::is_constructible_v<T, decltype(*FWD(self))>
+    requires ::fn::detail::_is_applicable<Fn>::value && ::std::is_constructible_v<T, decltype(*FWD(self))>
   {
-    using type = ::std::remove_cvref_t<typename ::fn::detail::_invoke_result<Fn>::type>;
+    using type = ::std::remove_cvref_t<typename ::fn::detail::_apply_result<Fn>::type>;
     static_assert(_is_some_optional<type &>);
     // compare whole optional types (not value_type) so optional<T&> instantiations, whose
     // value_type is the unqualified referent, take the same-type arm
@@ -211,14 +211,14 @@ template <typename T> struct _optional_base : ::pfn::detail::_optional_base<T, o
       if (self.has_value())
         return type(::std::in_place, *FWD(self));
       else
-        return ::fn::detail::_invoke(FWD(fn));
+        return ::fn::detail::_apply(FWD(fn));
     } else {
       using new_value_type = sum_for<T, typename type::value_type>;
       using new_type = ::fn::optional<new_value_type>;
       if (self.has_value())
         return new_type{::std::in_place, *FWD(self)};
       else {
-        auto t = ::fn::detail::_invoke(FWD(fn));
+        auto t = ::fn::detail::_apply(FWD(fn));
         if (t.has_value())
           return new_type{::std::in_place, ::std::move(t).value()};
         else
@@ -238,18 +238,18 @@ template <typename T> struct _optional_base : ::pfn::detail::_optional_base<T, o
     return _pfn_base::_or_else(FWD(self), FWD(fn));
   }
 
-  // transform, value type is not a sum. In the noexcept spec, only the invoke can throw: the
+  // transform, value type is not a sum. In the noexcept spec, only the apply can throw: the
   // result is direct-non-list-initialized from the thunk's result (guaranteed elision).
   template <typename Self, typename Fn>
-  static constexpr auto _transform(Self &&self, Fn &&fn)                             //
-      noexcept(::fn::detail::_is_nothrow_invocable<Fn, decltype(*FWD(self))>::value) // extension
-    requires(not some_sum<T>) && ::fn::detail::_is_invocable_if<not some_sum<T>, Fn, decltype(*FWD(self))>::value
+  static constexpr auto _transform(Self &&self, Fn &&fn)                              //
+      noexcept(::fn::detail::_is_nothrow_applicable<Fn, decltype(*FWD(self))>::value) // extension
+    requires(not some_sum<T>) && ::fn::detail::_is_applicable_if<not some_sum<T>, Fn, decltype(*FWD(self))>::value
   {
-    using new_value_type = ::std::remove_cv_t<typename ::fn::detail::_invoke_result<Fn, decltype(*FWD(self))>::type>;
+    using new_value_type = ::std::remove_cv_t<typename ::fn::detail::_apply_result<Fn, decltype(*FWD(self))>::type>;
     using type = ::fn::optional<new_value_type>;
     if (self.has_value())
       return type(::pfn::detail::_optional_from_invoke,
-                  [&fn, &self]() -> decltype(auto) { return ::fn::detail::_invoke(FWD(fn), *FWD(self)); });
+                  [&fn, &self]() -> decltype(auto) { return ::fn::detail::_apply(FWD(fn), *FWD(self)); });
     else
       return type(::std::nullopt);
   }
@@ -262,7 +262,7 @@ template <typename T> struct _optional_base : ::pfn::detail::_optional_base<T, o
   template <typename Self, typename Fn>
   static constexpr auto _transform(Self &&self, Fn &&fn)  //
       noexcept(noexcept((*FWD(self)).transform(FWD(fn)))) // extension
-    requires some_sum<T> && ::fn::detail::_typelist_invocable<Fn, decltype(*FWD(self))>
+    requires some_sum<T> && ::fn::detail::_typelist_applicable<Fn, decltype(*FWD(self))>
   {
     using new_value_type = decltype((*FWD(self)).transform(FWD(fn)));
     using type = ::fn::optional<new_value_type>;

--- a/include/fn/optional.hpp
+++ b/include/fn/optional.hpp
@@ -160,9 +160,9 @@ struct _nothrow_optional_or_else<T, Fn, ValArg> {
 // materialise their result via `optional_policy::template type<U>`.
 // The transform helpers hand pfn's _optional_from_invoke constructor a zero-argument
 // thunk, so the result's contained value is direct-non-list-initialized from fn's own
-// _invoke (or sum::transform) result: no extra move, and immovable result types work.
+// _apply (or sum::transform) result: no extra move, and immovable result types work.
 // The statics carry the same extension noexcept as pfn's, computed through fn's own machinery:
-// the callback of a sum/pack dispatch is invoked through `_invoke`, not called directly, so it is
+// the callback of a sum/pack dispatch is invoked through `_apply`, not called directly, so it is
 // `_is_nothrow_applicable` - not the std trait, which is false for a callable that is not directly
 // applicable on a sum or a pack - that answers for it.
 template <typename T> struct _optional_base : ::pfn::detail::_optional_base<T, optional_policy> {

--- a/include/fn/or_else.hpp
+++ b/include/fn/or_else.hpp
@@ -18,24 +18,24 @@ namespace fn {
  * @tparam V TODO
  */
 template <typename Fn, typename V>
-concept invocable_or_else //
+concept applicable_or_else //
     = (some_expected<V> && requires(Fn &&fn, V &&v) {
         {
-          ::fn::invoke(FWD(fn), FWD(v).error())
+          ::fn::apply(FWD(fn), FWD(v).error())
         } -> same_value_kind<V>;
       }) || (some_expected<V> //
          && some_sum<typename ::std::remove_cvref_t<V>::value_type> && requires(Fn &&fn, V &&v) {
         {
-          ::fn::invoke(FWD(fn), FWD(v).error())
+          ::fn::apply(FWD(fn), FWD(v).error())
         } -> some_expected;
       }) || (some_optional<V> && requires(Fn &&fn) {
         {
-          ::fn::invoke(FWD(fn))
+          ::fn::apply(FWD(fn))
         } -> same_value_kind<V>;
       }) || (some_optional<V>  //
          && some_sum<typename ::std::remove_cvref_t<V>::value_type> && requires(Fn &&fn, V &&v) {
         {
-          ::fn::invoke(FWD(fn))
+          ::fn::apply(FWD(fn))
         } -> some_optional;
       });
 
@@ -73,7 +73,7 @@ struct or_else_t::apply final {
   [[nodiscard]] constexpr auto operator()(V &&v, Fn &&fn) const //
       noexcept(noexcept(FWD(v).or_else(FWD(fn))))               //
       -> same_value_kind<V &&> auto
-    requires invocable_or_else<Fn &&, V &&>
+    requires applicable_or_else<Fn &&, V &&>
   {
     return FWD(v).or_else(FWD(fn));
   }

--- a/include/fn/pack.hpp
+++ b/include/fn/pack.hpp
@@ -171,11 +171,11 @@ template <typename... Ts> struct pack : detail::pack_impl<::std::index_sequence_
    */
   template <typename Fn>
   [[nodiscard]] constexpr auto apply(Fn &&fn, auto &&...args) & //
-      noexcept(noexcept(_impl::_invoke(::std::declval<pack &>(), FWD(fn), FWD(args)...)))
-          -> DEDUCED_RETURN(_impl::_invoke(*this, FWD(fn), FWD(args)...))
-    requires requires { _impl::_invoke(*this, FWD(fn), FWD(args)...); }
+      noexcept(noexcept(_impl::_apply(::std::declval<pack &>(), FWD(fn), FWD(args)...)))
+          -> DEDUCED_RETURN(_impl::_apply(*this, FWD(fn), FWD(args)...))
+    requires requires { _impl::_apply(*this, FWD(fn), FWD(args)...); }
   {
-    return _impl::_invoke(*this, FWD(fn), FWD(args)...);
+    return _impl::_apply(*this, FWD(fn), FWD(args)...);
   }
 
   /**
@@ -188,11 +188,11 @@ template <typename... Ts> struct pack : detail::pack_impl<::std::index_sequence_
    */
   template <typename Fn>
   [[nodiscard]] constexpr auto apply(Fn &&fn, auto &&...args) const & //
-      noexcept(noexcept(_impl::_invoke(::std::declval<pack const &>(), FWD(fn), FWD(args)...)))
-          -> DEDUCED_RETURN(_impl::_invoke(*this, FWD(fn), FWD(args)...))
-    requires requires { _impl::_invoke(*this, FWD(fn), FWD(args)...); }
+      noexcept(noexcept(_impl::_apply(::std::declval<pack const &>(), FWD(fn), FWD(args)...)))
+          -> DEDUCED_RETURN(_impl::_apply(*this, FWD(fn), FWD(args)...))
+    requires requires { _impl::_apply(*this, FWD(fn), FWD(args)...); }
   {
-    return _impl::_invoke(*this, FWD(fn), FWD(args)...);
+    return _impl::_apply(*this, FWD(fn), FWD(args)...);
   }
 
   /**
@@ -205,11 +205,11 @@ template <typename... Ts> struct pack : detail::pack_impl<::std::index_sequence_
    */
   template <typename Fn>
   [[nodiscard]] constexpr auto apply(Fn &&fn, auto &&...args) && //
-      noexcept(noexcept(_impl::_invoke(::std::declval<pack &&>(), FWD(fn), FWD(args)...)))
-          -> DEDUCED_RETURN(_impl::_invoke(::std::move(*this), FWD(fn), FWD(args)...))
-    requires requires { _impl::_invoke(::std::move(*this), FWD(fn), FWD(args)...); }
+      noexcept(noexcept(_impl::_apply(::std::declval<pack &&>(), FWD(fn), FWD(args)...)))
+          -> DEDUCED_RETURN(_impl::_apply(::std::move(*this), FWD(fn), FWD(args)...))
+    requires requires { _impl::_apply(::std::move(*this), FWD(fn), FWD(args)...); }
   {
-    return _impl::_invoke(::std::move(*this), FWD(fn), FWD(args)...);
+    return _impl::_apply(::std::move(*this), FWD(fn), FWD(args)...);
   }
 
   /**
@@ -222,11 +222,11 @@ template <typename... Ts> struct pack : detail::pack_impl<::std::index_sequence_
    */
   template <typename Fn>
   [[nodiscard]] constexpr auto apply(Fn &&fn, auto &&...args) const && //
-      noexcept(noexcept(_impl::_invoke(::std::declval<pack const &&>(), FWD(fn), FWD(args)...)))
-          -> DEDUCED_RETURN(_impl::_invoke(::std::move(*this), FWD(fn), FWD(args)...))
-    requires requires { _impl::_invoke(::std::move(*this), FWD(fn), FWD(args)...); }
+      noexcept(noexcept(_impl::_apply(::std::declval<pack const &&>(), FWD(fn), FWD(args)...)))
+          -> DEDUCED_RETURN(_impl::_apply(::std::move(*this), FWD(fn), FWD(args)...))
+    requires requires { _impl::_apply(::std::move(*this), FWD(fn), FWD(args)...); }
   {
-    return _impl::_invoke(::std::move(*this), FWD(fn), FWD(args)...);
+    return _impl::_apply(::std::move(*this), FWD(fn), FWD(args)...);
   }
 
   /**

--- a/include/fn/pack.hpp
+++ b/include/fn/pack.hpp
@@ -170,7 +170,7 @@ template <typename... Ts> struct pack : detail::pack_impl<::std::index_sequence_
    * @return TODO
    */
   template <typename Fn>
-  [[nodiscard]] constexpr auto invoke(Fn &&fn, auto &&...args) & //
+  [[nodiscard]] constexpr auto apply(Fn &&fn, auto &&...args) & //
       noexcept(noexcept(_impl::_invoke(::std::declval<pack &>(), FWD(fn), FWD(args)...)))
           -> DEDUCED_RETURN(_impl::_invoke(*this, FWD(fn), FWD(args)...))
     requires requires { _impl::_invoke(*this, FWD(fn), FWD(args)...); }
@@ -187,7 +187,7 @@ template <typename... Ts> struct pack : detail::pack_impl<::std::index_sequence_
    * @return TODO
    */
   template <typename Fn>
-  [[nodiscard]] constexpr auto invoke(Fn &&fn, auto &&...args) const & //
+  [[nodiscard]] constexpr auto apply(Fn &&fn, auto &&...args) const & //
       noexcept(noexcept(_impl::_invoke(::std::declval<pack const &>(), FWD(fn), FWD(args)...)))
           -> DEDUCED_RETURN(_impl::_invoke(*this, FWD(fn), FWD(args)...))
     requires requires { _impl::_invoke(*this, FWD(fn), FWD(args)...); }
@@ -204,7 +204,7 @@ template <typename... Ts> struct pack : detail::pack_impl<::std::index_sequence_
    * @return TODO
    */
   template <typename Fn>
-  [[nodiscard]] constexpr auto invoke(Fn &&fn, auto &&...args) && //
+  [[nodiscard]] constexpr auto apply(Fn &&fn, auto &&...args) && //
       noexcept(noexcept(_impl::_invoke(::std::declval<pack &&>(), FWD(fn), FWD(args)...)))
           -> DEDUCED_RETURN(_impl::_invoke(::std::move(*this), FWD(fn), FWD(args)...))
     requires requires { _impl::_invoke(::std::move(*this), FWD(fn), FWD(args)...); }
@@ -221,7 +221,7 @@ template <typename... Ts> struct pack : detail::pack_impl<::std::index_sequence_
    * @return TODO
    */
   template <typename Fn>
-  [[nodiscard]] constexpr auto invoke(Fn &&fn, auto &&...args) const && //
+  [[nodiscard]] constexpr auto apply(Fn &&fn, auto &&...args) const && //
       noexcept(noexcept(_impl::_invoke(::std::declval<pack const &&>(), FWD(fn), FWD(args)...)))
           -> DEDUCED_RETURN(_impl::_invoke(::std::move(*this), FWD(fn), FWD(args)...))
     requires requires { _impl::_invoke(::std::move(*this), FWD(fn), FWD(args)...); }
@@ -239,11 +239,11 @@ template <typename... Ts> struct pack : detail::pack_impl<::std::index_sequence_
    * @return TODO
    */
   template <typename Ret, typename Fn>
-  [[nodiscard]] constexpr auto invoke_r(Fn &&fn, auto &&...args) & //
-      noexcept(noexcept(_impl::template _invoke_r<Ret>(::std::declval<pack &>(), FWD(fn), FWD(args)...))) -> Ret
-    requires requires { _impl::template _invoke_r<Ret>(*this, FWD(fn), FWD(args)...); }
+  [[nodiscard]] constexpr auto apply_r(Fn &&fn, auto &&...args) & //
+      noexcept(noexcept(_impl::template _apply_r<Ret>(::std::declval<pack &>(), FWD(fn), FWD(args)...))) -> Ret
+    requires requires { _impl::template _apply_r<Ret>(*this, FWD(fn), FWD(args)...); }
   {
-    return _impl::template _invoke_r<Ret>(*this, FWD(fn), FWD(args)...);
+    return _impl::template _apply_r<Ret>(*this, FWD(fn), FWD(args)...);
   }
 
   /**
@@ -256,11 +256,11 @@ template <typename... Ts> struct pack : detail::pack_impl<::std::index_sequence_
    * @return TODO
    */
   template <typename Ret, typename Fn>
-  [[nodiscard]] constexpr auto invoke_r(Fn &&fn, auto &&...args) const & //
-      noexcept(noexcept(_impl::template _invoke_r<Ret>(::std::declval<pack const &>(), FWD(fn), FWD(args)...))) -> Ret
-    requires requires { _impl::template _invoke_r<Ret>(*this, FWD(fn), FWD(args)...); }
+  [[nodiscard]] constexpr auto apply_r(Fn &&fn, auto &&...args) const & //
+      noexcept(noexcept(_impl::template _apply_r<Ret>(::std::declval<pack const &>(), FWD(fn), FWD(args)...))) -> Ret
+    requires requires { _impl::template _apply_r<Ret>(*this, FWD(fn), FWD(args)...); }
   {
-    return _impl::template _invoke_r<Ret>(*this, FWD(fn), FWD(args)...);
+    return _impl::template _apply_r<Ret>(*this, FWD(fn), FWD(args)...);
   }
 
   /**
@@ -273,11 +273,11 @@ template <typename... Ts> struct pack : detail::pack_impl<::std::index_sequence_
    * @return TODO
    */
   template <typename Ret, typename Fn>
-  [[nodiscard]] constexpr auto invoke_r(Fn &&fn, auto &&...args) && //
-      noexcept(noexcept(_impl::template _invoke_r<Ret>(::std::declval<pack &&>(), FWD(fn), FWD(args)...))) -> Ret
-    requires requires { _impl::template _invoke_r<Ret>(::std::move(*this), FWD(fn), FWD(args)...); }
+  [[nodiscard]] constexpr auto apply_r(Fn &&fn, auto &&...args) && //
+      noexcept(noexcept(_impl::template _apply_r<Ret>(::std::declval<pack &&>(), FWD(fn), FWD(args)...))) -> Ret
+    requires requires { _impl::template _apply_r<Ret>(::std::move(*this), FWD(fn), FWD(args)...); }
   {
-    return _impl::template _invoke_r<Ret>(::std::move(*this), FWD(fn), FWD(args)...);
+    return _impl::template _apply_r<Ret>(::std::move(*this), FWD(fn), FWD(args)...);
   }
 
   /**
@@ -290,11 +290,11 @@ template <typename... Ts> struct pack : detail::pack_impl<::std::index_sequence_
    * @return TODO
    */
   template <typename Ret, typename Fn>
-  [[nodiscard]] constexpr auto invoke_r(Fn &&fn, auto &&...args) const && //
-      noexcept(noexcept(_impl::template _invoke_r<Ret>(::std::declval<pack const &&>(), FWD(fn), FWD(args)...))) -> Ret
-    requires requires { _impl::template _invoke_r<Ret>(::std::move(*this), FWD(fn), FWD(args)...); }
+  [[nodiscard]] constexpr auto apply_r(Fn &&fn, auto &&...args) const && //
+      noexcept(noexcept(_impl::template _apply_r<Ret>(::std::declval<pack const &&>(), FWD(fn), FWD(args)...))) -> Ret
+    requires requires { _impl::template _apply_r<Ret>(::std::move(*this), FWD(fn), FWD(args)...); }
   {
-    return _impl::template _invoke_r<Ret>(::std::move(*this), FWD(fn), FWD(args)...);
+    return _impl::template _apply_r<Ret>(::std::move(*this), FWD(fn), FWD(args)...);
   }
 };
 
@@ -304,7 +304,7 @@ template <typename... Args> pack(Args &&...args) -> pack<Args...>;
  * @brief Tuple-protocol element access
  *
  * Returns the `I`-th element carrying the pack's cv-qualification and value
- * category, exactly as `invoke` would pass it. Found by ADL, so it also serves
+ * category, exactly as `apply` would pass it. Found by ADL, so it also serves
  * structured bindings and the generic `using ::std::get; get<I>(p)` idiom.
  *
  * @tparam I element index

--- a/include/fn/recover.hpp
+++ b/include/fn/recover.hpp
@@ -26,20 +26,19 @@ namespace fn {
 // reference to it, which a prvalue cannot. The success branch carries the existing value over, so
 // that must survive the trip too.
 template <typename Fn, typename V>
-concept invocable_recover //
+concept applicable_recover //
     = (some_expected_non_void<V> && requires(Fn &&fn, V &&v) {
         {
-          ::fn::invoke(FWD(fn), FWD(v).error())
+          ::fn::apply(FWD(fn), FWD(v).error())
         } -> ::std::convertible_to<typename ::std::remove_cvref_t<V>::value_type>;
         requires ::std::is_constructible_v<::std::remove_cvref_t<V>, ::std::in_place_t,
-                                           decltype(::fn::invoke(FWD(fn), FWD(v).error()))>;
+                                           decltype(::fn::apply(FWD(fn), FWD(v).error()))>;
         requires detail::_relocatable_value<V>;
       }) || (some_expected_void<V> && requires(Fn &&fn, V &&v) {
-        { ::fn::invoke(FWD(fn), FWD(v).error()) } -> ::std::same_as<void>;
+        { ::fn::apply(FWD(fn), FWD(v).error()) } -> ::std::same_as<void>;
       }) || (some_optional<V> && requires(Fn &&fn, V &&v) {
-        { ::fn::invoke(FWD(fn)) } -> ::std::convertible_to<typename ::std::remove_cvref_t<V>::value_type>;
-        requires ::std::is_constructible_v<::std::remove_cvref_t<V>, ::std::in_place_t,
-                                           decltype(::fn::invoke(FWD(fn)))>;
+        { ::fn::apply(FWD(fn)) } -> ::std::convertible_to<typename ::std::remove_cvref_t<V>::value_type>;
+        requires ::std::is_constructible_v<::std::remove_cvref_t<V>, ::std::in_place_t, decltype(::fn::apply(FWD(fn)))>;
         requires detail::_relocatable_value<V>;
       });
 
@@ -76,18 +75,18 @@ struct recover_t::apply final {
   template <some_expected_non_void V, typename Fn>
   [[nodiscard]] constexpr auto operator()(V &&v, Fn &&fn) const //
       noexcept(
-          ::fn::is_nothrow_invocable_v<Fn, decltype(FWD(v).error())>
+          ::fn::is_nothrow_applicable_v<Fn, decltype(FWD(v).error())>
           && ::std::is_nothrow_constructible_v<::std::remove_cvref_t<V>, ::std::in_place_t, decltype(FWD(v).value())>
           && ::std::is_nothrow_constructible_v<::std::remove_cvref_t<V>, ::std::in_place_t,
-                                               ::fn::invoke_result_t<Fn, decltype(FWD(v).error())>>)
+                                               ::fn::apply_result_t<Fn, decltype(FWD(v).error())>>)
           -> ::std::remove_cvref_t<V>
-    requires invocable_recover<Fn &&, V &&>
+    requires applicable_recover<Fn &&, V &&>
   {
     using type = ::std::remove_cvref_t<V>;
     if (v.has_value()) {
       return type{::std::in_place, FWD(v).value()};
     }
-    return type{::std::in_place, ::fn::invoke(FWD(fn), FWD(v).error())};
+    return type{::std::in_place, ::fn::apply(FWD(fn), FWD(v).error())};
   }
 
   /**
@@ -99,16 +98,16 @@ struct recover_t::apply final {
    */
   template <some_expected_void V, typename Fn>
   [[nodiscard]] constexpr auto operator()(V &&v, Fn &&fn) const //
-      noexcept(::fn::is_nothrow_invocable_v<Fn, decltype(FWD(v).error())>
+      noexcept(::fn::is_nothrow_applicable_v<Fn, decltype(FWD(v).error())>
                && ::std::is_nothrow_constructible_v<::std::remove_cvref_t<V>, ::std::in_place_t>)
           -> ::std::remove_cvref_t<V>
-    requires invocable_recover<Fn &&, V &&>
+    requires applicable_recover<Fn &&, V &&>
   {
     using type = ::std::remove_cvref_t<V>;
     if (v.has_value()) {
       return type{::std::in_place};
     }
-    ::fn::invoke(FWD(fn), FWD(v).error()); // side-effects only
+    ::fn::apply(FWD(fn), FWD(v).error()); // side-effects only
     return type{::std::in_place};
   }
 
@@ -122,17 +121,17 @@ struct recover_t::apply final {
   template <some_optional V, typename Fn>
   [[nodiscard]] constexpr auto operator()(V &&v, Fn &&fn) const //
       noexcept(
-          ::fn::is_nothrow_invocable_v<Fn>
+          ::fn::is_nothrow_applicable_v<Fn>
           && ::std::is_nothrow_constructible_v<::std::remove_cvref_t<V>, ::std::in_place_t, decltype(FWD(v).value())>
-          && ::std::is_nothrow_constructible_v<::std::remove_cvref_t<V>, ::std::in_place_t, ::fn::invoke_result_t<Fn>>)
+          && ::std::is_nothrow_constructible_v<::std::remove_cvref_t<V>, ::std::in_place_t, ::fn::apply_result_t<Fn>>)
           -> ::std::remove_cvref_t<V>
-    requires invocable_recover<Fn &&, V &&>
+    requires applicable_recover<Fn &&, V &&>
   {
     using type = ::std::remove_cvref_t<V>;
     if (v.has_value()) {
       return type{::std::in_place, FWD(v).value()};
     }
-    return type{::std::in_place, ::fn::invoke(FWD(fn))};
+    return type{::std::in_place, ::fn::apply(FWD(fn))};
   }
 
   // No support for choice since there's no error to recover from

--- a/include/fn/sum.hpp
+++ b/include/fn/sum.hpp
@@ -43,7 +43,7 @@ static constexpr bool _is_valid_sum_subtype //
     &&(not some_in_place_type<T>)           //
     &&::std::is_same_v<T, ::std::remove_cv_t<T>>;
 
-struct _invoke_autodetect_tag final {};
+struct _apply_autodetect_tag final {};
 
 // Whether comparing an alternative can throw. An alternative the other side does not have is never
 // compared, so it cannot throw - and need not even be comparable, which is why this is a guarded
@@ -54,17 +54,17 @@ template <typename T, typename... Tx>
   requires type_one_of<T, Tx...>
 constexpr inline bool _nothrow_eq_with<T, Tx...> = noexcept(::std::declval<T const &>() == ::std::declval<T const &>());
 
-template <typename Fn, typename Self, typename T, typename... Args> struct _typelist_select_invoke_result;
+template <typename Fn, typename Self, typename T, typename... Args> struct _typelist_select_apply_result;
 template <typename Fn, typename Self, template <typename...> typename Tpl, typename... Ts, typename... Args>
-struct _typelist_select_invoke_result<Fn, Self, Tpl<Ts...>, Args...> {
+struct _typelist_select_apply_result<Fn, Self, Tpl<Ts...>, Args...> {
   using T0 = select_nth_t<0, Ts...>;
-  using R0 = ::fn::detail::_invoke_result<Fn, apply_const_lvalue_t<Self, T0>, Args...>::type;
+  using R0 = ::fn::detail::_apply_result<Fn, apply_const_lvalue_t<Self, T0>, Args...>::type;
   static constexpr bool type_found
       = (...
          && ::std::is_same_v<R0,
-                             typename ::fn::detail::_invoke_result<Fn, apply_const_lvalue_t<Self, Ts>, Args...>::type>);
-  // If every alternative is invocable here, they must all yield the same result type.
-  static_assert(not(... && ::fn::detail::_is_invocable<Fn, apply_const_lvalue_t<Self, Ts>, Args...>::value)
+                             typename ::fn::detail::_apply_result<Fn, apply_const_lvalue_t<Self, Ts>, Args...>::type>);
+  // If every alternative is applicable here, they must all yield the same result type.
+  static_assert(not(... && ::fn::detail::_is_applicable<Fn, apply_const_lvalue_t<Self, Ts>, Args...>::value)
                 || type_found);
   using type = ::std::conditional_t<type_found, R0, void>;
 };
@@ -106,20 +106,20 @@ struct _typelist_collapsing_sum<Fn, Self, Tpl<Ts...>, Args...>
     : _collapsing_sum_gate<
           (...
            && _collapsible_result<::std::remove_cvref_t<
-               typename ::fn::detail::_invoke_result<Fn, apply_const_lvalue_t<Self, Ts>, Args...>::type>>),
+               typename ::fn::detail::_apply_result<Fn, apply_const_lvalue_t<Self, Ts>, Args...>::type>>),
           Tpl,
           ::std::remove_cvref_t<
-              typename ::fn::detail::_invoke_result<Fn, apply_const_lvalue_t<Self, Ts>, Args...>::type>...> {};
+              typename ::fn::detail::_apply_result<Fn, apply_const_lvalue_t<Self, Ts>, Args...>::type>...> {};
 
-template <typename T, typename Fn, typename Self, typename... Args> struct _sum_invoke_result final {
+template <typename T, typename Fn, typename Self, typename... Args> struct _sum_apply_result final {
   using type = T;
 };
 template <typename Fn, typename Self, typename... Args>
-struct _sum_invoke_result<_invoke_autodetect_tag, Fn, Self, Args...> final {
-  using type = _typelist_select_invoke_result<Fn, Self, ::std::remove_cvref_t<Self>, Args...>::type;
+struct _sum_apply_result<_apply_autodetect_tag, Fn, Self, Args...> final {
+  using type = _typelist_select_apply_result<Fn, Self, ::std::remove_cvref_t<Self>, Args...>::type;
 };
 template <typename Fn, typename Self, typename... Args>
-struct _sum_invoke_result<_collapsing_sum_tag, Fn, Self, Args...> final
+struct _sum_apply_result<_collapsing_sum_tag, Fn, Self, Args...> final
     : _typelist_collapsing_sum<Fn, Self, ::std::remove_cvref_t<Self>, Args...> {};
 
 template <typename Fn, typename Self, typename T> struct _typelist_type_select_invoke_result;
@@ -147,7 +147,7 @@ struct _typelist_type_collapsing_sum<Fn, Self, Tpl<Ts...>>
 template <typename T, typename Fn, typename Self> struct _sum_invoke_type_result final {
   using type = T;
 };
-template <typename Fn, typename Self> struct _sum_invoke_type_result<_invoke_autodetect_tag, Fn, Self> final {
+template <typename Fn, typename Self> struct _sum_invoke_type_result<_apply_autodetect_tag, Fn, Self> final {
   using type = _typelist_type_select_invoke_result<Fn, Self, ::std::remove_cvref_t<Self>>::type;
 };
 template <typename Fn, typename Self>
@@ -721,15 +721,15 @@ struct sum<Ts...> {
    * @return TODO
    */
   template <typename Fn, typename... Args>
-  [[nodiscard]] constexpr auto invoke(Fn &&fn, Args &&...args) & noexcept(
-      detail::_is_nothrow_rts_invocable<
-          typename detail::_sum_invoke_result<detail::_invoke_autodetect_tag, Fn &&, sum &, Args &&...>::type, Fn &&,
+  [[nodiscard]] constexpr auto apply(Fn &&fn, Args &&...args) & noexcept(
+      detail::_is_nothrow_rts_applicable<
+          typename detail::_sum_apply_result<detail::_apply_autodetect_tag, Fn &&, sum &, Args &&...>::type, Fn &&,
           sum &, Args &&...>) ->
-      typename detail::_sum_invoke_result<detail::_invoke_autodetect_tag, Fn &&, sum &, Args &&...>::type
-    requires typelist_invocable<Fn, sum &, Args &&...>
+      typename detail::_sum_apply_result<detail::_apply_autodetect_tag, Fn &&, sum &, Args &&...>::type
+    requires typelist_applicable<Fn, sum &, Args &&...>
   {
-    using type = detail::_sum_invoke_result<detail::_invoke_autodetect_tag, Fn &&, sum &, Args &&...>::type;
-    return detail::invoke_variadic_union<type, data_t>(this->data, index, FWD(fn), FWD(args)...);
+    using type = detail::_sum_apply_result<detail::_apply_autodetect_tag, Fn &&, sum &, Args &&...>::type;
+    return detail::apply_variadic_union<type, data_t>(this->data, index, FWD(fn), FWD(args)...);
   }
 
   /**
@@ -742,15 +742,15 @@ struct sum<Ts...> {
    * @return TODO
    */
   template <typename Fn, typename... Args>
-  [[nodiscard]] constexpr auto invoke(Fn &&fn, Args &&...args) const & noexcept(
-      detail::_is_nothrow_rts_invocable<
-          typename detail::_sum_invoke_result<detail::_invoke_autodetect_tag, Fn &&, sum const &, Args &&...>::type,
+  [[nodiscard]] constexpr auto apply(Fn &&fn, Args &&...args) const & noexcept(
+      detail::_is_nothrow_rts_applicable<
+          typename detail::_sum_apply_result<detail::_apply_autodetect_tag, Fn &&, sum const &, Args &&...>::type,
           Fn &&, sum const &, Args &&...>) ->
-      typename detail::_sum_invoke_result<detail::_invoke_autodetect_tag, Fn &&, sum const &, Args &&...>::type
-    requires typelist_invocable<Fn, sum const &, Args &&...>
+      typename detail::_sum_apply_result<detail::_apply_autodetect_tag, Fn &&, sum const &, Args &&...>::type
+    requires typelist_applicable<Fn, sum const &, Args &&...>
   {
-    using type = detail::_sum_invoke_result<detail::_invoke_autodetect_tag, Fn &&, sum const &, Args &&...>::type;
-    return detail::invoke_variadic_union<type, data_t>(this->data, index, FWD(fn), FWD(args)...);
+    using type = detail::_sum_apply_result<detail::_apply_autodetect_tag, Fn &&, sum const &, Args &&...>::type;
+    return detail::apply_variadic_union<type, data_t>(this->data, index, FWD(fn), FWD(args)...);
   }
 
   /**
@@ -763,15 +763,15 @@ struct sum<Ts...> {
    * @return TODO
    */
   template <typename Fn, typename... Args>
-  [[nodiscard]] constexpr auto invoke(Fn &&fn, Args &&...args) && noexcept(
-      detail::_is_nothrow_rts_invocable<
-          typename detail::_sum_invoke_result<detail::_invoke_autodetect_tag, Fn &&, sum &&, Args &&...>::type, Fn &&,
+  [[nodiscard]] constexpr auto apply(Fn &&fn, Args &&...args) && noexcept(
+      detail::_is_nothrow_rts_applicable<
+          typename detail::_sum_apply_result<detail::_apply_autodetect_tag, Fn &&, sum &&, Args &&...>::type, Fn &&,
           sum &&, Args &&...>) ->
-      typename detail::_sum_invoke_result<detail::_invoke_autodetect_tag, Fn &&, sum &&, Args &&...>::type
-    requires typelist_invocable<Fn, sum &&, Args &&...>
+      typename detail::_sum_apply_result<detail::_apply_autodetect_tag, Fn &&, sum &&, Args &&...>::type
+    requires typelist_applicable<Fn, sum &&, Args &&...>
   {
-    using type = detail::_sum_invoke_result<detail::_invoke_autodetect_tag, Fn &&, sum &&, Args &&...>::type;
-    return detail::invoke_variadic_union<type, data_t>(::std::move(*this).data, index, FWD(fn), FWD(args)...);
+    using type = detail::_sum_apply_result<detail::_apply_autodetect_tag, Fn &&, sum &&, Args &&...>::type;
+    return detail::apply_variadic_union<type, data_t>(::std::move(*this).data, index, FWD(fn), FWD(args)...);
   }
 
   /**
@@ -784,15 +784,15 @@ struct sum<Ts...> {
    * @return TODO
    */
   template <typename Fn, typename... Args>
-  [[nodiscard]] constexpr auto invoke(Fn &&fn, Args &&...args) const && noexcept(
-      detail::_is_nothrow_rts_invocable<
-          typename detail::_sum_invoke_result<detail::_invoke_autodetect_tag, Fn &&, sum const &&, Args &&...>::type,
+  [[nodiscard]] constexpr auto apply(Fn &&fn, Args &&...args) const && noexcept(
+      detail::_is_nothrow_rts_applicable<
+          typename detail::_sum_apply_result<detail::_apply_autodetect_tag, Fn &&, sum const &&, Args &&...>::type,
           Fn &&, sum const &&, Args &&...>) ->
-      typename detail::_sum_invoke_result<detail::_invoke_autodetect_tag, Fn &&, sum const &&, Args &&...>::type
-    requires typelist_invocable<Fn, sum const &&, Args &&...>
+      typename detail::_sum_apply_result<detail::_apply_autodetect_tag, Fn &&, sum const &&, Args &&...>::type
+    requires typelist_applicable<Fn, sum const &&, Args &&...>
   {
-    using type = detail::_sum_invoke_result<detail::_invoke_autodetect_tag, Fn &&, sum const &&, Args &&...>::type;
-    return detail::invoke_variadic_union<type, data_t>(::std::move(*this).data, index, FWD(fn), FWD(args)...);
+    using type = detail::_sum_apply_result<detail::_apply_autodetect_tag, Fn &&, sum const &&, Args &&...>::type;
+    return detail::apply_variadic_union<type, data_t>(::std::move(*this).data, index, FWD(fn), FWD(args)...);
   }
 
   /**
@@ -807,11 +807,11 @@ struct sum<Ts...> {
    */
   template <typename Ret, typename Fn, typename... Args>
   [[nodiscard]] constexpr auto
-  invoke_r(Fn &&fn, Args &&...args) & noexcept(detail::_is_nothrow_rts_invocable<Ret, Fn &&, sum &, Args &&...>) -> Ret
-    requires typelist_invocable_r<Ret, Fn, sum &, Args &&...>
+  apply_r(Fn &&fn, Args &&...args) & noexcept(detail::_is_nothrow_rts_applicable<Ret, Fn &&, sum &, Args &&...>) -> Ret
+    requires typelist_applicable_r<Ret, Fn, sum &, Args &&...>
   {
-    using type = detail::_sum_invoke_result<Ret, Fn &&, sum &, Args &&...>::type;
-    return detail::invoke_variadic_union<type, data_t>(this->data, index, FWD(fn), FWD(args)...);
+    using type = detail::_sum_apply_result<Ret, Fn &&, sum &, Args &&...>::type;
+    return detail::apply_variadic_union<type, data_t>(this->data, index, FWD(fn), FWD(args)...);
   }
 
   /**
@@ -825,12 +825,12 @@ struct sum<Ts...> {
    * @return TODO
    */
   template <typename Ret, typename Fn, typename... Args>
-  [[nodiscard]] constexpr auto invoke_r(Fn &&fn, Args &&...args) const & noexcept(
-      detail::_is_nothrow_rts_invocable<Ret, Fn &&, sum const &, Args &&...>) -> Ret
-    requires typelist_invocable_r<Ret, Fn, sum const &, Args &&...>
+  [[nodiscard]] constexpr auto apply_r(Fn &&fn, Args &&...args) const & noexcept(
+      detail::_is_nothrow_rts_applicable<Ret, Fn &&, sum const &, Args &&...>) -> Ret
+    requires typelist_applicable_r<Ret, Fn, sum const &, Args &&...>
   {
-    using type = detail::_sum_invoke_result<Ret, Fn &&, sum const &, Args &&...>::type;
-    return detail::invoke_variadic_union<type, data_t>(this->data, index, FWD(fn), FWD(args)...);
+    using type = detail::_sum_apply_result<Ret, Fn &&, sum const &, Args &&...>::type;
+    return detail::apply_variadic_union<type, data_t>(this->data, index, FWD(fn), FWD(args)...);
   }
 
   /**
@@ -845,12 +845,12 @@ struct sum<Ts...> {
    */
   template <typename Ret, typename Fn, typename... Args>
   [[nodiscard]] constexpr auto
-  invoke_r(Fn &&fn, Args &&...args) && noexcept(detail::_is_nothrow_rts_invocable<Ret, Fn &&, sum &&, Args &&...>)
+  apply_r(Fn &&fn, Args &&...args) && noexcept(detail::_is_nothrow_rts_applicable<Ret, Fn &&, sum &&, Args &&...>)
       -> Ret
-    requires typelist_invocable_r<Ret, Fn, sum &&, Args &&...>
+    requires typelist_applicable_r<Ret, Fn, sum &&, Args &&...>
   {
-    using type = detail::_sum_invoke_result<Ret, Fn &&, sum &&, Args &&...>::type;
-    return detail::invoke_variadic_union<type, data_t>(::std::move(*this).data, index, FWD(fn), FWD(args)...);
+    using type = detail::_sum_apply_result<Ret, Fn &&, sum &&, Args &&...>::type;
+    return detail::apply_variadic_union<type, data_t>(::std::move(*this).data, index, FWD(fn), FWD(args)...);
   }
 
   /**
@@ -864,12 +864,12 @@ struct sum<Ts...> {
    * @return TODO
    */
   template <typename Ret, typename Fn, typename... Args>
-  [[nodiscard]] constexpr auto invoke_r(Fn &&fn, Args &&...args) const && noexcept(
-      detail::_is_nothrow_rts_invocable<Ret, Fn &&, sum const &&, Args &&...>) -> Ret
-    requires typelist_invocable_r<Ret, Fn, sum const &&, Args &&...>
+  [[nodiscard]] constexpr auto apply_r(Fn &&fn, Args &&...args) const && noexcept(
+      detail::_is_nothrow_rts_applicable<Ret, Fn &&, sum const &&, Args &&...>) -> Ret
+    requires typelist_applicable_r<Ret, Fn, sum const &&, Args &&...>
   {
-    using type = detail::_sum_invoke_result<Ret, Fn &&, sum const &&, Args &&...>::type;
-    return detail::invoke_variadic_union<type, data_t>(::std::move(*this).data, index, FWD(fn), FWD(args)...);
+    using type = detail::_sum_apply_result<Ret, Fn &&, sum const &&, Args &&...>::type;
+    return detail::apply_variadic_union<type, data_t>(::std::move(*this).data, index, FWD(fn), FWD(args)...);
   }
 
   /**
@@ -883,14 +883,14 @@ struct sum<Ts...> {
    */
   template <typename Fn, typename... Args>
   [[nodiscard]] constexpr auto transform(Fn &&fn, Args &&...args) & noexcept(
-      detail::_is_nothrow_rts_invocable<
-          typename detail::_sum_invoke_result<detail::_collapsing_sum_tag, Fn &&, sum &, Args &&...>::type, Fn &&,
-          sum &, Args &&...>) ->
-      typename detail::_sum_invoke_result<detail::_collapsing_sum_tag, Fn &&, sum &, Args &&...>::type
-    requires typelist_invocable<Fn, sum &, Args &&...>
+      detail::_is_nothrow_rts_applicable<
+          typename detail::_sum_apply_result<detail::_collapsing_sum_tag, Fn &&, sum &, Args &&...>::type, Fn &&, sum &,
+          Args &&...>) ->
+      typename detail::_sum_apply_result<detail::_collapsing_sum_tag, Fn &&, sum &, Args &&...>::type
+    requires typelist_applicable<Fn, sum &, Args &&...>
   {
-    using type = detail::_sum_invoke_result<detail::_collapsing_sum_tag, Fn &&, sum &, Args &&...>::type;
-    return detail::invoke_variadic_union<type, data_t>(this->data, index, FWD(fn), FWD(args)...);
+    using type = detail::_sum_apply_result<detail::_collapsing_sum_tag, Fn &&, sum &, Args &&...>::type;
+    return detail::apply_variadic_union<type, data_t>(this->data, index, FWD(fn), FWD(args)...);
   }
 
   /**
@@ -904,14 +904,14 @@ struct sum<Ts...> {
    */
   template <typename Fn, typename... Args>
   [[nodiscard]] constexpr auto transform(Fn &&fn, Args &&...args) const & noexcept(
-      detail::_is_nothrow_rts_invocable<
-          typename detail::_sum_invoke_result<detail::_collapsing_sum_tag, Fn &&, sum const &, Args &&...>::type, Fn &&,
+      detail::_is_nothrow_rts_applicable<
+          typename detail::_sum_apply_result<detail::_collapsing_sum_tag, Fn &&, sum const &, Args &&...>::type, Fn &&,
           sum const &, Args &&...>) ->
-      typename detail::_sum_invoke_result<detail::_collapsing_sum_tag, Fn &&, sum const &, Args &&...>::type
-    requires typelist_invocable<Fn, sum const &, Args &&...>
+      typename detail::_sum_apply_result<detail::_collapsing_sum_tag, Fn &&, sum const &, Args &&...>::type
+    requires typelist_applicable<Fn, sum const &, Args &&...>
   {
-    using type = detail::_sum_invoke_result<detail::_collapsing_sum_tag, Fn &&, sum const &, Args &&...>::type;
-    return detail::invoke_variadic_union<type, data_t>(this->data, index, FWD(fn), FWD(args)...);
+    using type = detail::_sum_apply_result<detail::_collapsing_sum_tag, Fn &&, sum const &, Args &&...>::type;
+    return detail::apply_variadic_union<type, data_t>(this->data, index, FWD(fn), FWD(args)...);
   }
 
   /**
@@ -925,14 +925,14 @@ struct sum<Ts...> {
    */
   template <typename Fn, typename... Args>
   [[nodiscard]] constexpr auto transform(Fn &&fn, Args &&...args) && noexcept(
-      detail::_is_nothrow_rts_invocable<
-          typename detail::_sum_invoke_result<detail::_collapsing_sum_tag, Fn &&, sum &&, Args &&...>::type, Fn &&,
+      detail::_is_nothrow_rts_applicable<
+          typename detail::_sum_apply_result<detail::_collapsing_sum_tag, Fn &&, sum &&, Args &&...>::type, Fn &&,
           sum &&, Args &&...>) ->
-      typename detail::_sum_invoke_result<detail::_collapsing_sum_tag, Fn &&, sum &&, Args &&...>::type
-    requires typelist_invocable<Fn, sum &&, Args &&...>
+      typename detail::_sum_apply_result<detail::_collapsing_sum_tag, Fn &&, sum &&, Args &&...>::type
+    requires typelist_applicable<Fn, sum &&, Args &&...>
   {
-    using type = detail::_sum_invoke_result<detail::_collapsing_sum_tag, Fn &&, sum &&, Args &&...>::type;
-    return detail::invoke_variadic_union<type, data_t>(::std::move(*this).data, index, FWD(fn), FWD(args)...);
+    using type = detail::_sum_apply_result<detail::_collapsing_sum_tag, Fn &&, sum &&, Args &&...>::type;
+    return detail::apply_variadic_union<type, data_t>(::std::move(*this).data, index, FWD(fn), FWD(args)...);
   }
 
   /**
@@ -946,14 +946,14 @@ struct sum<Ts...> {
    */
   template <typename Fn, typename... Args>
   [[nodiscard]] constexpr auto transform(Fn &&fn, Args &&...args) const && noexcept(
-      detail::_is_nothrow_rts_invocable<
-          typename detail::_sum_invoke_result<detail::_collapsing_sum_tag, Fn &&, sum const &&, Args &&...>::type,
-          Fn &&, sum const &&, Args &&...>) ->
-      typename detail::_sum_invoke_result<detail::_collapsing_sum_tag, Fn &&, sum const &&, Args &&...>::type
-    requires typelist_invocable<Fn, sum const &&, Args &&...>
+      detail::_is_nothrow_rts_applicable<
+          typename detail::_sum_apply_result<detail::_collapsing_sum_tag, Fn &&, sum const &&, Args &&...>::type, Fn &&,
+          sum const &&, Args &&...>) ->
+      typename detail::_sum_apply_result<detail::_collapsing_sum_tag, Fn &&, sum const &&, Args &&...>::type
+    requires typelist_applicable<Fn, sum const &&, Args &&...>
   {
-    using type = detail::_sum_invoke_result<detail::_collapsing_sum_tag, Fn &&, sum const &&, Args &&...>::type;
-    return detail::invoke_variadic_union<type, data_t>(::std::move(*this).data, index, FWD(fn), FWD(args)...);
+    using type = detail::_sum_apply_result<detail::_collapsing_sum_tag, Fn &&, sum const &&, Args &&...>::type;
+    return detail::apply_variadic_union<type, data_t>(::std::move(*this).data, index, FWD(fn), FWD(args)...);
   }
 };
 

--- a/include/fn/transform.hpp
+++ b/include/fn/transform.hpp
@@ -24,11 +24,11 @@ namespace fn {
  * @tparam V TODO
  */
 template <typename Fn, typename V>
-concept invocable_transform //
+concept applicable_transform //
     = (some_expected_non_void<V>//
            && (not some_sum<typename ::std::remove_cvref_t<V>::value_type>) && requires(Fn &&fn, V &&v) {
         {
-          ::fn::invoke(FWD(fn), FWD(v).value())
+          ::fn::apply(FWD(fn), FWD(v).value())
         } -> convertible_to_expected<typename ::std::remove_cvref_t<decltype(v)>::error_type>;
       }) || (some_expected<V> && some_sum<typename ::std::remove_cvref_t<V>::value_type> && requires(Fn &&fn, V &&v) {
         {
@@ -36,12 +36,12 @@ concept invocable_transform //
         } -> convertible_to_expected<typename ::std::remove_cvref_t<decltype(v)>::error_type>;
       }) || (some_expected_void<V> && requires(Fn &&fn, V &&v) {
         {
-          ::fn::invoke(FWD(fn))
+          ::fn::apply(FWD(fn))
         } -> convertible_to_expected<typename ::std::remove_cvref_t<decltype(v)>::error_type>;
       }) || (some_optional<V> //
             && (not some_sum<typename ::std::remove_cvref_t<V>::value_type>) && requires(Fn &&fn, V &&v) {
         {
-          ::fn::invoke(FWD(fn), FWD(v).value())
+          ::fn::apply(FWD(fn), FWD(v).value())
         } -> convertible_to_optional;
       }) || (some_optional<V> && some_sum<typename ::std::remove_cvref_t<V>::value_type> && requires(Fn &&fn, V &&v) {
         {
@@ -86,7 +86,7 @@ struct transform_t::apply final {
   template <some_monadic_type V, typename Fn>
   [[nodiscard]] constexpr auto operator()(V &&v, Fn &&fn) const noexcept(noexcept(FWD(v).transform(FWD(fn))))
       -> same_kind<V &&> auto
-    requires invocable_transform<Fn &&, V &&>
+    requires applicable_transform<Fn &&, V &&>
   {
     return FWD(v).transform(FWD(fn));
   }

--- a/include/fn/transform_error.hpp
+++ b/include/fn/transform_error.hpp
@@ -18,9 +18,9 @@ namespace fn {
  * @tparam V TODO
  */
 template <typename Fn, typename V>
-concept invocable_transform_error //
+concept applicable_transform_error //
     = (some_expected<V> && (not some_sum<typename ::std::remove_cvref_t<V>::error_type>) && requires(Fn &&fn, V &&v) {
-        { ::fn::invoke(FWD(fn), FWD(v).error()) } -> convertible_to_unexpected;
+        { ::fn::apply(FWD(fn), FWD(v).error()) } -> convertible_to_unexpected;
       }) || (some_expected<V> && some_sum<typename ::std::remove_cvref_t<V>::error_type> && requires(Fn &&fn, V &&v) {
         {
           FWD(v).error().transform(FWD(fn))
@@ -61,7 +61,7 @@ struct transform_error_t::apply final {
   template <some_expected V, typename Fn>
   [[nodiscard]] constexpr auto operator()(V &&v, Fn &&fn) const noexcept(noexcept(FWD(v).transform_error(FWD(fn))))
       -> same_value_kind<V &&> auto
-    requires invocable_transform_error<Fn &&, V &&>
+    requires applicable_transform_error<Fn &&, V &&>
   {
     return FWD(v).transform_error(FWD(fn));
   }

--- a/include/fn/value_or.hpp
+++ b/include/fn/value_or.hpp
@@ -24,7 +24,7 @@ namespace fn {
 // be able to survive that: an immovable value type would otherwise satisfy this and then fail inside
 // the body.
 template <typename V, typename... Args>
-concept invocable_value_or                                                                                          //
+concept applicable_value_or                                                                                         //
     = (some_expected_non_void<V> && ::std::is_constructible_v<::std::remove_cvref_t<V>, ::std::in_place_t, Args...> //
        && detail::_relocatable_value<V>)
       || (some_optional<V> && ::std::is_constructible_v<::std::remove_cvref_t<V>, ::std::in_place_t, Args...>
@@ -69,7 +69,7 @@ struct value_or_t::apply final {
           ::std::is_nothrow_constructible_v<::std::remove_cvref_t<V>, ::std::in_place_t, Args...>
           && ::std::is_nothrow_constructible_v<::std::remove_cvref_t<V>, ::std::in_place_t, decltype(FWD(v).value())>)
           -> ::std::remove_cvref_t<V>
-    requires invocable_value_or<V &&, Args...>
+    requires applicable_value_or<V &&, Args...>
   {
     using type = ::std::remove_cvref_t<V>;
     return FWD(v).or_else([&args...](auto &&...) -> type { return type{::std::in_place, FWD(args)...}; });

--- a/tests/fn/and_then.cpp
+++ b/tests/fn/and_then.cpp
@@ -72,12 +72,12 @@ template <typename Operand> constexpr bool member_viability()
   using M = member_fns<Operand>;
 
   static_assert(is::invocable_with_any(M::fn0));
-  static_assert(is::template invocable<lvalue>(M::fn1));
+  static_assert(is::template applicable<lvalue>(M::fn1));
   static_assert(is::template not_invocable<prvalue, cvalue, clvalue, rvalue, crvalue>(M::fn1));
   static_assert(is::invocable_with_any(M::fn2));
-  static_assert(is::template invocable<prvalue, rvalue>(M::fn3));
+  static_assert(is::template applicable<prvalue, rvalue>(M::fn3));
   static_assert(is::template not_invocable<cvalue, lvalue, clvalue, crvalue>(M::fn3));
-  static_assert(is::template invocable<prvalue, cvalue, rvalue, crvalue>(M::fn4));
+  static_assert(is::template applicable<prvalue, cvalue, rvalue, crvalue>(M::fn4));
   static_assert(is::template not_invocable<lvalue, clvalue>(M::fn4));
   return true;
 }
@@ -100,7 +100,7 @@ TEMPLATE_TEST_CASE("and_then member", "[and_then][member_functions]", ExpectedXi
     {
       static_assert(monadic_static_check<fn::and_then_t, decltype(v)>::invocable_with_any(M::fn0));
 
-      auto const r = fn::invoke(and_then_t::apply{}, v, M::fn0);
+      auto const r = fn::apply(and_then_t::apply{}, v, M::fn0);
       CHECK(r.value() == 2);
 
       auto const q = v | and_then(M::fn0);
@@ -113,7 +113,7 @@ TEMPLATE_TEST_CASE("and_then member", "[and_then][member_functions]", ExpectedXi
     {
       static_assert(monadic_static_check<fn::and_then_t, decltype(v)>::invocable_with_any(M::fn2));
 
-      auto const r = fn::invoke(and_then_t::apply{}, v, M::fn2);
+      auto const r = fn::apply(and_then_t::apply{}, v, M::fn2);
       CHECK(r.value() == 4);
 
       auto const q = v | and_then(M::fn2);
@@ -128,9 +128,9 @@ TEMPLATE_TEST_CASE("and_then member", "[and_then][member_functions]", ExpectedXi
     SECTION("const rvalue-ref")
     {
       static_assert(
-          monadic_static_check<fn::and_then_t, decltype(v)>::template invocable<prvalue, crvalue, cvalue>(M::fn4));
+          monadic_static_check<fn::and_then_t, decltype(v)>::template applicable<prvalue, crvalue, cvalue>(M::fn4));
 
-      auto const r = fn::invoke(and_then_t::apply{}, std::move(v), M::fn4);
+      auto const r = fn::apply(and_then_t::apply{}, std::move(v), M::fn4);
       CHECK(r.value() == 6);
 
       auto const q = std::move(v) | and_then(M::fn4);
@@ -149,7 +149,7 @@ TEMPLATE_TEST_CASE("and_then member", "[and_then][member_functions]", ExpectedXi
     {
       static_assert(monadic_static_check<fn::and_then_t, decltype(v)>::invocable_with_any(M::fn0));
 
-      auto const r = fn::invoke(and_then_t::apply{}, v, M::fn0);
+      auto const r = fn::apply(and_then_t::apply{}, v, M::fn0);
       CHECK(r.value() == 2);
 
       auto const q = v | and_then(M::fn0);
@@ -158,9 +158,9 @@ TEMPLATE_TEST_CASE("and_then member", "[and_then][member_functions]", ExpectedXi
 
     SECTION("lvalue-ref")
     {
-      static_assert(monadic_static_check<fn::and_then_t, decltype(v)>::template invocable<lvalue>(M::fn1));
+      static_assert(monadic_static_check<fn::and_then_t, decltype(v)>::template applicable<lvalue>(M::fn1));
 
-      auto const r = fn::invoke(and_then_t::apply{}, v, M::fn1);
+      auto const r = fn::apply(and_then_t::apply{}, v, M::fn1);
       CHECK(r.value() == 3);
 
       auto const q = v | and_then(M::fn1);
@@ -174,7 +174,7 @@ TEMPLATE_TEST_CASE("and_then member", "[and_then][member_functions]", ExpectedXi
     {
       static_assert(monadic_static_check<fn::and_then_t, decltype(v)>::invocable_with_any(M::fn2));
 
-      auto const r = fn::invoke(and_then_t::apply{}, v, M::fn2);
+      auto const r = fn::apply(and_then_t::apply{}, v, M::fn2);
       CHECK(r.value() == 4);
 
       auto const q = v | and_then(M::fn2);
@@ -186,9 +186,9 @@ TEMPLATE_TEST_CASE("and_then member", "[and_then][member_functions]", ExpectedXi
 
     SECTION("rvalue-ref")
     {
-      static_assert(monadic_static_check<fn::and_then_t, decltype(v)>::template invocable<prvalue, rvalue>(M::fn3));
+      static_assert(monadic_static_check<fn::and_then_t, decltype(v)>::template applicable<prvalue, rvalue>(M::fn3));
 
-      auto const r = fn::invoke(and_then_t::apply{}, std::move(v), M::fn3);
+      auto const r = fn::apply(and_then_t::apply{}, std::move(v), M::fn3);
       CHECK(r.value() == 5);
 
       auto const q = std::move(v) | and_then(M::fn3);
@@ -201,9 +201,9 @@ TEMPLATE_TEST_CASE("and_then member", "[and_then][member_functions]", ExpectedXi
     SECTION("const rvalue-ref")
     {
       static_assert(
-          monadic_static_check<fn::and_then_t, decltype(v)>::template invocable<prvalue, crvalue, cvalue>(M::fn4));
+          monadic_static_check<fn::and_then_t, decltype(v)>::template applicable<prvalue, crvalue, cvalue>(M::fn4));
 
-      auto const r = fn::invoke(and_then_t::apply{}, std::move(v), M::fn4);
+      auto const r = fn::apply(and_then_t::apply{}, std::move(v), M::fn4);
       CHECK(r.value() == 6);
 
       auto const q = std::move(v) | and_then(M::fn4);
@@ -230,14 +230,14 @@ TEST_CASE("and_then", "[and_then][expected][expected_value][pack]")
   constexpr auto fnXabs = [](int i) -> fn::expected<Xint, Error> { return {{std::abs(8 - i)}}; };
 
   static_assert(is::invocable_with_any(fnValue));
-  static_assert(is::invocable_with_any([](auto...) -> operand_t { throw 0; }));              // allow generic call
-  static_assert(is::invocable_with_any([](int) -> operand_t { throw 0; }));                  // allow copy
-  static_assert(is::invocable_with_any([](unsigned) -> operand_t { throw 0; }));             // allow conversion
-  static_assert(is::invocable_with_any([](int) -> operand_other_t { throw 0; }));            // allow conversion
-  static_assert(is::invocable_with_any([](int const &) -> operand_t { throw 0; }));          // binds to const ref
-  static_assert(is::invocable<lvalue>([](int &) -> operand_t { throw 0; }));                 // binds to lvalue
-  static_assert(is::invocable<rvalue, prvalue>([](int &&) -> operand_t { throw 0; }));       // can move
-  static_assert(is::invocable<rvalue, crvalue>([](int const &&) -> operand_t { throw 0; })); // binds to const rvalue
+  static_assert(is::invocable_with_any([](auto...) -> operand_t { throw 0; }));               // allow generic call
+  static_assert(is::invocable_with_any([](int) -> operand_t { throw 0; }));                   // allow copy
+  static_assert(is::invocable_with_any([](unsigned) -> operand_t { throw 0; }));              // allow conversion
+  static_assert(is::invocable_with_any([](int) -> operand_other_t { throw 0; }));             // allow conversion
+  static_assert(is::invocable_with_any([](int const &) -> operand_t { throw 0; }));           // binds to const ref
+  static_assert(is::applicable<lvalue>([](int &) -> operand_t { throw 0; }));                 // binds to lvalue
+  static_assert(is::applicable<rvalue, prvalue>([](int &&) -> operand_t { throw 0; }));       // can move
+  static_assert(is::applicable<rvalue, crvalue>([](int const &&) -> operand_t { throw 0; })); // binds to const rvalue
   static_assert(is::not_invocable_with_any([](int) -> operand_other_err_t { throw 0; })); // disallow error conversion
   static_assert(
       is::not_invocable<clvalue, crvalue, cvalue>([](int &) -> operand_t { throw 0; })); // cannot remove const
@@ -285,10 +285,10 @@ TEST_CASE("and_then", "[and_then][expected][expected_value][pack]")
     static_assert(not std::is_nothrow_copy_constructible_v<ThrowingCopy>);
     static_assert(not noexcept(and_then(std::declval<ThrowingCopy const &>())));
 
-    // fn::invoke reaches the very same apply and reports the same answer: the library's two entry
+    // fn::apply reaches the very same apply and reports the same answer: the library's two entry
     // points to one operation agree, where they once disagreed in opposite directions
-    static_assert(not noexcept(fn::invoke(and_then_t::apply{}, std::declval<operand_t &>(), fnThrows)));
-    static_assert(noexcept(fn::invoke(and_then_t::apply{}, std::declval<nothrow_t &>(), fnNothrow2)));
+    static_assert(not noexcept(fn::apply(and_then_t::apply{}, std::declval<operand_t &>(), fnThrows)));
+    static_assert(noexcept(fn::apply(and_then_t::apply{}, std::declval<nothrow_t &>(), fnNothrow2)));
 
     SUCCEED();
   }
@@ -667,14 +667,14 @@ TEST_CASE("and_then", "[and_then][optional][pack]")
   constexpr auto fnXabs = [](int i) -> fn::optional<Xint> { return {{std::abs(8 - i)}}; };
 
   static_assert(is::invocable_with_any(fnValue));
-  static_assert(is::invocable_with_any([](auto...) -> operand_t { throw 0; }));              // allow generic call
-  static_assert(is::invocable_with_any([](int) -> operand_t { throw 0; }));                  // allow copy
-  static_assert(is::invocable_with_any([](unsigned) -> operand_t { throw 0; }));             // allow conversion
-  static_assert(is::invocable_with_any([](int) -> operand_other_t { throw 0; }));            // allow conversion
-  static_assert(is::invocable_with_any([](int const &) -> operand_t { throw 0; }));          // binds to const ref
-  static_assert(is::invocable<lvalue>([](int &) -> operand_t { throw 0; }));                 // binds to lvalue
-  static_assert(is::invocable<rvalue, prvalue>([](int &&) -> operand_t { throw 0; }));       // can move
-  static_assert(is::invocable<rvalue, crvalue>([](int const &&) -> operand_t { throw 0; })); // binds to const rvalue
+  static_assert(is::invocable_with_any([](auto...) -> operand_t { throw 0; }));               // allow generic call
+  static_assert(is::invocable_with_any([](int) -> operand_t { throw 0; }));                   // allow copy
+  static_assert(is::invocable_with_any([](unsigned) -> operand_t { throw 0; }));              // allow conversion
+  static_assert(is::invocable_with_any([](int) -> operand_other_t { throw 0; }));             // allow conversion
+  static_assert(is::invocable_with_any([](int const &) -> operand_t { throw 0; }));           // binds to const ref
+  static_assert(is::applicable<lvalue>([](int &) -> operand_t { throw 0; }));                 // binds to lvalue
+  static_assert(is::applicable<rvalue, prvalue>([](int &&) -> operand_t { throw 0; }));       // can move
+  static_assert(is::applicable<rvalue, crvalue>([](int const &&) -> operand_t { throw 0; })); // binds to const rvalue
   static_assert(
       is::not_invocable<clvalue, crvalue, cvalue>([](int &) -> operand_t { throw 0; })); // cannot remove const
   static_assert(is::not_invocable<rvalue>([](int &) -> operand_t { throw 0; }));         // disallow bind
@@ -886,13 +886,13 @@ TEST_CASE("and_then choice", "[and_then][choice]")
   constexpr auto fnXabs = [](int i) -> operand_other_t { return {Xint{std::abs(8 - i)}}; };
 
   static_assert(is::invocable_with_any(fnValue));
-  static_assert(is::invocable_with_any([](int) -> operand_t { throw 0; }));                   // allow copy
-  static_assert(is::invocable_with_any([](unsigned) -> operand_t { throw 0; }));              // allow conversion
-  static_assert(is::invocable_with_any([](int) -> operand_other_t { throw 0; }));             // allow conversion
-  static_assert(is::invocable_with_any([](int const &) -> operand_t { throw 0; }));           // binds to const ref
-  static_assert(is::invocable<lvalue>([](auto &) -> operand_t { throw 0; }));                 // binds to lvalue
-  static_assert(is::invocable<rvalue, prvalue>([](auto &&) -> operand_t { throw 0; }));       // can move
-  static_assert(is::invocable<rvalue, crvalue>([](auto const &&) -> operand_t { throw 0; })); // binds to const rvalue
+  static_assert(is::invocable_with_any([](int) -> operand_t { throw 0; }));                    // allow copy
+  static_assert(is::invocable_with_any([](unsigned) -> operand_t { throw 0; }));               // allow conversion
+  static_assert(is::invocable_with_any([](int) -> operand_other_t { throw 0; }));              // allow conversion
+  static_assert(is::invocable_with_any([](int const &) -> operand_t { throw 0; }));            // binds to const ref
+  static_assert(is::applicable<lvalue>([](auto &) -> operand_t { throw 0; }));                 // binds to lvalue
+  static_assert(is::applicable<rvalue, prvalue>([](auto &&) -> operand_t { throw 0; }));       // can move
+  static_assert(is::applicable<rvalue, crvalue>([](auto const &&) -> operand_t { throw 0; })); // binds to const rvalue
 
   constexpr auto fnLvalue = fn::overload{[](bool &) -> operand_t { throw 0; },   //
                                          [](double &) -> operand_t { throw 0; }, //
@@ -968,11 +968,11 @@ TEST_CASE("and_then choice", "[and_then][choice]")
         return {0.0};
       };
       constexpr auto r1 = T{0} | fn::and_then(fn);
-      static_assert(r1.invoke([](int i) -> int { return i; }) == 1);
+      static_assert(r1.apply([](int i) -> int { return i; }) == 1);
       constexpr auto r2 = T{0.5} | fn::and_then(fn);
-      static_assert(r2.invoke([](int i) -> int { return i; }) == 1);
+      static_assert(r2.apply([](int i) -> int { return i; }) == 1);
       constexpr auto r3 = r1 | fn::and_then(fn) | fn::and_then(fn) | fn::and_then(fn);
-      static_assert(r3.invoke([](double i) -> int { return i; }) == 0.0);
+      static_assert(r3.apply([](double i) -> int { return i; }) == 0.0);
 
       SUCCEED();
     }
@@ -990,11 +990,11 @@ TEST_CASE("and_then choice", "[and_then][choice]")
       };
       constexpr auto r1 = T{1} | fn::and_then(fn);
       static_assert(std::is_same_v<decltype(r1), fn::choice<bool, int> const>);
-      static_assert(r1.invoke([](bool i) -> bool { return i; }) == true);
+      static_assert(r1.apply([](bool i) -> bool { return i; }) == true);
       constexpr auto r2 = T{0} | fn::and_then(fn);
-      static_assert(r2.invoke([](bool i) -> bool { return i; }) == false);
+      static_assert(r2.apply([](bool i) -> bool { return i; }) == false);
       constexpr auto r3 = T{2} | fn::and_then(fn);
-      static_assert(r3.invoke([](int i) -> int { return i; }) == 2);
+      static_assert(r3.apply([](int i) -> int { return i; }) == 2);
 
       SUCCEED();
     }
@@ -1017,44 +1017,44 @@ template <typename T> [[maybe_unused]] constexpr auto fn_int_const_rvalue = [](i
 } // namespace
 
 // clang-format off
-static_assert(invocable_and_then<decltype(fn_int<expected<Value, Error>>), expected<int, Error>>);
-static_assert(invocable_and_then<decltype(fn_int<expected<void, Error>>), expected<int, Error>>);
-static_assert(not invocable_and_then<decltype(fn_int<expected<int, Xerror>>), expected<int, Error>>);           // different error_type
-static_assert(not invocable_and_then<decltype(fn_int<expected<int, Error>>), expected<Value, Error>>);          // wrong parameter type
-static_assert(invocable_and_then<decltype(fn_generic<expected<int, Error>>), expected<Value, Error>>);
-static_assert(not invocable_and_then<decltype(fn_generic<expected<int, Xerror>>), expected<Value, Error>>);     // different error_type
-static_assert(invocable_and_then<decltype(fn_generic<expected<int, Error>>), expected<void, Error>>);
-static_assert(invocable_and_then<decltype(fn_generic<expected<void, Error>>), expected<void, Error>>);
-static_assert(invocable_and_then<decltype(fn_generic<expected<Value, Error>>), expected<void, Error>>);
-static_assert(not invocable_and_then<decltype(fn_generic<expected<int, Xerror>>), expected<void, Error>>);      // different error_type
-static_assert(not invocable_and_then<decltype(fn_generic<expected<void, Xerror>>), expected<void, Error>>);     // different error_type
-static_assert(not invocable_and_then<decltype(fn_generic<expected<int, Error>>), optional<Value>>);             // mixed optional and expected
-static_assert(not invocable_and_then<decltype(fn_generic<expected<int, Xerror>>), optional<int>>);              // mixed optional and expected
-static_assert(not invocable_and_then<decltype(fn_generic<optional<int>>), expected<Value, Error>>);             // mixed optional and expected
-static_assert(invocable_and_then<decltype(fn_generic<optional<int>>), optional<Value>>);
-static_assert(invocable_and_then<decltype(fn_generic<optional<Value>>), optional<int>>);
-static_assert(not invocable_and_then<decltype(fn_int_lvalue<expected<Value, Error>>), expected<int, Error>>);   // cannot bind temporary to lvalue
-static_assert(invocable_and_then<decltype(fn_int_lvalue<expected<Value, Error>>), expected<int, Error> &>);
-static_assert(invocable_and_then<decltype(fn_int_rvalue<expected<Value, Error>>), expected<int, Error>>);
-static_assert(not invocable_and_then<decltype(fn_int_rvalue<expected<Value, Error>>), expected<int, Error> &>); // cannot bind lvalue to rvalue-ref
+static_assert(applicable_and_then<decltype(fn_int<expected<Value, Error>>), expected<int, Error>>);
+static_assert(applicable_and_then<decltype(fn_int<expected<void, Error>>), expected<int, Error>>);
+static_assert(not applicable_and_then<decltype(fn_int<expected<int, Xerror>>), expected<int, Error>>);           // different error_type
+static_assert(not applicable_and_then<decltype(fn_int<expected<int, Error>>), expected<Value, Error>>);          // wrong parameter type
+static_assert(applicable_and_then<decltype(fn_generic<expected<int, Error>>), expected<Value, Error>>);
+static_assert(not applicable_and_then<decltype(fn_generic<expected<int, Xerror>>), expected<Value, Error>>);     // different error_type
+static_assert(applicable_and_then<decltype(fn_generic<expected<int, Error>>), expected<void, Error>>);
+static_assert(applicable_and_then<decltype(fn_generic<expected<void, Error>>), expected<void, Error>>);
+static_assert(applicable_and_then<decltype(fn_generic<expected<Value, Error>>), expected<void, Error>>);
+static_assert(not applicable_and_then<decltype(fn_generic<expected<int, Xerror>>), expected<void, Error>>);      // different error_type
+static_assert(not applicable_and_then<decltype(fn_generic<expected<void, Xerror>>), expected<void, Error>>);     // different error_type
+static_assert(not applicable_and_then<decltype(fn_generic<expected<int, Error>>), optional<Value>>);             // mixed optional and expected
+static_assert(not applicable_and_then<decltype(fn_generic<expected<int, Xerror>>), optional<int>>);              // mixed optional and expected
+static_assert(not applicable_and_then<decltype(fn_generic<optional<int>>), expected<Value, Error>>);             // mixed optional and expected
+static_assert(applicable_and_then<decltype(fn_generic<optional<int>>), optional<Value>>);
+static_assert(applicable_and_then<decltype(fn_generic<optional<Value>>), optional<int>>);
+static_assert(not applicable_and_then<decltype(fn_int_lvalue<expected<Value, Error>>), expected<int, Error>>);   // cannot bind temporary to lvalue
+static_assert(applicable_and_then<decltype(fn_int_lvalue<expected<Value, Error>>), expected<int, Error> &>);
+static_assert(applicable_and_then<decltype(fn_int_rvalue<expected<Value, Error>>), expected<int, Error>>);
+static_assert(not applicable_and_then<decltype(fn_int_rvalue<expected<Value, Error>>), expected<int, Error> &>); // cannot bind lvalue to rvalue-ref
 
 // A sum error type grades the monad: the callback may then return an expected with a DIFFERENT error,
 // which the operation widens into the sum. Without one, the error types must match exactly - the two
 // disjuncts above and below are what tell those cases apart.
-static_assert(invocable_and_then<decltype(fn_int<expected<Value, sum<Error>>>), expected<int, sum<Error>>>);
-static_assert(invocable_and_then<decltype(fn_int<expected<Value, Xerror>>), expected<int, sum<Error>>>);         // widens the error
-static_assert(invocable_and_then<decltype(fn_int<expected<Value, Error>>), expected<int, sum<Error, Xerror>>>);  // already covered by the sum
-static_assert(not invocable_and_then<decltype(fn_int<expected<Value, Xerror>>), expected<int, Error>>);          // no sum: error must match
-static_assert(invocable_and_then<decltype(fn_generic<expected<Value, Xerror>>), expected<void, sum<Error>>>);    // ... and the same for void
-static_assert(not invocable_and_then<decltype(fn_generic<expected<Value, Xerror>>), expected<void, Error>>);
+static_assert(applicable_and_then<decltype(fn_int<expected<Value, sum<Error>>>), expected<int, sum<Error>>>);
+static_assert(applicable_and_then<decltype(fn_int<expected<Value, Xerror>>), expected<int, sum<Error>>>);         // widens the error
+static_assert(applicable_and_then<decltype(fn_int<expected<Value, Error>>), expected<int, sum<Error, Xerror>>>);  // already covered by the sum
+static_assert(not applicable_and_then<decltype(fn_int<expected<Value, Xerror>>), expected<int, Error>>);          // no sum: error must match
+static_assert(applicable_and_then<decltype(fn_generic<expected<Value, Xerror>>), expected<void, sum<Error>>>);    // ... and the same for void
+static_assert(not applicable_and_then<decltype(fn_generic<expected<Value, Xerror>>), expected<void, Error>>);
 
 // choice - the concept's remaining disjunct
-static_assert(invocable_and_then<decltype(fn_generic<choice<int>>), choice<int>>);
-static_assert(invocable_and_then<decltype(fn_generic<choice<Value>>), choice<int>>);                            // may change the type
-static_assert(not invocable_and_then<decltype(fn_generic<optional<int>>), choice<int>>);                        // must stay a choice
-static_assert(not invocable_and_then<decltype(fn_generic<expected<int, Error>>), choice<int>>);
-static_assert(not invocable_and_then<decltype(fn_generic<choice<int>>), optional<int>>);                        // mixed choice and optional
-static_assert(not invocable_and_then<decltype(fn_int_lvalue<choice<int>>), choice<int>>);                       // cannot bind temporary to lvalue
-static_assert(invocable_and_then<decltype(fn_int_lvalue<choice<int>>), choice<int> &>);
+static_assert(applicable_and_then<decltype(fn_generic<choice<int>>), choice<int>>);
+static_assert(applicable_and_then<decltype(fn_generic<choice<Value>>), choice<int>>);                            // may change the type
+static_assert(not applicable_and_then<decltype(fn_generic<optional<int>>), choice<int>>);                        // must stay a choice
+static_assert(not applicable_and_then<decltype(fn_generic<expected<int, Error>>), choice<int>>);
+static_assert(not applicable_and_then<decltype(fn_generic<choice<int>>), optional<int>>);                        // mixed choice and optional
+static_assert(not applicable_and_then<decltype(fn_int_lvalue<choice<int>>), choice<int>>);                       // cannot bind temporary to lvalue
+static_assert(applicable_and_then<decltype(fn_int_lvalue<choice<int>>), choice<int> &>);
 // clang-format on
 } // namespace fn

--- a/tests/fn/choice.cpp
+++ b/tests/fn/choice.cpp
@@ -105,11 +105,11 @@ TEST_CASE("choice non-monadic functionality", "[choice]")
         [](helper &o) -> int { return o.v + 1; },  [](helper const &o) -> int { return o.v + 2; },
         [](helper &&o) -> int { return o.v + 3; }, [](helper const &&o) -> int { return o.v + 4; },
     };
-    static_assert(std::same_as<int, decltype(s.value().invoke(fn))>);
-    CHECK((s.value().invoke(fn)) == 43);
-    CHECK((std::as_const(s).value().invoke(fn)) == 44);
-    CHECK((std::move(std::as_const(s)).value().invoke(fn)) == 46);
-    CHECK((std::move(s).value().invoke(fn)) == 45);
+    static_assert(std::same_as<int, decltype(s.value().apply(fn))>);
+    CHECK((s.value().apply(fn)) == 43);
+    CHECK((std::as_const(s).value().apply(fn)) == 44);
+    CHECK((std::move(std::as_const(s)).value().apply(fn)) == 46);
+    CHECK((std::move(s).value().apply(fn)) == 45);
   }
 
   SECTION("choice_for")
@@ -154,27 +154,27 @@ TEST_CASE("choice non-monadic functionality", "[choice]")
     static_assert(std::same_as<fn::choice_for<double, fn::sum<>, fn::sum<bool, int>>, fn::choice<bool, double, int>>);
   }
 
-  SECTION("invocable")
+  SECTION("applicable")
   {
     using type = fn::choice_for<TestType, int>; // choice<...> order is platform-specific; choice_for normalizes
-    static_assert(fn::typelist_invocable<decltype([](auto) {}), type &>);
-    static_assert(fn::typelist_invocable<decltype([](auto &) {}), type &>);
-    static_assert(fn::typelist_invocable<decltype([](auto const &) {}), type &>);
-    static_assert(fn::typelist_invocable<decltype(fn::overload{[](int &) {}, [](TestType &) {}}), type &>);
-    static_assert(fn::typelist_invocable<decltype(fn::overload{[](int) {}, [](TestType) {}}), type const &>);
+    static_assert(fn::typelist_applicable<decltype([](auto) {}), type &>);
+    static_assert(fn::typelist_applicable<decltype([](auto &) {}), type &>);
+    static_assert(fn::typelist_applicable<decltype([](auto const &) {}), type &>);
+    static_assert(fn::typelist_applicable<decltype(fn::overload{[](int &) {}, [](TestType &) {}}), type &>);
+    static_assert(fn::typelist_applicable<decltype(fn::overload{[](int) {}, [](TestType) {}}), type const &>);
 
-    static_assert(not fn::typelist_invocable<decltype([](TestType &) {}), type &>); // missing int
-    static_assert(not fn::typelist_invocable<decltype([](int &) {}), type &>);      // missing TestType
-    static_assert(not fn::typelist_invocable<decltype(fn::overload{[](int &&) {}, [](TestType &&) {}}),
-                                             type &>); // cannot bind lvalue to rvalue-reference
-    static_assert(not fn::typelist_invocable<decltype([](auto &) {}),
-                                             type &&>); // cannot bind rvalue to lvalue-reference
-    static_assert(not fn::typelist_invocable<decltype([](auto, auto &) {}), type &>); // bad arity
-    static_assert(not fn::typelist_invocable<decltype(fn::overload{[](int &) {}, [](TestType &) {}}),
-                                             type const &>); // cannot bind const to non-const reference
+    static_assert(not fn::typelist_applicable<decltype([](TestType &) {}), type &>); // missing int
+    static_assert(not fn::typelist_applicable<decltype([](int &) {}), type &>);      // missing TestType
+    static_assert(not fn::typelist_applicable<decltype(fn::overload{[](int &&) {}, [](TestType &&) {}}),
+                                              type &>); // cannot bind lvalue to rvalue-reference
+    static_assert(not fn::typelist_applicable<decltype([](auto &) {}),
+                                              type &&>); // cannot bind rvalue to lvalue-reference
+    static_assert(not fn::typelist_applicable<decltype([](auto, auto &) {}), type &>); // bad arity
+    static_assert(not fn::typelist_applicable<decltype(fn::overload{[](int &) {}, [](TestType &) {}}),
+                                              type const &>); // cannot bind const to non-const reference
 
-    static_assert(fn::typelist_invocable<decltype([](auto &) {}), choice<NonCopyable> &>);
-    static_assert(not fn::typelist_invocable<decltype([](auto) {}), NonCopyable &>); // copy-constructor not available
+    static_assert(fn::typelist_applicable<decltype([](auto &) {}), choice<NonCopyable> &>);
+    static_assert(not fn::typelist_applicable<decltype([](auto) {}), NonCopyable &>); // copy-constructor not available
   }
 
   SECTION("single parameter constructor")
@@ -197,7 +197,7 @@ TEST_CASE("choice non-monadic functionality", "[choice]")
 
       constexpr auto c = choice{std::array<int, 3>{3, 14, 15}};
       static_assert(std::is_same_v<decltype(c), choice<std::array<int, 3>> const>);
-      static_assert(c.invoke([](auto &&a) -> bool { return a.size() == 3 && a[0] == 3 && a[1] == 14 && a[2] == 15; }));
+      static_assert(c.apply([](auto &&a) -> bool { return a.size() == 3 && a[0] == 3 && a[1] == 14 && a[2] == 15; }));
     }
 
     SECTION("constexpr move from rvalue")
@@ -441,7 +441,7 @@ TEST_CASE("choice non-monadic functionality", "[choice]")
   SECTION("forwarding constructors (immovable)")
   {
     choice<NonCopyable> a{std::in_place_type<NonCopyable>, 42};
-    CHECK(a.invoke([](auto &i) -> bool { return i.i == 42; }));
+    CHECK(a.apply([](auto &i) -> bool { return i.i == 42; }));
 
     SECTION("CTAD")
     {
@@ -473,7 +473,7 @@ TEST_CASE("choice non-monadic functionality", "[choice]")
       static_assert(not decltype(a)::has_type<int>);
       CHECK(a.has_value(std::in_place_type<std::array<int, 3>>));
       CHECK(a.template has_value<std::array<int, 3>>());
-      CHECK(a.invoke([](auto &i) -> bool {
+      CHECK(a.apply([](auto &i) -> bool {
         return std::same_as<std::array<int, 3> &, decltype(i)> && i.size() == 3 && i[0] == 1 && i[1] == 2 && i[2] == 3;
       }));
     }
@@ -485,7 +485,7 @@ TEST_CASE("choice non-monadic functionality", "[choice]")
       static_assert(not decltype(a)::has_type<int>);
       static_assert(a.has_value(std::in_place_type<std::array<int, 3>>));
       static_assert(a.template has_value<std::array<int, 3>>());
-      static_assert(a.invoke([](auto &i) -> bool {
+      static_assert(a.apply([](auto &i) -> bool {
         return std::same_as<std::array<int, 3> const &, decltype(i)> && i.size() == 3 && i[0] == 1 && i[1] == 2
                && i[2] == 3;
       }));
@@ -530,27 +530,27 @@ TEST_CASE("choice non-monadic functionality", "[choice]")
     CHECK(b != choice<double, int>{42});
   }
 
-  SECTION("invoke")
+  SECTION("apply")
   {
     choice<int> a{std::in_place_type<int>, 42};
     SECTION("value only")
     {
-      CHECK(a.invoke(  //
+      CHECK(a.apply(   //
           fn::overload{//
                        [](auto) -> bool { throw 1; }, [](int &) -> bool { return true; },
                        [](int const &) -> bool { throw 0; }, [](int &&) -> bool { throw 0; },
                        [](int const &&) -> bool { throw 0; }}));
-      CHECK(std::as_const(a).invoke( //
-          fn::overload{              //
+      CHECK(std::as_const(a).apply( //
+          fn::overload{             //
                        [](auto) -> bool { throw 1; }, [](int &) -> bool { throw 0; },
                        [](int const &) -> bool { return true; }, [](int &&) -> bool { throw 0; },
                        [](int const &&) -> bool { throw 0; }}));
       CHECK(std::move(std::as_const(a))
-                .invoke(fn::overload{[](auto) -> bool { throw 1; }, [](int &) -> bool { throw 0; },
-                                     [](int const &) -> bool { throw 0; }, [](int &&) -> bool { throw 0; },
-                                     [](int const &&) -> bool { return true; }}));
-      CHECK(std::move(a).invoke( //
-          fn::overload{          //
+                .apply(fn::overload{[](auto) -> bool { throw 1; }, [](int &) -> bool { throw 0; },
+                                    [](int const &) -> bool { throw 0; }, [](int &&) -> bool { throw 0; },
+                                    [](int const &&) -> bool { return true; }}));
+      CHECK(std::move(a).apply( //
+          fn::overload{         //
                        [](auto) -> bool { throw 1; }, [](int &) -> bool { throw 0; },
                        [](int const &) -> bool { throw 0; }, [](int &&) -> bool { return true; },
                        [](int const &&) -> bool { throw 0; }}));
@@ -558,11 +558,11 @@ TEST_CASE("choice non-monadic functionality", "[choice]")
       SECTION("constexpr")
       {
         constexpr choice<int> a{std::in_place_type<int>, 42};
-        static_assert(a.invoke(fn::overload{
+        static_assert(a.apply(fn::overload{
             [](auto) -> std::false_type { return {}; }, //
             [](int &) -> std::false_type { return {}; }, [](int const &) -> std::true_type { return {}; },
             [](int &&) -> std::false_type { return {}; }, [](int const &&) -> std::false_type { return {}; }}));
-        static_assert(std::move(a).invoke(fn::overload{
+        static_assert(std::move(a).apply(fn::overload{
             [](auto) -> std::false_type { return {}; }, //
             [](int &) -> std::false_type { return {}; }, [](int const &) -> std::false_type { return {}; },
             [](int &&) -> std::false_type { return {}; }, [](int const &&) -> std::true_type { return {}; }}));
@@ -570,27 +570,27 @@ TEST_CASE("choice non-monadic functionality", "[choice]")
     }
   }
 
-  SECTION("invoke_r")
+  SECTION("apply_r")
   {
     choice<int> a{std::in_place_type<int>, 42};
     SECTION("value only")
     {
-      CHECK(a.invoke_r<int>( //
-          fn::overload{      //
+      CHECK(a.apply_r<int>( //
+          fn::overload{     //
                        [](auto) -> int { throw 1; }, [](int &) -> bool { return true; },
                        [](int const &) -> bool { throw 0; }, [](int &&) -> bool { throw 0; },
                        [](int const &&) -> bool { throw 0; }}));
-      CHECK(std::as_const(a).invoke_r<int>( //
-          fn::overload{                     //
+      CHECK(std::as_const(a).apply_r<int>( //
+          fn::overload{                    //
                        [](auto) -> int { throw 1; }, [](int &) -> bool { throw 0; },
                        [](int const &) -> bool { return true; }, [](int &&) -> bool { throw 0; },
                        [](int const &&) -> bool { throw 0; }}));
       CHECK(std::move(std::as_const(a))
-                .invoke_r<int>(fn::overload{[](auto) -> int { throw 1; }, [](int &) -> bool { throw 0; },
-                                            [](int const &) -> bool { throw 0; }, [](int &&) -> bool { throw 0; },
-                                            [](int const &&) -> bool { return true; }}));
-      CHECK(std::move(a).invoke_r<int>( //
-          fn::overload{                 //
+                .apply_r<int>(fn::overload{[](auto) -> int { throw 1; }, [](int &) -> bool { throw 0; },
+                                           [](int const &) -> bool { throw 0; }, [](int &&) -> bool { throw 0; },
+                                           [](int const &&) -> bool { return true; }}));
+      CHECK(std::move(a).apply_r<int>( //
+          fn::overload{                //
                        [](auto) -> int { throw 1; }, [](int &) -> bool { throw 0; },
                        [](int const &) -> bool { throw 0; }, [](int &&) -> bool { return true; },
                        [](int const &&) -> bool { throw 0; }}));
@@ -598,11 +598,11 @@ TEST_CASE("choice non-monadic functionality", "[choice]")
       SECTION("constexpr")
       {
         constexpr choice<int> a{std::in_place_type<int>, 42};
-        static_assert(a.invoke_r<int>(fn::overload{
+        static_assert(a.apply_r<int>(fn::overload{
             [](auto) -> std::false_type { return {}; }, //
             [](int &) -> std::false_type { return {}; }, [](int const &) -> std::true_type { return {}; },
             [](int &&) -> std::false_type { return {}; }, [](int const &&) -> std::false_type { return {}; }}));
-        static_assert(std::move(a).invoke_r<int>(fn::overload{
+        static_assert(std::move(a).apply_r<int>(fn::overload{
             [](auto) -> std::false_type { return {}; }, //
             [](int &) -> std::false_type { return {}; }, [](int const &) -> std::false_type { return {}; },
             [](int &&) -> std::false_type { return {}; }, [](int const &&) -> std::true_type { return {}; }}));
@@ -639,8 +639,8 @@ TEST_CASE("choice noexcept", "[choice][noexcept]")
   constexpr auto throwing_t = [](auto) { return 0; };
   static_assert(noexcept(std::declval<C &>().transform(nothrow_t)));
   static_assert(not noexcept(std::declval<C &>().transform(throwing_t)));
-  static_assert(noexcept(std::declval<C &>().invoke(nothrow_t)));
-  static_assert(not noexcept(std::declval<C &>().invoke(throwing_t)));
+  static_assert(noexcept(std::declval<C &>().apply(nothrow_t)));
+  static_assert(not noexcept(std::declval<C &>().apply(throwing_t)));
 
   // a throwing callback is weighed in every value category
   constexpr auto fnChoice = [](Throwing const &t) noexcept(false) -> choice<int> { return {t.v}; };
@@ -652,8 +652,8 @@ TEST_CASE("choice noexcept", "[choice][noexcept]")
   constexpr auto fnInt = [](Throwing const &t) noexcept(false) -> int { return t.v; };
   static_assert(not noexcept(std::declval<T &>().transform(fnInt)));
   static_assert(not noexcept(std::declval<T const &>().transform(fnInt)));
-  static_assert(not noexcept(std::declval<T &>().invoke(fnInt)));
-  static_assert(not noexcept(std::declval<T &>().template invoke_r<long>(fnInt)));
+  static_assert(not noexcept(std::declval<T &>().apply(fnInt)));
+  static_assert(not noexcept(std::declval<T &>().template apply_r<long>(fnInt)));
 
   // the constructors that widen a sum into a choice copy or move every alternative across
   using W = fn::choice_for<Throwing, int>;

--- a/tests/fn/detail/functional.cpp
+++ b/tests/fn/detail/functional.cpp
@@ -18,132 +18,132 @@ template <typename...> struct types;
 constexpr auto sum_two = [](int i, double d) { return i + d; };
 } // namespace
 
-TEST_CASE("_invoke_result", "[functional][invoke_result]")
+TEST_CASE("_apply_result", "[functional][apply_result]")
 {
-  using fn::detail::_invoke_result;
+  using fn::detail::_apply_result;
   // plain invocation matches std::invoke_result
-  static_assert(std::same_as<_invoke_result<decltype(sum_two), int, double>::type, double>);
+  static_assert(std::same_as<_apply_result<decltype(sum_two), int, double>::type, double>);
   // pack arg unpacks element types into Fn
-  static_assert(std::same_as<_invoke_result<decltype(sum_two), fn::pack<int, double> &>::type, double>);
-  // non-invocable falls back to void (the trait's _result helper return)
-  static_assert(std::same_as<_invoke_result<decltype(sum_two), int *>::type, void>);
+  static_assert(std::same_as<_apply_result<decltype(sum_two), fn::pack<int, double> &>::type, double>);
+  // non-applicable falls back to void (the trait's _result helper return)
+  static_assert(std::same_as<_apply_result<decltype(sum_two), int *>::type, void>);
   SUCCEED();
 }
 
-TEST_CASE("_is_invocable", "[functional][is_invocable]")
+TEST_CASE("_is_applicable", "[functional][is_applicable]")
 {
-  using fn::detail::_is_invocable;
-  static_assert(_is_invocable<decltype(sum_two), int, double>::value);
-  // pack arg dispatches through pack::invoke
-  static_assert(_is_invocable<decltype(sum_two), fn::pack<int, double> &>::value);
+  using fn::detail::_is_applicable;
+  static_assert(_is_applicable<decltype(sum_two), int, double>::value);
+  // pack arg dispatches through pack::apply
+  static_assert(_is_applicable<decltype(sum_two), fn::pack<int, double> &>::value);
   // negative: incompatible argument
-  static_assert(not _is_invocable<decltype(sum_two), int, int *>::value);
+  static_assert(not _is_applicable<decltype(sum_two), int, int *>::value);
   // negative: wrong arity
-  static_assert(not _is_invocable<decltype(sum_two), int>::value);
+  static_assert(not _is_applicable<decltype(sum_two), int>::value);
   SUCCEED();
 }
 
-TEST_CASE("_is_invocable_r", "[functional][is_invocable_r]")
+TEST_CASE("_is_applicable_r", "[functional][is_applicable_r]")
 {
-  using fn::detail::_is_invocable_r;
+  using fn::detail::_is_applicable_r;
   // exact return type
-  static_assert(_is_invocable_r<double, decltype(sum_two), int, double>::value);
+  static_assert(_is_applicable_r<double, decltype(sum_two), int, double>::value);
   // convertible return type
-  static_assert(_is_invocable_r<long, decltype(sum_two), int, double>::value);
-  // pack arg dispatches through pack::invoke_r
-  static_assert(_is_invocable_r<double, decltype(sum_two), fn::pack<int, double> &>::value);
+  static_assert(_is_applicable_r<long, decltype(sum_two), int, double>::value);
+  // pack arg dispatches through pack::apply_r
+  static_assert(_is_applicable_r<double, decltype(sum_two), fn::pack<int, double> &>::value);
   // negative: non-convertible return type
-  static_assert(not _is_invocable_r<int *, decltype(sum_two), int, double>::value);
+  static_assert(not _is_applicable_r<int *, decltype(sum_two), int, double>::value);
   SUCCEED();
 }
 
-TEST_CASE("_is_nothrow_invocable", "[functional][is_nothrow_invocable]")
+TEST_CASE("_is_nothrow_applicable", "[functional][is_nothrow_applicable]")
 {
-  using fn::detail::_is_nothrow_invocable;
-  static_assert(not _is_nothrow_invocable<decltype(sum_two), int, double>::value); // sum_two can throw
-  static_assert(_is_nothrow_invocable<decltype([]() noexcept { return 0; })>::value);
-  static_assert(not _is_nothrow_invocable<decltype([]() { return 0; })>::value);
-  static_assert(not _is_nothrow_invocable<decltype([](int) noexcept { return 0; })>::value); // not invocable at all
+  using fn::detail::_is_nothrow_applicable;
+  static_assert(not _is_nothrow_applicable<decltype(sum_two), int, double>::value); // sum_two can throw
+  static_assert(_is_nothrow_applicable<decltype([]() noexcept { return 0; })>::value);
+  static_assert(not _is_nothrow_applicable<decltype([]() { return 0; })>::value);
+  static_assert(not _is_nothrow_applicable<decltype([](int) noexcept { return 0; })>::value); // not applicable at all
 
   // it composes through the dispatch: a pack answers for the call over its elements, a sum for the
   // call over every alternative, since which one runs is only known at run time
   constexpr auto nothrow_generic = [](auto &&...) noexcept { return 0; };
   constexpr auto throwing_generic = [](auto &&...) { return 0; };
-  static_assert(_is_nothrow_invocable<decltype(nothrow_generic), fn::pack<int, bool> &>::value);
-  static_assert(not _is_nothrow_invocable<decltype(throwing_generic), fn::pack<int, bool> &>::value);
-  static_assert(_is_nothrow_invocable<decltype(nothrow_generic), fn::sum<bool, int> &>::value);
-  static_assert(not _is_nothrow_invocable<decltype(throwing_generic), fn::sum<bool, int> &>::value);
+  static_assert(_is_nothrow_applicable<decltype(nothrow_generic), fn::pack<int, bool> &>::value);
+  static_assert(not _is_nothrow_applicable<decltype(throwing_generic), fn::pack<int, bool> &>::value);
+  static_assert(_is_nothrow_applicable<decltype(nothrow_generic), fn::sum<bool, int> &>::value);
+  static_assert(not _is_nothrow_applicable<decltype(throwing_generic), fn::sum<bool, int> &>::value);
 
   // one throwing alternative is enough
   constexpr auto mixed = fn::overload{[](int &) noexcept { return 0; }, [](bool &) { return 0; }};
-  static_assert(not _is_nothrow_invocable<decltype(mixed), fn::sum<bool, int> &>::value);
+  static_assert(not _is_nothrow_applicable<decltype(mixed), fn::sum<bool, int> &>::value);
   SUCCEED();
 }
 
-TEST_CASE("_is_nothrow_invocable_r", "[functional][is_nothrow_invocable_r]")
+TEST_CASE("_is_nothrow_applicable_r", "[functional][is_nothrow_applicable_r]")
 {
-  using fn::detail::_is_nothrow_invocable_r;
-  static_assert(not _is_nothrow_invocable_r<double, decltype(sum_two), int, double>::value);
-  static_assert(_is_nothrow_invocable_r<int, decltype([]() noexcept { return 0; })>::value);
-  static_assert(not _is_nothrow_invocable_r<int, decltype([]() { return 0; })>::value);
-  static_assert(not _is_nothrow_invocable_r<int *, decltype([]() noexcept { return 0; })>::value); // not convertible
+  using fn::detail::_is_nothrow_applicable_r;
+  static_assert(not _is_nothrow_applicable_r<double, decltype(sum_two), int, double>::value);
+  static_assert(_is_nothrow_applicable_r<int, decltype([]() noexcept { return 0; })>::value);
+  static_assert(not _is_nothrow_applicable_r<int, decltype([]() { return 0; })>::value);
+  static_assert(not _is_nothrow_applicable_r<int *, decltype([]() noexcept { return 0; })>::value); // not convertible
 
   constexpr auto nothrow_generic = [](auto &&...) noexcept { return 0; };
-  static_assert(_is_nothrow_invocable_r<int, decltype(nothrow_generic), fn::pack<int, bool> &>::value);
-  static_assert(_is_nothrow_invocable_r<int, decltype(nothrow_generic), fn::sum<bool, int> &>::value);
+  static_assert(_is_nothrow_applicable_r<int, decltype(nothrow_generic), fn::pack<int, bool> &>::value);
+  static_assert(_is_nothrow_applicable_r<int, decltype(nothrow_generic), fn::sum<bool, int> &>::value);
   SUCCEED();
 }
 
-TEST_CASE("_invoke", "[functional][invoke]")
+TEST_CASE("_apply", "[functional][apply]")
 {
-  using fn::detail::_invoke;
+  using fn::detail::_apply;
   // plain invocation
-  static_assert(_invoke(sum_two, 1, 0.5) == 1.5);
-  static_assert(std::same_as<decltype(_invoke(sum_two, 1, 0.5)), double>);
-  // pack arg: dispatches through pack::invoke
+  static_assert(_apply(sum_two, 1, 0.5) == 1.5);
+  static_assert(std::same_as<decltype(_apply(sum_two, 1, 0.5)), double>);
+  // pack arg: dispatches through pack::apply
   constexpr fn::pack<int, double> p{2, 0.25};
-  static_assert(_invoke(sum_two, p) == 2.25);
+  static_assert(_apply(sum_two, p) == 2.25);
   SUCCEED();
 }
 
-TEST_CASE("_invoke_r", "[functional][invoke_r]")
+TEST_CASE("_apply_r", "[functional][apply_r]")
 {
-  using fn::detail::_invoke_r;
+  using fn::detail::_apply_r;
   // return-type conversion
-  static_assert(_invoke_r<long>(sum_two, 1, 0.5) == 1);
-  static_assert(std::same_as<decltype(_invoke_r<long>(sum_two, 1, 0.5)), long>);
-  // pack arg: dispatches through pack::invoke_r
+  static_assert(_apply_r<long>(sum_two, 1, 0.5) == 1);
+  static_assert(std::same_as<decltype(_apply_r<long>(sum_two, 1, 0.5)), long>);
+  // pack arg: dispatches through pack::apply_r
   constexpr fn::pack<int, double> p{3, 0.5};
-  static_assert(_invoke_r<int>(sum_two, p) == 3);
+  static_assert(_apply_r<int>(sum_two, p) == 3);
   SUCCEED();
 }
 
-TEST_CASE("_typelist_invocable", "[functional][typelist_invocable]")
+TEST_CASE("_typelist_applicable", "[functional][typelist_applicable]")
 {
-  using fn::detail::_typelist_invocable;
+  using fn::detail::_typelist_applicable;
 
-  // satisfied when Fn is invocable with each typelist element under matching qualifier
-  static_assert(_typelist_invocable<decltype([](auto) {}), types<int, double> &>);
-  static_assert(_typelist_invocable<decltype([](auto const &) {}), types<int, double> const &>);
-  static_assert(_typelist_invocable<decltype([](auto &&) {}), types<int, double> &&>);
+  // satisfied when Fn is applicable with each typelist element under matching qualifier
+  static_assert(_typelist_applicable<decltype([](auto) {}), types<int, double> &>);
+  static_assert(_typelist_applicable<decltype([](auto const &) {}), types<int, double> const &>);
+  static_assert(_typelist_applicable<decltype([](auto &&) {}), types<int, double> &&>);
 
   // extra trailing args are forwarded after the element type
-  static_assert(_typelist_invocable<decltype([](auto, int) {}), types<int, double> &, int>);
+  static_assert(_typelist_applicable<decltype([](auto, int) {}), types<int, double> &, int>);
 
-  // negative: one element is not invocable
-  static_assert(not _typelist_invocable<decltype([](int) {}), types<int, char const *> &>);
+  // negative: one element is not applicable
+  static_assert(not _typelist_applicable<decltype([](int) {}), types<int, char const *> &>);
   // negative: T is not a typelist (no Tpl<Ts...> match)
-  static_assert(not _typelist_invocable<decltype([](auto) {}), int>);
+  static_assert(not _typelist_applicable<decltype([](auto) {}), int>);
   SUCCEED();
 }
 
-TEST_CASE("_typelist_invocable_r", "[functional][typelist_invocable_r]")
+TEST_CASE("_typelist_applicable_r", "[functional][typelist_applicable_r]")
 {
-  using fn::detail::_typelist_invocable_r;
+  using fn::detail::_typelist_applicable_r;
 
   // satisfied when each invocation's result converts to R
-  static_assert(_typelist_invocable_r<long, decltype([](auto v) { return v; }), types<int, short> &>);
+  static_assert(_typelist_applicable_r<long, decltype([](auto v) { return v; }), types<int, short> &>);
   // negative: result of one element does not convert to R
-  static_assert(not _typelist_invocable_r<int *, decltype([](auto v) { return v; }), types<int, short> &>);
+  static_assert(not _typelist_applicable_r<int *, decltype([](auto v) { return v; }), types<int, short> &>);
   SUCCEED();
 }

--- a/tests/fn/detail/pack_impl.cpp
+++ b/tests/fn/detail/pack_impl.cpp
@@ -32,7 +32,7 @@ concept can_swap_invoke
     = requires(P p, Fn fn, Args &&...args) { P::_swap_invoke(p, fn, static_cast<Args &&>(args)...); };
 
 template <typename P, typename Fn, typename... Args>
-concept can_invoke = requires(P p, Fn fn, Args &&...args) { P::_invoke(p, fn, static_cast<Args &&>(args)...); };
+concept can_invoke = requires(P p, Fn fn, Args &&...args) { P::_apply(p, fn, static_cast<Args &&>(args)...); };
 
 template <typename P, typename T, typename... Args>
 concept can_append = requires(P p, Args &&...args) { P::template _append<T>(p, static_cast<Args &&>(args)...); };
@@ -49,27 +49,27 @@ TEST_CASE("pack_impl size and aggregate construction", "[pack_impl]")
   using P0 = pack_impl<std::index_sequence<>>;
   static_assert(P0::size == 0);
   static_assert(std::is_trivially_default_constructible_v<P0>);
-  static_assert(P0::_invoke(P0{}, []() { return 7; }) == 7);
+  static_assert(P0::_apply(P0{}, []() { return 7; }) == 7);
 
   using P1 = pack_impl<std::index_sequence_for<int>, int>;
   static_assert(P1::size == 1);
   constexpr P1 p1{42};
-  static_assert(P1::_invoke(p1, [](int v) { return v; }) == 42);
+  static_assert(P1::_apply(p1, [](int v) { return v; }) == 42);
 
   using P3 = pack_impl<std::index_sequence_for<int, double, A>, int, double, A>;
   static_assert(P3::size == 3);
   constexpr P3 p3{3, 1.5, A{14}};
-  static_assert(P3::_invoke(p3, [](int i, double d, A a) { return i + d + a.v; }) == 18.5);
+  static_assert(P3::_apply(p3, [](int i, double d, A a) { return i + d + a.v; }) == 18.5);
 
   // duplicate types are permitted at distinct indices
   using PD = pack_impl<std::index_sequence_for<int, int>, int, int>;
   constexpr PD pd{7, 9};
-  static_assert(PD::_invoke(pd, [](int a, int b) { return a * 100 + b; }) == 709);
+  static_assert(PD::_apply(pd, [](int a, int b) { return a * 100 + b; }) == 709);
 
   // non-copyable element constructs in place and is reachable
   using PN = pack_impl<std::index_sequence_for<NonCopyable>, NonCopyable>;
   constexpr PN pn{NonCopyable{99}};
-  static_assert(PN::_invoke(pn, [](NonCopyable const &n) { return n.v; }) == 99);
+  static_assert(PN::_apply(pn, [](NonCopyable const &n) { return n.v; }) == 99);
 
   SUCCEED();
 }
@@ -96,7 +96,7 @@ TEST_CASE("pack_impl noexcept", "[pack_impl][noexcept]")
 
   // both dispatchers weigh the callback they apply
   static_assert(not noexcept(P::_swap_invoke(std::declval<P const &>(), throwing_fn)));
-  static_assert(not noexcept(P::_invoke(std::declval<P const &>(), throwing_fn)));
+  static_assert(not noexcept(P::_apply(std::declval<P const &>(), throwing_fn)));
 
   // _append weighs the element it constructs AND every element it relocates into the new pack: here
   // the appended int cannot throw, but the Throwing already in the pack must be moved across ...
@@ -133,8 +133,8 @@ TEST_CASE("pack_impl _swap_invoke", "[pack_impl][swap_invoke]")
     i = 5;
     d = 6.0;
   });
-  CHECK(P::_invoke(pm, [](int i, double) { return i; }) == 5);
-  CHECK(P::_invoke(pm, [](int, double d) { return d; }) == 6.0);
+  CHECK(P::_apply(pm, [](int i, double) { return i; }) == 5);
+  CHECK(P::_apply(pm, [](int, double d) { return d; }) == 6.0);
 
   // SFINAE: non-applicable fn is rejected (wrong arity)
   static_assert(not can_swap_invoke<P, decltype([]() {})>);
@@ -144,28 +144,28 @@ TEST_CASE("pack_impl _swap_invoke", "[pack_impl][swap_invoke]")
   static_assert(can_swap_invoke<P, decltype([](int, double) {})>);
 }
 
-TEST_CASE("pack_impl _invoke", "[pack_impl][apply]")
+TEST_CASE("pack_impl _apply", "[pack_impl][apply]")
 {
   using fn::detail::pack_impl;
   using P = pack_impl<std::index_sequence_for<int, double>, int, double>;
 
   constexpr P p{2, 0.5};
-  // _invoke calls fn(elements..., args...)
-  static_assert(P::_invoke(p, [](int i, double d) { return i + d; }) == 2.5);
-  static_assert(P::_invoke(p, [](int i, double d, int suffix) { return i + d + suffix; }, 100) == 102.5);
-  static_assert(std::same_as<decltype(P::_invoke(p, [](int, double) -> long { return 0; })), long>);
+  // _apply calls fn(elements..., args...)
+  static_assert(P::_apply(p, [](int i, double d) { return i + d; }) == 2.5);
+  static_assert(P::_apply(p, [](int i, double d, int suffix) { return i + d + suffix; }, 100) == 102.5);
+  static_assert(std::same_as<decltype(P::_apply(p, [](int, double) -> long { return 0; })), long>);
 
   // const lvalue propagation: elements are passed as const lvalue references when pack is const
-  static_assert(P::_invoke(p, [](int const &, double const &) { return true; }));
+  static_assert(P::_apply(p, [](int const &, double const &) { return true; }));
 
   // mutable access via non-const pack
   P pm{3, 4.0};
-  P::_invoke(pm, [](int &i, double &d) {
+  P::_apply(pm, [](int &i, double &d) {
     i = 5;
     d = 6.0;
   });
-  CHECK(P::_invoke(pm, [](int i, double) { return i; }) == 5);
-  CHECK(P::_invoke(pm, [](int, double d) { return d; }) == 6.0);
+  CHECK(P::_apply(pm, [](int i, double) { return i; }) == 5);
+  CHECK(P::_apply(pm, [](int, double d) { return d; }) == 6.0);
 
   // SFINAE: non-applicable fn is rejected (wrong arity)
   static_assert(not can_invoke<P, decltype([]() {})>);
@@ -216,17 +216,17 @@ TEST_CASE("pack_impl _append and append_type", "[pack_impl][append][append_type]
   constexpr P0 p0{};
   constexpr auto p1 = P0::template _append<int>(p0, 7);
   static_assert(std::same_as<decltype(p1), P1 const>);
-  static_assert(P1::_invoke(p1, [](int v) { return v; }) == 7);
+  static_assert(P1::_apply(p1, [](int v) { return v; }) == 7);
 
   constexpr auto p2 = P1::template _append<double>(p1, 1.25);
   static_assert(std::same_as<decltype(p2), P2 const>);
-  static_assert(P2::_invoke(p2, [](int i, double d) { return i + d; }) == 8.25);
+  static_assert(P2::_apply(p2, [](int i, double d) { return i + d; }) == 8.25);
 
   // construction with multi-arg ctor
   using PA = pack_impl<std::index_sequence_for<A>, A>;
   constexpr auto pa = P0::template _append<A>(p0, 99);
   static_assert(std::same_as<decltype(pa), PA const>);
-  static_assert(PA::_invoke(pa, [](A const &a) { return a.v; }) == 99);
+  static_assert(PA::_apply(pa, [](A const &a) { return a.v; }) == 99);
 
   // SFINAE: incompatible ctor args are rejected (no `A(char const *)`)
   static_assert(not can_append<P0, A, char const *>);

--- a/tests/fn/detail/pack_impl.cpp
+++ b/tests/fn/detail/pack_impl.cpp
@@ -94,7 +94,7 @@ TEST_CASE("pack_impl noexcept", "[pack_impl][noexcept]")
 
   constexpr auto throwing_fn = [](auto &&...) noexcept(false) -> int { return 0; };
 
-  // both dispatchers weigh the callback they invoke
+  // both dispatchers weigh the callback they apply
   static_assert(not noexcept(P::_swap_invoke(std::declval<P const &>(), throwing_fn)));
   static_assert(not noexcept(P::_invoke(std::declval<P const &>(), throwing_fn)));
 
@@ -136,15 +136,15 @@ TEST_CASE("pack_impl _swap_invoke", "[pack_impl][swap_invoke]")
   CHECK(P::_invoke(pm, [](int i, double) { return i; }) == 5);
   CHECK(P::_invoke(pm, [](int, double d) { return d; }) == 6.0);
 
-  // SFINAE: non-invocable fn is rejected (wrong arity)
+  // SFINAE: non-applicable fn is rejected (wrong arity)
   static_assert(not can_swap_invoke<P, decltype([]() {})>);
-  // SFINAE: non-invocable fn is rejected (incompatible argument types)
+  // SFINAE: non-applicable fn is rejected (incompatible argument types)
   static_assert(not can_swap_invoke<P, decltype([](int *, int *) {})>);
   // positive control
   static_assert(can_swap_invoke<P, decltype([](int, double) {})>);
 }
 
-TEST_CASE("pack_impl _invoke", "[pack_impl][invoke]")
+TEST_CASE("pack_impl _invoke", "[pack_impl][apply]")
 {
   using fn::detail::pack_impl;
   using P = pack_impl<std::index_sequence_for<int, double>, int, double>;
@@ -167,9 +167,9 @@ TEST_CASE("pack_impl _invoke", "[pack_impl][invoke]")
   CHECK(P::_invoke(pm, [](int i, double) { return i; }) == 5);
   CHECK(P::_invoke(pm, [](int, double d) { return d; }) == 6.0);
 
-  // SFINAE: non-invocable fn is rejected (wrong arity)
+  // SFINAE: non-applicable fn is rejected (wrong arity)
   static_assert(not can_invoke<P, decltype([]() {})>);
-  // SFINAE: non-invocable fn is rejected (incompatible argument types)
+  // SFINAE: non-applicable fn is rejected (incompatible argument types)
   static_assert(not can_invoke<P, decltype([](int *, int *) {})>);
   // positive control
   static_assert(can_invoke<P, decltype([](int, double) {})>);

--- a/tests/fn/detail/variadic_union.cpp
+++ b/tests/fn/detail/variadic_union.cpp
@@ -15,8 +15,8 @@
 #include <type_traits>
 #include <utility>
 
+using fn::detail::apply_variadic_union;
 using fn::detail::invoke_type_variadic_union;
-using fn::detail::invoke_variadic_union;
 using fn::detail::make_variadic_union;
 using fn::detail::ptr_variadic_union;
 using fn::detail::variadic_union;
@@ -89,12 +89,12 @@ template <typename U, std::size_t I> constexpr auto check_alternative() -> bool
 
   bool ok = *ptr_variadic_union<T, U>(u) == v && *ptr_variadic_union<T, U>(m) == v;
 
-  // invoke passes the alternative alone; the result converts to whatever R asks for
+  // apply passes the alternative alone; the result converts to whatever R asks for
   constexpr auto size_of = [](auto x) -> std::size_t { return sizeof(x); };
-  static_assert(std::same_as<std::size_t, decltype(invoke_variadic_union<std::size_t, U>(u, I, size_of))>);
-  static_assert(std::same_as<long, decltype(invoke_variadic_union<long, U>(u, I, size_of))>);
-  ok = ok && invoke_variadic_union<std::size_t, U>(u, I, size_of) == sizeof(T);
-  ok = ok && invoke_variadic_union<long, U>(u, I, size_of) == static_cast<long>(sizeof(T));
+  static_assert(std::same_as<std::size_t, decltype(apply_variadic_union<std::size_t, U>(u, I, size_of))>);
+  static_assert(std::same_as<long, decltype(apply_variadic_union<long, U>(u, I, size_of))>);
+  ok = ok && apply_variadic_union<std::size_t, U>(u, I, size_of) == sizeof(T);
+  ok = ok && apply_variadic_union<long, U>(u, I, size_of) == static_cast<long>(sizeof(T));
 
   // invoke_type additionally passes in_place_type<T>, naming the alternative it dispatched to - and
   // passes exactly those two arguments
@@ -106,9 +106,9 @@ template <typename U, std::size_t I> constexpr auto check_alternative() -> bool
        });
 
   // both dispatchers have a separate void-returning overload per union size
-  static_assert(std::same_as<void, decltype(invoke_variadic_union<void, U>(u, I, size_of))>);
+  static_assert(std::same_as<void, decltype(apply_variadic_union<void, U>(u, I, size_of))>);
   std::size_t seen = 0;
-  invoke_variadic_union<void, U>(u, I, [&seen](auto x) { seen = sizeof(x); });
+  apply_variadic_union<void, U>(u, I, [&seen](auto x) { seen = sizeof(x); });
   ok = ok && seen == sizeof(T);
 
   static_assert(std::same_as<void, decltype(invoke_type_variadic_union<void, U>(u, I, arity))>);
@@ -142,7 +142,7 @@ using U5 = variadic_union<bool, int, double, float, std::string_view>;
 // recursive one that chains a nested union past the fourth alternative.
 TEMPLATE_TEST_CASE("variadic_union",
                    "[variadic_union][make_variadic_union][ptr_variadic_union]"
-                   "[invoke_variadic_union][invoke_type_variadic_union]",
+                   "[apply_variadic_union][invoke_type_variadic_union]",
                    U1, U2, U3, U4, U5)
 {
   using U = TestType;
@@ -193,7 +193,7 @@ TEST_CASE("variadic_union with a non-copyable alternative", "[variadic_union][ma
   constexpr T6 a4 = make_variadic_union<NonCopyable, T6>(42);
   static_assert(ptr_variadic_union<NonCopyable, T6>(a4)->v == 42);
   // by const reference: a by-value callback would copy the alternative, which NonCopyable forbids
-  static_assert(invoke_variadic_union<int, T6>(a4, 4, [](auto const &i) -> int { return static_cast<int>(i); }) == 42);
+  static_assert(apply_variadic_union<int, T6>(a4, 4, [](auto const &i) -> int { return static_cast<int>(i); }) == 42);
 
   CHECK(ptr_variadic_union<NonCopyable, T6>(a4)->v == 42);
 }

--- a/tests/fn/expected.cpp
+++ b/tests/fn/expected.cpp
@@ -123,7 +123,7 @@ TEST_CASE("graded monad", "[expected][sum][graded][and_then][or_else][sum_value]
         static_assert(std::is_same_v<decltype(a), fn::expected<immovable_t, fn::sum<>>>);
         CHECK(a.value().v == 7);
 
-        // the from-invoke tag ctor backing this is not part of the public interface
+        // the from-apply tag ctor backing this is not part of the public interface
         // (is_constructible_v cannot see private ctors)
         static_assert(
             not std::is_constructible_v<fn::expected<immovable_t, fn::sum<>>, pfn::detail::_expected_from_invoke_t,
@@ -873,7 +873,7 @@ TEST_CASE("expected pack support", "[expected][pack][and_then][transform][operat
   {
     using S = fn::expected<fn::pack<int, std::string_view>, Error>;
 
-    // noexcept (extension): the spec asks fn's own nothrow-invocable trait, which asks the
+    // noexcept (extension): the spec asks fn's own nothrow-applicable trait, which asks the
     // pack-apply dispatch that will actually run - one argument per element
     constexpr auto nothrow_two = [](int &, std::string_view &) noexcept -> fn::expected<bool, Error> { return {true}; };
     static_assert(noexcept(std::declval<S &>().and_then(nothrow_two)));
@@ -950,7 +950,7 @@ TEST_CASE("expected pack support", "[expected][pack][and_then][transform][operat
     SECTION("noexcept")
     {
       // a pack's callback is invoked through fn's own dispatch, taking one argument per element: it
-      // is not directly invocable on the pack, so only fn's nothrow-invocable trait can answer
+      // is not directly applicable on the pack, so only fn's nothrow-applicable trait can answer
       using T = fn::expected<fn::pack<int, double>, Error>;
       static_assert(noexcept(
           std::declval<T &>().and_then([](int, double) noexcept -> fn::expected<bool, Error> { return {true}; })));
@@ -2489,8 +2489,8 @@ TEST_CASE("expected sum support and_then", "[expected][sum][and_then]")
 {
   using S = fn::expected<fn::sum_for<int, std::string_view>, Error>;
 
-  // noexcept (extension): same-error-type result AND nothrow invoke AND nothrow error copy - and
-  // the invoke is weighed by fn's own trait, which asks the per-alternative dispatch that will run,
+  // noexcept (extension): same-error-type result AND nothrow apply AND nothrow error copy - and
+  // the apply is weighed by fn's own trait, which asks the per-alternative dispatch that will run,
   // so a visitor set is weighed alternative by alternative.
   constexpr auto nothrow_lval
       = fn::overload{[](int &) noexcept -> fn::expected<bool, Error> { return {true}; },
@@ -2610,7 +2610,7 @@ TEST_CASE("expected sum support and_then", "[expected][sum][and_then]")
 
   SECTION("noexcept")
   {
-    // the callback is invoked through fn's own dispatch, so only fn's nothrow-invocable trait can
+    // the callback is invoked through fn's own dispatch, so only fn's nothrow-applicable trait can
     // answer for it - and it is nothrow only if EVERY alternative's call is
     using T = fn::expected<fn::sum<double, int>, Error>;
     static_assert(
@@ -2627,8 +2627,8 @@ TEST_CASE("expected sum support or_else", "[expected][sum][or_else]")
 {
   using S = fn::expected<double, fn::sum_for<int, std::string_view>>;
 
-  // noexcept (extension): same-value-type result AND nothrow invoke AND nothrow value copy, with
-  // the invoke weighed per alternative by fn's own trait.
+  // noexcept (extension): same-value-type result AND nothrow apply AND nothrow value copy, with
+  // the apply weighed per alternative by fn's own trait.
   constexpr auto nothrow_lval
       = fn::overload{[](int &) noexcept -> fn::expected<double, Error> { return {0.5}; },
                      [](std::string_view &) noexcept -> fn::expected<double, Error> { return {0.5}; }};
@@ -3223,7 +3223,7 @@ TEST_CASE("expected pack support or_else", "[expected][or_else][pack]")
 {
   using S = fn::expected<int, fn::pack<int, Error>>;
 
-  // noexcept (extension): the invoke is weighed by fn's own trait, which asks the pack-apply
+  // noexcept (extension): the apply is weighed by fn's own trait, which asks the pack-apply
   // dispatch that will run - one argument per element
   constexpr auto nothrow_two = [](int, Error &) noexcept -> fn::expected<int, Error> { return {1}; };
   static_assert(noexcept(std::declval<S &>().or_else(nothrow_two)));
@@ -3319,7 +3319,7 @@ TEST_CASE("expected pack support transform_error", "[expected][transform_error][
 {
   using S = fn::expected<int, fn::pack<int, Error>>;
 
-  // noexcept (extension): nothrow invoke AND nothrow value copy, with the invoke weighed by fn's
+  // noexcept (extension): nothrow apply AND nothrow value copy, with the apply weighed by fn's
   // own trait against the pack-apply dispatch that will run
   constexpr auto nothrow_two = [](int, Error &) noexcept -> bool { return true; };
   static_assert(noexcept(std::declval<S &>().transform_error(nothrow_two)));

--- a/tests/fn/fail.cpp
+++ b/tests/fn/fail.cpp
@@ -56,9 +56,9 @@ TEST_CASE("fail", "[fail][expected][expected_value][pack]")
   static_assert(is::invocable_with_any([](unsigned) -> Error { throw 0; }));                   // allow conversion
   static_assert(is::invocable_with_any([](auto...) -> Derived { throw 0; }));                  // allow conversion
   static_assert(is::invocable_with_any([](int const &) -> Error { throw 0; }));                // binds to const ref
-  static_assert(is::invocable<lvalue>([](int &) -> Error { throw 0; }));                       // binds to lvalue
-  static_assert(is::invocable<rvalue, prvalue>([](int &&) -> Error { throw 0; }));             // can move
-  static_assert(is::invocable<rvalue, crvalue>([](int const &&) -> Error { throw 0; }));       // binds to const rvalue
+  static_assert(is::applicable<lvalue>([](int &) -> Error { throw 0; }));                      // binds to lvalue
+  static_assert(is::applicable<rvalue, prvalue>([](int &&) -> Error { throw 0; }));            // can move
+  static_assert(is::applicable<rvalue, crvalue>([](int const &&) -> Error { throw 0; }));      // binds to const rvalue
   static_assert(is::not_invocable_with_any([](auto...) -> std::string { throw 0; }));          // no conversion found
   static_assert(is::not_invocable<clvalue, crvalue, cvalue>([](int &) -> Error { throw 0; })); // cannot remove const
   static_assert(is::not_invocable<rvalue>([](int &) -> Error { throw 0; }));                   // disallow bind
@@ -266,9 +266,9 @@ TEST_CASE("fail", "[fail][optional][pack]")
   static_assert(is::invocable_with_any([](int) { throw 0; }));                                 // allow copy
   static_assert(is::invocable_with_any([](unsigned) { throw 0; }));                            // allow conversion
   static_assert(is::invocable_with_any([](int const &) { throw 0; }));                         // binds to const ref
-  static_assert(is::invocable<lvalue>([](int &) { throw 0; }));                                // binds to lvalue
-  static_assert(is::invocable<rvalue, prvalue>([](int &&) { throw 0; }));                      // can move
-  static_assert(is::invocable<rvalue, crvalue>([](int const &&) { throw 0; }));                // binds to const rvalue
+  static_assert(is::applicable<lvalue>([](int &) { throw 0; }));                               // binds to lvalue
+  static_assert(is::applicable<rvalue, prvalue>([](int &&) { throw 0; }));                     // can move
+  static_assert(is::applicable<rvalue, crvalue>([](int const &&) { throw 0; }));               // binds to const rvalue
   static_assert(is::not_invocable<clvalue, crvalue, cvalue>([](int &) { throw 0; }));          // cannot remove const
   static_assert(is::not_invocable<rvalue>([](int &) { throw 0; }));                            // disallow bind
   static_assert(is::not_invocable<lvalue, clvalue, crvalue, cvalue>([](int &&) { throw 0; })); // cannot move
@@ -425,24 +425,24 @@ template <typename E> constexpr auto fn_int_lvalue = [](int &) -> E { throw 0; }
 template <typename E> constexpr auto fn_int_rvalue = [](int &&) -> E { throw 0; };
 } // namespace
 
-static_assert(invocable_fail<decltype(fn_int<Error>), expected<int, Error>>);
-static_assert(invocable_fail<decltype(fn_generic<Error>), expected<void, Error>>);
-static_assert(invocable_fail<decltype(fn_int<Xerror>), expected<int, Error>>);           // return type conversion
-static_assert(not invocable_fail<decltype(fn_int<Error>), expected<int, Xerror>>);       // cannot convert error
-static_assert(not invocable_fail<decltype(fn_generic<Error>), expected<void, Xerror>>);  // cannot convert error
-static_assert(not invocable_fail<decltype(fn_generic<Error>), expected<Value, Xerror>>); // cannot convert error
-static_assert(not invocable_fail<decltype(fn_int<Error>), expected<Value, Error>>);      // wrong parameter type
-static_assert(invocable_fail<decltype(fn_generic<Error>), expected<Value, Error>>);
-static_assert(invocable_fail<decltype(fn_int<void>), optional<int>>);
-static_assert(not invocable_fail<decltype(fn_int<void>), optional<Value>>); // wrong parameter type
-static_assert(invocable_fail<decltype(fn_generic<void>), optional<Value>>);
-static_assert(not invocable_fail<decltype(fn_generic<Error>), optional<Value>>); // bad return type
+static_assert(applicable_fail<decltype(fn_int<Error>), expected<int, Error>>);
+static_assert(applicable_fail<decltype(fn_generic<Error>), expected<void, Error>>);
+static_assert(applicable_fail<decltype(fn_int<Xerror>), expected<int, Error>>);           // return type conversion
+static_assert(not applicable_fail<decltype(fn_int<Error>), expected<int, Xerror>>);       // cannot convert error
+static_assert(not applicable_fail<decltype(fn_generic<Error>), expected<void, Xerror>>);  // cannot convert error
+static_assert(not applicable_fail<decltype(fn_generic<Error>), expected<Value, Xerror>>); // cannot convert error
+static_assert(not applicable_fail<decltype(fn_int<Error>), expected<Value, Error>>);      // wrong parameter type
+static_assert(applicable_fail<decltype(fn_generic<Error>), expected<Value, Error>>);
+static_assert(applicable_fail<decltype(fn_int<void>), optional<int>>);
+static_assert(not applicable_fail<decltype(fn_int<void>), optional<Value>>); // wrong parameter type
+static_assert(applicable_fail<decltype(fn_generic<void>), optional<Value>>);
+static_assert(not applicable_fail<decltype(fn_generic<Error>), optional<Value>>); // bad return type
 static_assert(
-    not invocable_fail<decltype(fn_int_lvalue<Error>), expected<int, Error>>); // cannot bind temporary to lvalue
-static_assert(invocable_fail<decltype(fn_int_lvalue<Error>), expected<int, Error> &>);
-static_assert(invocable_fail<decltype(fn_int_rvalue<Error>), expected<int, Error>>);
+    not applicable_fail<decltype(fn_int_lvalue<Error>), expected<int, Error>>); // cannot bind temporary to lvalue
+static_assert(applicable_fail<decltype(fn_int_lvalue<Error>), expected<int, Error> &>);
+static_assert(applicable_fail<decltype(fn_int_rvalue<Error>), expected<int, Error>>);
 static_assert(
-    not invocable_fail<decltype(fn_int_rvalue<Error>), expected<int, Error> &>); // cannot bind lvalue to rvalue-ref
+    not applicable_fail<decltype(fn_int_rvalue<Error>), expected<int, Error> &>); // cannot bind lvalue to rvalue-ref
 } // namespace fn
 
 TEST_CASE("fail constraints", "[fail][constraints]")
@@ -459,8 +459,8 @@ TEST_CASE("fail constraints", "[fail][constraints]")
 
   // ... and a move-only error only where it can be moved out of
   using is = monadic_static_check<fail_t, fn::expected<int, helper_move_only>>;
-  static_assert(is::invocable<rvalue, prvalue>(from_value));     // moved
-  static_assert(is::invocable<crvalue, cvalue>(from_value));     // const-moved
+  static_assert(is::applicable<rvalue, prvalue>(from_value));    // moved
+  static_assert(is::applicable<crvalue, cvalue>(from_value));    // const-moved
   static_assert(is::not_invocable<lvalue, clvalue>(from_value)); // would have to copy
 
   // An optional discards its value and returns nullopt, relocating nothing

--- a/tests/fn/filter.cpp
+++ b/tests/fn/filter.cpp
@@ -58,13 +58,13 @@ TEST_CASE("filter", "[filter][expected][expected_value]")
   static_assert(p_is::not_invocable_with_any([](int, int) -> bool { throw 0; }));    // bad arity
 
   static_assert(e_is::invocable_with_any(onError));
-  static_assert(e_is::invocable_with_any([](auto...) -> Error { throw 0; }));              // allow generic call
-  static_assert(e_is::invocable_with_any([](int) -> Error { throw 0; }));                  // allow copy
-  static_assert(e_is::invocable_with_any([](unsigned) -> Error { throw 0; }));             // allow conversion
-  static_assert(e_is::invocable_with_any([](int const &) -> Error { throw 0; }));          // binds to const ref
-  static_assert(e_is::invocable<lvalue>([](int &) -> Error { throw 0; }));                 // binds to lvalue
-  static_assert(e_is::invocable<rvalue, prvalue>([](int &&) -> Error { throw 0; }));       // can move
-  static_assert(e_is::invocable<rvalue, crvalue>([](int const &&) -> Error { throw 0; })); // binds to const rvalue
+  static_assert(e_is::invocable_with_any([](auto...) -> Error { throw 0; }));               // allow generic call
+  static_assert(e_is::invocable_with_any([](int) -> Error { throw 0; }));                   // allow copy
+  static_assert(e_is::invocable_with_any([](unsigned) -> Error { throw 0; }));              // allow conversion
+  static_assert(e_is::invocable_with_any([](int const &) -> Error { throw 0; }));           // binds to const ref
+  static_assert(e_is::applicable<lvalue>([](int &) -> Error { throw 0; }));                 // binds to lvalue
+  static_assert(e_is::applicable<rvalue, prvalue>([](int &&) -> Error { throw 0; }));       // can move
+  static_assert(e_is::applicable<rvalue, crvalue>([](int const &&) -> Error { throw 0; })); // binds to const rvalue
   static_assert(e_is::not_invocable<clvalue, crvalue, cvalue>([](int &) -> Error { throw 0; })); // cannot remove const
   static_assert(e_is::not_invocable<rvalue>([](int &) -> Error { throw 0; }));                   // disallow bind
   static_assert(e_is::not_invocable<lvalue, clvalue, crvalue, cvalue>([](int &&) -> Error { throw 0; })); // cannot move
@@ -203,12 +203,12 @@ TEST_CASE("filter member function", "[filter][expected][expected_value][member_f
   static_assert(p_is::not_invocable_with_any([](Value, int) -> bool { throw 0; }));  // bad arity
 
   static_assert(e_is::invocable_with_any(onError));
-  static_assert(e_is::invocable_with_any([](auto...) -> Error { throw 0; }));                // allow generic call
-  static_assert(e_is::invocable_with_any([](Value) -> Error { throw 0; }));                  // allow copy
-  static_assert(e_is::invocable_with_any([](Value const &) -> Error { throw 0; }));          // binds to const ref
-  static_assert(e_is::invocable<lvalue>([](Value &) -> Error { throw 0; }));                 // binds to lvalue
-  static_assert(e_is::invocable<rvalue, prvalue>([](Value &&) -> Error { throw 0; }));       // can move
-  static_assert(e_is::invocable<rvalue, crvalue>([](Value const &&) -> Error { throw 0; })); // binds to const rvalue
+  static_assert(e_is::invocable_with_any([](auto...) -> Error { throw 0; }));                 // allow generic call
+  static_assert(e_is::invocable_with_any([](Value) -> Error { throw 0; }));                   // allow copy
+  static_assert(e_is::invocable_with_any([](Value const &) -> Error { throw 0; }));           // binds to const ref
+  static_assert(e_is::applicable<lvalue>([](Value &) -> Error { throw 0; }));                 // binds to lvalue
+  static_assert(e_is::applicable<rvalue, prvalue>([](Value &&) -> Error { throw 0; }));       // can move
+  static_assert(e_is::applicable<rvalue, crvalue>([](Value const &&) -> Error { throw 0; })); // binds to const rvalue
   static_assert(e_is::not_invocable<clvalue, crvalue, cvalue>([](Value &) -> Error { throw 0; })); // no remove const
   static_assert(e_is::not_invocable<rvalue>([](Value &) -> operand_t { throw 0; }));               // disallow bind
   static_assert(e_is::not_invocable<lvalue, clvalue, crvalue, cvalue>([](Value &&) -> Error { throw 0; })); // no move
@@ -692,7 +692,7 @@ TEST_CASE("filter constraints", "[filter][constraints]")
 
   // ... and a move-only one only where it can be moved out of
   using is = monadic_static_check<filter_t, fn::expected<helper_move_only, int>>;
-  static_assert(is::invocable<rvalue, prvalue>(keep, on_err));     // moved
+  static_assert(is::applicable<rvalue, prvalue>(keep, on_err));    // moved
   static_assert(is::not_invocable<lvalue, clvalue>(keep, on_err)); // would have to copy
   SUCCEED();
 }
@@ -711,18 +711,18 @@ template <typename T> constexpr auto err_nullary = []() -> T { throw 0; };
 } // namespace
 
 // clang-format off
-static_assert(invocable_filter<decltype(pred_int), decltype(err_int<Error>), expected<int, Error>>);
-static_assert(not invocable_filter<decltype(pred_opaque), decltype(err_int<Error>), expected<int, Error>>);   // predicate must convert to bool
-static_assert(not invocable_filter<decltype(pred_int), decltype(err_int<Value>), expected<int, Error>>);      // no conversion to error
-static_assert(not invocable_filter<decltype(pred_nullary), decltype(err_int<Error>), expected<int, Error>>);  // bad arity
+static_assert(applicable_filter<decltype(pred_int), decltype(err_int<Error>), expected<int, Error>>);
+static_assert(not applicable_filter<decltype(pred_opaque), decltype(err_int<Error>), expected<int, Error>>);   // predicate must convert to bool
+static_assert(not applicable_filter<decltype(pred_int), decltype(err_int<Value>), expected<int, Error>>);      // no conversion to error
+static_assert(not applicable_filter<decltype(pred_nullary), decltype(err_int<Error>), expected<int, Error>>);  // bad arity
 // The predicate sees the value as const, whatever the operand's category.
-static_assert(not invocable_filter<decltype(pred_int_lvalue), decltype(err_int<Error>), expected<int, Error> &>);
-static_assert(invocable_filter<decltype(pred_nullary), decltype(err_nullary<Error>), expected<void, Error>>);
-static_assert(not invocable_filter<decltype(pred_int), decltype(err_int<Error>), expected<void, Error>>);     // void: nullary only
+static_assert(not applicable_filter<decltype(pred_int_lvalue), decltype(err_int<Error>), expected<int, Error> &>);
+static_assert(applicable_filter<decltype(pred_nullary), decltype(err_nullary<Error>), expected<void, Error>>);
+static_assert(not applicable_filter<decltype(pred_int), decltype(err_int<Error>), expected<void, Error>>);     // void: nullary only
 // filter over optional takes NO error callback: the Err parameter is void, and only void.
-static_assert(invocable_filter<decltype(pred_int), void, optional<int>>);
-static_assert(not invocable_filter<decltype(pred_int), decltype(err_int<Error>), optional<int>>);
-static_assert(not invocable_filter<decltype(pred_int), void, optional<Value>>);                               // wrong parameter type
-static_assert(not invocable_filter<decltype(pred_int), void, choice<int>>);                                   // no choice disjunct
+static_assert(applicable_filter<decltype(pred_int), void, optional<int>>);
+static_assert(not applicable_filter<decltype(pred_int), decltype(err_int<Error>), optional<int>>);
+static_assert(not applicable_filter<decltype(pred_int), void, optional<Value>>);                               // wrong parameter type
+static_assert(not applicable_filter<decltype(pred_int), void, choice<int>>);                                   // no choice disjunct
 // clang-format on
 } // namespace fn

--- a/tests/fn/functional.cpp
+++ b/tests/fn/functional.cpp
@@ -303,7 +303,9 @@ TEST_CASE("apply tuple-like", "[apply][apply_r][tuple]")
                   == pfn::is_applicable_v<TakesAlternative, std::tuple<fn::sum<int>>>);
     // and a pack is not tuple-like: it keeps fn's own dispatch
     static_assert(fn::apply(arity, fn::pack{1, 2, 3}) == 3);
-    SUCCEED();
+
+    CHECK(fn::apply(TakesSum{}, std::tuple<fn::sum<int>>{fn::sum<int>{1}}) == 7);
+    CHECK(fn::apply(arity, fn::pack{1, 2, 3}) == 3);
   }
 
   SECTION("apply_r over the elements")

--- a/tests/fn/functional.cpp
+++ b/tests/fn/functional.cpp
@@ -7,9 +7,12 @@
 #include <fn/pack.hpp>
 #include <fn/sum.hpp>
 #include <fn/utility.hpp>
+#include <pfn/tuple.hpp>
 
 #include <catch2/catch_all.hpp>
 
+#include <array>
+#include <tuple>
 #include <type_traits>
 #include <utility>
 
@@ -245,4 +248,80 @@ TEST_CASE("is_nothrow_applicable", "[is_nothrow_applicable][is_nothrow_applicabl
 
   CHECK(fn::apply(fnNothrow, 1) == 1);
   CHECK(fn::apply_r<long>(fnNothrow, 1) == 1L);
+}
+
+TEST_CASE("apply tuple-like", "[apply][apply_r][tuple]")
+{
+  constexpr auto add2 = [](int a, int b) noexcept { return a + b; };
+  constexpr auto arity = [](auto &&...args) noexcept { return (0 + ... + (static_cast<void>(args), 1)); };
+
+  SECTION("std::apply's meaning on std::apply's domain")
+  {
+    // shared machinery with pfn::apply: the two agree by construction
+    static_assert(fn::apply(add2, std::tuple{2, 3}) == pfn::apply(add2, std::tuple{2, 3}));
+    static_assert(fn::apply(add2, std::pair{2, 3}) == 5);
+    static_assert(fn::apply(add2, std::array{2, 3}) == 5);
+    static_assert(fn::is_applicable_v<decltype(add2), std::tuple<int, int>>
+                  == pfn::is_applicable_v<decltype(add2), std::tuple<int, int>>);
+    static_assert(fn::is_applicable_v<decltype(add2), std::tuple<int>>
+                  == pfn::is_applicable_v<decltype(add2), std::tuple<int>>); // both false: arity mismatch
+    static_assert(fn::is_nothrow_applicable_v<decltype(add2), std::tuple<int, int>>);
+    static_assert(std::same_as<fn::apply_result_t<decltype(add2), std::tuple<int, int>>, int>);
+
+    // a generic callable unpacks, as std::apply does
+    static_assert(fn::apply(arity, std::tuple{1, 2, 3}) == 3);
+
+    CHECK(fn::apply(add2, std::tuple{20, 22}) == 42);
+    CHECK(fn::apply(arity, std::tuple{1, 2, 3}) == 3);
+  }
+
+  SECTION("pass-whole survives where unpacking is not viable")
+  {
+    struct TakesTuple {
+      constexpr int operator()(std::tuple<int, int> const &) const noexcept { return -1; }
+    };
+    static_assert(fn::apply(TakesTuple{}, std::tuple{1, 2}) == -1);
+    // a tuple-like among further arguments has no unpacking route, and passes whole
+    static_assert(fn::apply(arity, std::tuple{1, 2}, 0) == 2);
+    CHECK(fn::apply(TakesTuple{}, std::tuple{1, 2}) == -1);
+  }
+
+  SECTION("elements are terminal")
+  {
+    // a sum element is handed over whole, exactly as std::apply hands it - never dispatched
+    struct TakesSum {
+      constexpr int operator()(fn::sum<int> const &) const noexcept { return 7; }
+    };
+    struct TakesAlternative {
+      constexpr int operator()(int) const noexcept { return 8; }
+    };
+    static_assert(fn::apply(TakesSum{}, std::tuple<fn::sum<int>>{fn::sum<int>{1}}) == 7);
+    static_assert(not fn::is_applicable_v<TakesAlternative, std::tuple<fn::sum<int>>>);
+    static_assert(fn::is_applicable_v<TakesSum, std::tuple<fn::sum<int>>>
+                  == pfn::is_applicable_v<TakesSum, std::tuple<fn::sum<int>>>);
+    static_assert(fn::is_applicable_v<TakesAlternative, std::tuple<fn::sum<int>>>
+                  == pfn::is_applicable_v<TakesAlternative, std::tuple<fn::sum<int>>>);
+    // and a pack is not tuple-like: it keeps fn's own dispatch
+    static_assert(fn::apply(arity, fn::pack{1, 2, 3}) == 3);
+    SUCCEED();
+  }
+
+  SECTION("apply_r over the elements")
+  {
+    static_assert(fn::apply_r<long>(add2, std::tuple{2, 3}) == 5L);
+    static_assert(std::same_as<decltype(fn::apply_r<long>(add2, std::tuple{2, 3})), long>);
+    static_assert(fn::is_applicable_r_v<long, decltype(add2), std::tuple<int, int>>);
+    static_assert(fn::is_applicable_r_v<void, decltype(add2), std::tuple<int, int>>);
+    static_assert(not fn::is_applicable_r_v<char *, decltype(add2), std::tuple<int, int>>);
+    CHECK(fn::apply_r<long>(add2, std::tuple{20, 22}) == 42L);
+  }
+
+  SECTION("noexcept follows the elements' call")
+  {
+    constexpr auto loud = [](int a, int b) { return a + b; };
+    static_assert(not fn::is_nothrow_applicable_v<decltype(loud), std::tuple<int, int>>);
+    static_assert(not noexcept(fn::apply(loud, std::declval<std::tuple<int, int> &>())));
+    static_assert(noexcept(fn::apply(add2, std::declval<std::tuple<int, int> &>())));
+    SUCCEED();
+  }
 }

--- a/tests/fn/functional.cpp
+++ b/tests/fn/functional.cpp
@@ -13,7 +13,7 @@
 #include <type_traits>
 #include <utility>
 
-TEST_CASE("invoke multidispatch", "[pack][sum][invoke][invoke_r]")
+TEST_CASE("apply multidispatch", "[pack][sum][apply][apply_r]")
 {
   using namespace ::fn::detail;
   using ::fn::pack;
@@ -21,122 +21,122 @@ TEST_CASE("invoke multidispatch", "[pack][sum][invoke][invoke_r]")
 
   constexpr auto fn = [](auto &&...a) { return (0 + ... + static_cast<int>(a)); };
 
-  static_assert(fn::invoke(fn) == 0);
-  static_assert(fn::invoke(fn, 1, 2) == 3);
-  static_assert(fn::invoke(fn, pack{1, 2}) == 1 + 2);
-  static_assert(fn::invoke(fn, pack{1, 2}, 3) == 1 + 2 + 3);
-  static_assert(fn::invoke(fn, 1, pack{2, 3, 5}) == 1 + 2 + 3 + 5);
-  static_assert(fn::invoke(fn, sum<bool, int>{2}) == 2);
-  static_assert(fn::invoke(fn, sum<bool, int>{2}, 3) == 2 + 3);
-  static_assert(fn::invoke(fn, 2, sum<bool, int>{3}) == 2 + 3);
-  static_assert(fn::invoke(fn, 2, sum<bool, int>{3}, pack{2, 3, 5}) == 2 + 3 + 2 + 3 + 5);
-  static_assert(fn::invoke(fn, 2, pack{3, 5}, 7, sum<bool, int>{2}) == 2 + 3 + 5 + 7 + 2);
-  static_assert(fn::invoke(fn, sum<bool, int>{3}, 2, pack{2, 3, 5}) == 2 + 3 + 2 + 3 + 5);
-  static_assert(fn::invoke(fn, sum<bool, int>{3}, pack{2, 3, 5}, 2) == 2 + 3 + 2 + 3 + 5);
-  static_assert(fn::invoke(fn, pack{3, 5}, 2, 7, sum<bool, int>{2}) == 2 + 3 + 5 + 7 + 2);
-  static_assert(fn::invoke(fn, pack{3, 5}, sum<bool, int>{2}, 2, 7) == 2 + 3 + 5 + 7 + 2);
+  static_assert(fn::apply(fn) == 0);
+  static_assert(fn::apply(fn, 1, 2) == 3);
+  static_assert(fn::apply(fn, pack{1, 2}) == 1 + 2);
+  static_assert(fn::apply(fn, pack{1, 2}, 3) == 1 + 2 + 3);
+  static_assert(fn::apply(fn, 1, pack{2, 3, 5}) == 1 + 2 + 3 + 5);
+  static_assert(fn::apply(fn, sum<bool, int>{2}) == 2);
+  static_assert(fn::apply(fn, sum<bool, int>{2}, 3) == 2 + 3);
+  static_assert(fn::apply(fn, 2, sum<bool, int>{3}) == 2 + 3);
+  static_assert(fn::apply(fn, 2, sum<bool, int>{3}, pack{2, 3, 5}) == 2 + 3 + 2 + 3 + 5);
+  static_assert(fn::apply(fn, 2, pack{3, 5}, 7, sum<bool, int>{2}) == 2 + 3 + 5 + 7 + 2);
+  static_assert(fn::apply(fn, sum<bool, int>{3}, 2, pack{2, 3, 5}) == 2 + 3 + 2 + 3 + 5);
+  static_assert(fn::apply(fn, sum<bool, int>{3}, pack{2, 3, 5}, 2) == 2 + 3 + 2 + 3 + 5);
+  static_assert(fn::apply(fn, pack{3, 5}, 2, 7, sum<bool, int>{2}) == 2 + 3 + 5 + 7 + 2);
+  static_assert(fn::apply(fn, pack{3, 5}, sum<bool, int>{2}, 2, 7) == 2 + 3 + 5 + 7 + 2);
 
-  static_assert(fn::invoke_r<long>(fn) == 0);
-  static_assert(fn::invoke_r<long>(fn, 1, 2) == 3);
-  static_assert(fn::invoke_r<long>(fn, pack{1, 2}) == 1 + 2);
-  static_assert(fn::invoke_r<long>(fn, pack{1, 2}, 3) == 1 + 2 + 3);
-  static_assert(fn::invoke_r<long>(fn, 1, pack{2, 3, 5}) == 1 + 2 + 3 + 5);
-  static_assert(fn::invoke_r<long>(fn, sum<bool, int>{2}) == 2);
-  static_assert(fn::invoke_r<long>(fn, sum<bool, int>{2}, 3) == 2 + 3);
-  static_assert(fn::invoke_r<long>(fn, 2, sum<bool, int>{3}) == 2 + 3);
-  static_assert(fn::invoke_r<long>(fn, 2, sum<bool, int>{3}, pack{2, 3, 5}) == 2 + 3 + 2 + 3 + 5);
-  static_assert(fn::invoke_r<long>(fn, 2, pack{3, 5}, 7, sum<bool, int>{2}) == 2 + 3 + 5 + 7 + 2);
-  static_assert(fn::invoke_r<long>(fn, sum<bool, int>{3}, 2, pack{2, 3, 5}) == 2 + 3 + 2 + 3 + 5);
-  static_assert(fn::invoke_r<long>(fn, sum<bool, int>{3}, pack{2, 3, 5}, 2) == 2 + 3 + 2 + 3 + 5);
-  static_assert(fn::invoke_r<long>(fn, pack{3, 5}, 2, 7, sum<bool, int>{2}) == 2 + 3 + 5 + 7 + 2);
-  static_assert(fn::invoke_r<long>(fn, pack{3, 5}, sum<bool, int>{2}, 2, 7) == 2 + 3 + 5 + 7 + 2);
+  static_assert(fn::apply_r<long>(fn) == 0);
+  static_assert(fn::apply_r<long>(fn, 1, 2) == 3);
+  static_assert(fn::apply_r<long>(fn, pack{1, 2}) == 1 + 2);
+  static_assert(fn::apply_r<long>(fn, pack{1, 2}, 3) == 1 + 2 + 3);
+  static_assert(fn::apply_r<long>(fn, 1, pack{2, 3, 5}) == 1 + 2 + 3 + 5);
+  static_assert(fn::apply_r<long>(fn, sum<bool, int>{2}) == 2);
+  static_assert(fn::apply_r<long>(fn, sum<bool, int>{2}, 3) == 2 + 3);
+  static_assert(fn::apply_r<long>(fn, 2, sum<bool, int>{3}) == 2 + 3);
+  static_assert(fn::apply_r<long>(fn, 2, sum<bool, int>{3}, pack{2, 3, 5}) == 2 + 3 + 2 + 3 + 5);
+  static_assert(fn::apply_r<long>(fn, 2, pack{3, 5}, 7, sum<bool, int>{2}) == 2 + 3 + 5 + 7 + 2);
+  static_assert(fn::apply_r<long>(fn, sum<bool, int>{3}, 2, pack{2, 3, 5}) == 2 + 3 + 2 + 3 + 5);
+  static_assert(fn::apply_r<long>(fn, sum<bool, int>{3}, pack{2, 3, 5}, 2) == 2 + 3 + 2 + 3 + 5);
+  static_assert(fn::apply_r<long>(fn, pack{3, 5}, 2, 7, sum<bool, int>{2}) == 2 + 3 + 5 + 7 + 2);
+  static_assert(fn::apply_r<long>(fn, pack{3, 5}, sum<bool, int>{2}, 2, 7) == 2 + 3 + 5 + 7 + 2);
 }
 
-TEST_CASE("invoke_result pack", "[invoke_result][pack]")
+TEST_CASE("apply_result pack", "[apply_result][pack]")
 {
-  using fn::invoke_result;
-  using fn::invoke_result_t;
+  using fn::apply_result;
+  using fn::apply_result_t;
   using fn::pack;
 
   constexpr pack<int, double> p{3, 14.15};
   constexpr auto fn1 = [](int i, double j) -> int { return i * 100 + (int)j; };
-  static_assert(std::is_same_v<invoke_result<decltype(fn1), decltype(p)>::type, int>);
-  static_assert(std::is_same_v<invoke_result_t<decltype(fn1), decltype(p)>, int>);
+  static_assert(std::is_same_v<apply_result<decltype(fn1), decltype(p)>::type, int>);
+  static_assert(std::is_same_v<apply_result_t<decltype(fn1), decltype(p)>, int>);
   SUCCEED();
 }
 
-TEST_CASE("is_invocable pack", "[is_invocable][pack]")
+TEST_CASE("is_applicable pack", "[is_applicable][pack]")
 {
-  using fn::is_invocable;
-  using fn::is_invocable_v;
+  using fn::is_applicable;
+  using fn::is_applicable_v;
   using fn::pack;
 
   constexpr pack<int, double> p{3, 14.15};
   constexpr auto fn1 = [](int i, double j) -> int { return i * 100 + (int)j; };
-  static_assert(is_invocable<decltype(fn1), decltype(p)>::value);
-  static_assert(is_invocable_v<decltype(fn1), decltype(p)>);
+  static_assert(is_applicable<decltype(fn1), decltype(p)>::value);
+  static_assert(is_applicable_v<decltype(fn1), decltype(p)>);
 
   constexpr auto fn2 = [](int, double &) -> int { throw 0; };
-  static_assert(not is_invocable<decltype(fn2), decltype(p)>::value);
-  static_assert(not is_invocable_v<decltype(fn2), decltype(p)>);
+  static_assert(not is_applicable<decltype(fn2), decltype(p)>::value);
+  static_assert(not is_applicable_v<decltype(fn2), decltype(p)>);
   SUCCEED();
 }
 
-TEST_CASE("is_invocable sum", "[is_invocable][sum]")
+TEST_CASE("is_applicable sum", "[is_applicable][sum]")
 {
-  using fn::is_invocable;
-  using fn::is_invocable_v;
+  using fn::is_applicable;
+  using fn::is_applicable_v;
   using fn::overload;
   using fn::sum;
 
   constexpr sum<double, int> p{3};
   constexpr auto fn1 = overload{[](int i) -> int { return i * 100; }, [](double j) -> int { return (int)j; }};
-  static_assert(is_invocable<decltype(fn1), decltype(p)>::value);
-  static_assert(is_invocable_v<decltype(fn1), decltype(p)>);
+  static_assert(is_applicable<decltype(fn1), decltype(p)>::value);
+  static_assert(is_applicable_v<decltype(fn1), decltype(p)>);
   constexpr auto fn2 = [](int &) -> int { throw 0; };
-  static_assert(not is_invocable<decltype(fn2), decltype(p)>::value);
-  static_assert(not is_invocable_v<decltype(fn2), decltype(p)>);
+  static_assert(not is_applicable<decltype(fn2), decltype(p)>::value);
+  static_assert(not is_applicable_v<decltype(fn2), decltype(p)>);
 }
 
-TEST_CASE("is_invocable_r pack", "[is_invocable_r][pack]")
+TEST_CASE("is_applicable_r pack", "[is_applicable_r][pack]")
 {
-  using fn::is_invocable_r;
-  using fn::is_invocable_r_v;
+  using fn::is_applicable_r;
+  using fn::is_applicable_r_v;
   using fn::pack;
 
   constexpr pack<int, double> p{3, 14.15};
   constexpr auto fn1 = [](int i, double j) -> int { return i * 100 + (int)j; };
-  static_assert(is_invocable_r<bool, decltype(fn1), decltype(p)>::value);
-  static_assert(is_invocable_r_v<bool, decltype(fn1), decltype(p)>);
-  static_assert(not is_invocable_r<int *, decltype(fn1), decltype(p)>::value);
-  static_assert(not is_invocable_r_v<int *, decltype(fn1), decltype(p)>);
+  static_assert(is_applicable_r<bool, decltype(fn1), decltype(p)>::value);
+  static_assert(is_applicable_r_v<bool, decltype(fn1), decltype(p)>);
+  static_assert(not is_applicable_r<int *, decltype(fn1), decltype(p)>::value);
+  static_assert(not is_applicable_r_v<int *, decltype(fn1), decltype(p)>);
   constexpr auto fn2 = [](int, double &) -> int { throw 0; };
-  static_assert(not is_invocable_r<bool, decltype(fn2), decltype(p)>::value);
-  static_assert(not is_invocable_r_v<bool, decltype(fn2), decltype(p)>);
+  static_assert(not is_applicable_r<bool, decltype(fn2), decltype(p)>::value);
+  static_assert(not is_applicable_r_v<bool, decltype(fn2), decltype(p)>);
 }
 
-TEST_CASE("is_invocable_r sum", "[is_invocable_r][sum]")
+TEST_CASE("is_applicable_r sum", "[is_applicable_r][sum]")
 {
-  using fn::is_invocable_r;
-  using fn::is_invocable_r_v;
+  using fn::is_applicable_r;
+  using fn::is_applicable_r_v;
   using fn::overload;
   using fn::sum;
 
   constexpr sum<double, int> p{3};
   constexpr auto fn1 = overload{[](int i) -> int { return i * 100; }, [](double j) -> int { return (int)j; }};
-  static_assert(is_invocable_r<bool, decltype(fn1), decltype(p)>::value);
-  static_assert(is_invocable_r_v<bool, decltype(fn1), decltype(p)>);
-  static_assert(not is_invocable_r<int *, decltype(fn1), decltype(p)>::value);
-  static_assert(not is_invocable_r_v<int *, decltype(fn1), decltype(p)>);
+  static_assert(is_applicable_r<bool, decltype(fn1), decltype(p)>::value);
+  static_assert(is_applicable_r_v<bool, decltype(fn1), decltype(p)>);
+  static_assert(not is_applicable_r<int *, decltype(fn1), decltype(p)>::value);
+  static_assert(not is_applicable_r_v<int *, decltype(fn1), decltype(p)>);
   constexpr auto fn2 = [](int &) -> int { throw 0; };
-  static_assert(not is_invocable_r<decltype(fn2), decltype(p)>::value);
-  static_assert(not is_invocable_r_v<decltype(fn2), decltype(p)>);
+  static_assert(not is_applicable_r<decltype(fn2), decltype(p)>::value);
+  static_assert(not is_applicable_r_v<decltype(fn2), decltype(p)>);
   SUCCEED();
 }
 
-TEST_CASE("invoke polyfill", "[invoke][polyfill]")
+TEST_CASE("apply polyfill", "[apply][polyfill]")
 {
-  using fn::invoke;
+  using fn::apply;
   struct Xint final {
     int value;
 
@@ -148,101 +148,101 @@ TEST_CASE("invoke polyfill", "[invoke][polyfill]")
   };
 
   Xint v{12};
-  CHECK(invoke(Xint::fn, v) == 12);
-  CHECK(invoke(&Xint::fn1, v) == 13);
-  CHECK(invoke(&Xint::fn2, v) == 14);
-  CHECK(invoke(&Xint::fn2, std::as_const(v)) == 14);
-  CHECK(invoke(&Xint::fn4, std::move(v)) == 16);
-  CHECK(invoke(&Xint::fn4, std::move(std::as_const(v))) == 16);
-  CHECK(invoke(&Xint::fn3, std::move(v)) == 15);
+  CHECK(apply(Xint::fn, v) == 12);
+  CHECK(apply(&Xint::fn1, v) == 13);
+  CHECK(apply(&Xint::fn2, v) == 14);
+  CHECK(apply(&Xint::fn2, std::as_const(v)) == 14);
+  CHECK(apply(&Xint::fn4, std::move(v)) == 16);
+  CHECK(apply(&Xint::fn4, std::move(std::as_const(v))) == 16);
+  CHECK(apply(&Xint::fn3, std::move(v)) == 15);
 }
 
-TEST_CASE("invoke pack", "[invoke][pack]")
+TEST_CASE("apply pack", "[apply][pack]")
 {
-  using fn::invoke;
+  using fn::apply;
   using fn::pack;
 
   constexpr auto fn = [](int i, double j) -> int { return i * 100 + (int)j; };
   pack<int, double> p{3, 14.15};
 
-  CHECK(invoke(fn, p) == 314);
-  CHECK(invoke(fn, std::as_const(p)) == 314);
-  CHECK(invoke(fn, std::move(std::as_const(p))) == 314);
-  CHECK(invoke(fn, std::move(p)) == 314);
+  CHECK(apply(fn, p) == 314);
+  CHECK(apply(fn, std::as_const(p)) == 314);
+  CHECK(apply(fn, std::move(std::as_const(p))) == 314);
+  CHECK(apply(fn, std::move(p)) == 314);
 }
 
-TEST_CASE("invoke_r pack", "[invoke_r][pack]")
+TEST_CASE("apply_r pack", "[apply_r][pack]")
 {
-  using fn::invoke_r;
+  using fn::apply_r;
   using fn::pack;
 
   constexpr auto fn = [](int i, double j) -> int { return i * 100 + (int)j; };
   pack<int, double> p{3, 14.15};
 
-  CHECK(invoke_r<double>(fn, p) == 314.0);
-  CHECK(invoke_r<double>(fn, std::as_const(p)) == 314.0);
-  CHECK(invoke_r<double>(fn, std::move(std::as_const(p))) == 314.0);
-  CHECK(invoke_r<double>(fn, std::move(p)) == 314.0);
+  CHECK(apply_r<double>(fn, p) == 314.0);
+  CHECK(apply_r<double>(fn, std::as_const(p)) == 314.0);
+  CHECK(apply_r<double>(fn, std::move(std::as_const(p))) == 314.0);
+  CHECK(apply_r<double>(fn, std::move(p)) == 314.0);
 }
 
-TEST_CASE("invoke sum", "[invoke][sum]")
+TEST_CASE("apply sum", "[apply][sum]")
 {
-  using fn::invoke;
+  using fn::apply;
   using fn::overload;
   using fn::sum;
 
   constexpr auto fn = overload{[](int i) -> int { return i * 10; }, [](double) -> int { throw 0; }};
   sum<double, int> p{3};
 
-  CHECK(invoke(fn, p) == 30);
-  CHECK(invoke(fn, std::as_const(p)) == 30);
-  CHECK(invoke(fn, std::move(std::as_const(p))) == 30);
-  CHECK(invoke(fn, std::move(p)) == 30);
+  CHECK(apply(fn, p) == 30);
+  CHECK(apply(fn, std::as_const(p)) == 30);
+  CHECK(apply(fn, std::move(std::as_const(p))) == 30);
+  CHECK(apply(fn, std::move(p)) == 30);
 }
 
-TEST_CASE("invoke_r sum", "[invoke_r][sum]")
+TEST_CASE("apply_r sum", "[apply_r][sum]")
 {
-  using fn::invoke_r;
+  using fn::apply_r;
   using fn::overload;
   using fn::sum;
 
   constexpr auto fn = overload{[](int) -> bool { throw 0; }, [](double j) -> short { return j * 100; }};
   sum<double, int> p{14.15};
 
-  CHECK(invoke_r<int>(fn, p) == 1415);
-  CHECK(invoke_r<int>(fn, std::as_const(p)) == 1415);
-  CHECK(invoke_r<int>(fn, std::move(std::as_const(p))) == 1415);
-  CHECK(invoke_r<int>(fn, std::move(p)) == 1415);
+  CHECK(apply_r<int>(fn, p) == 1415);
+  CHECK(apply_r<int>(fn, std::as_const(p)) == 1415);
+  CHECK(apply_r<int>(fn, std::move(std::as_const(p))) == 1415);
+  CHECK(apply_r<int>(fn, std::move(p)) == 1415);
 }
 
-TEST_CASE("is_nothrow_invocable", "[is_nothrow_invocable][is_nothrow_invocable_r][invoke][noexcept]")
+TEST_CASE("is_nothrow_applicable", "[is_nothrow_applicable][is_nothrow_applicable_r][apply][noexcept]")
 {
   constexpr auto fnNothrow = [](int i) noexcept -> int { return i; };
   constexpr auto fnThrows = [](int i) noexcept(false) -> int { return i; };
 
   // over a plain argument the traits agree with their std counterparts
   static_assert(std::is_nothrow_invocable_v<decltype(fnNothrow), int>);
-  static_assert(fn::is_nothrow_invocable_v<decltype(fnNothrow), int>);
-  static_assert(not fn::is_nothrow_invocable_v<decltype(fnThrows), int>);
+  static_assert(fn::is_nothrow_applicable_v<decltype(fnNothrow), int>);
+  static_assert(not fn::is_nothrow_applicable_v<decltype(fnThrows), int>);
 
   static_assert(std::is_nothrow_invocable_r_v<long, decltype(fnNothrow), int>);
-  static_assert(fn::is_nothrow_invocable_r_v<long, decltype(fnNothrow), int>);
+  static_assert(fn::is_nothrow_applicable_r_v<long, decltype(fnNothrow), int>);
 
   // The pack and sum dispatch paths have no std counterpart to fall back on, which is why the traits
-  // exist at all: they answer by asking the invoke chain itself - a pack for the call over its
+  // exist at all: they answer by asking the apply chain itself - a pack for the call over its
   // elements, a sum for the call over every alternative.
-  static_assert(fn::is_nothrow_invocable_v<decltype(fnNothrow), fn::pack<int>>);
-  static_assert(fn::is_nothrow_invocable_v<decltype(fnNothrow), fn::sum<int>>);
-  static_assert(not fn::is_nothrow_invocable_v<decltype(fnThrows), fn::pack<int>>);
-  static_assert(not fn::is_nothrow_invocable_v<decltype(fnThrows), fn::sum<int>>);
+  static_assert(fn::is_nothrow_applicable_v<decltype(fnNothrow), fn::pack<int>>);
+  static_assert(fn::is_nothrow_applicable_v<decltype(fnNothrow), fn::sum<int>>);
+  static_assert(not fn::is_nothrow_applicable_v<decltype(fnThrows), fn::pack<int>>);
+  static_assert(not fn::is_nothrow_applicable_v<decltype(fnThrows), fn::sum<int>>);
 
-  // so fn::invoke propagates what the callable promises
-  static_assert(fn::is_invocable_v<decltype(fnNothrow), int>);
-  static_assert(noexcept(fn::invoke(fnNothrow, 1)));
-  static_assert(noexcept(fn::invoke_r<long>(fnNothrow, 1)));
-  static_assert(not noexcept(fn::invoke(fnThrows, 1)));
-  static_assert(not noexcept(fn::invoke_r<long>(fnThrows, 1)));
+  // so fn::apply propagates what the callable promises
+  static_assert(fn::is_applicable_v<decltype(fnNothrow), int>);
+  static_assert(noexcept(fn::apply(fnNothrow, 1)));
+  static_assert(noexcept(fn::apply_r<long>(fnNothrow, 1)));
+  static_assert(not noexcept(fn::apply(fnThrows, 1)));
+  static_assert(not noexcept(fn::apply_r<long>(fnThrows, 1)));
 
-  CHECK(fn::invoke(fnNothrow, 1) == 1);
-  CHECK(fn::invoke_r<long>(fnNothrow, 1) == 1L);
+  CHECK(fn::apply(fnNothrow, 1) == 1);
+  CHECK(fn::apply_r<long>(fnNothrow, 1) == 1L);
 }

--- a/tests/fn/inspect.cpp
+++ b/tests/fn/inspect.cpp
@@ -445,7 +445,7 @@ TEST_CASE("inspect noexcept", "[inspect][noexcept]")
 
   // inspect has no monadic member to delegate to - its apply IS the implementation, invoking the
   // callback itself (inspect.hpp:61-69). So there was never a spec for it to propagate: it computes
-  // one, from the callback it is about to invoke.
+  // one, from the callback it is about to apply.
   //
   // One test case for every monad, not one each: nothing here differs between them, because no
   // member is consulted.
@@ -485,31 +485,31 @@ constexpr auto fn_int_rvalue = [](int &&) {};
 constexpr auto fn_int_const_rvalue = [](int const &&) {};
 } // namespace
 
-static_assert(invocable_inspect<decltype(fn_int<void>), expected<int, Error>>);
-static_assert(not invocable_inspect<decltype(fn_int<int>), expected<int, Error>>); // wrong return type
-static_assert(invocable_inspect<decltype(fn_generic<void>), expected<void, Error>>);
-static_assert(not invocable_inspect<decltype(fn_generic<int>), expected<void, Error>>); // wrong return type
-static_assert(invocable_inspect<decltype(fn_generic<void>), expected<Value, Error>>);
-static_assert(not invocable_inspect<decltype(fn_int<void>), expected<Value, Error>>); // wrong parameter type
-static_assert(invocable_inspect<decltype(fn_int<void>), expected<unsigned, Xerror>>); // parameter type conversion
-static_assert(not invocable_inspect<decltype(fn_int<void>), expected<Value, Error>>); // wrong parameter type
-static_assert(invocable_inspect<decltype(fn_generic<void>), optional<int>>);
-static_assert(not invocable_inspect<decltype(fn_generic<int>), optional<Value>>); // wrong return type
+static_assert(applicable_inspect<decltype(fn_int<void>), expected<int, Error>>);
+static_assert(not applicable_inspect<decltype(fn_int<int>), expected<int, Error>>); // wrong return type
+static_assert(applicable_inspect<decltype(fn_generic<void>), expected<void, Error>>);
+static_assert(not applicable_inspect<decltype(fn_generic<int>), expected<void, Error>>); // wrong return type
+static_assert(applicable_inspect<decltype(fn_generic<void>), expected<Value, Error>>);
+static_assert(not applicable_inspect<decltype(fn_int<void>), expected<Value, Error>>); // wrong parameter type
+static_assert(applicable_inspect<decltype(fn_int<void>), expected<unsigned, Xerror>>); // parameter type conversion
+static_assert(not applicable_inspect<decltype(fn_int<void>), expected<Value, Error>>); // wrong parameter type
+static_assert(applicable_inspect<decltype(fn_generic<void>), optional<int>>);
+static_assert(not applicable_inspect<decltype(fn_generic<int>), optional<Value>>); // wrong return type
 
 // binding to const lvalue-ref
-static_assert(invocable_inspect<decltype(fn_int_const_lvalue), expected<int, Error>>);
-static_assert(invocable_inspect<decltype(fn_int_const_lvalue), expected<int, Error> const>);
-static_assert(invocable_inspect<decltype(fn_int_const_lvalue), expected<int, Error> &>);
-static_assert(invocable_inspect<decltype(fn_int_const_lvalue), expected<int, Error> const &>);
-static_assert(invocable_inspect<decltype(fn_int_const_lvalue), expected<int, Error> &&>);
-static_assert(invocable_inspect<decltype(fn_int_const_lvalue), expected<int, Error> const &&>);
+static_assert(applicable_inspect<decltype(fn_int_const_lvalue), expected<int, Error>>);
+static_assert(applicable_inspect<decltype(fn_int_const_lvalue), expected<int, Error> const>);
+static_assert(applicable_inspect<decltype(fn_int_const_lvalue), expected<int, Error> &>);
+static_assert(applicable_inspect<decltype(fn_int_const_lvalue), expected<int, Error> const &>);
+static_assert(applicable_inspect<decltype(fn_int_const_lvalue), expected<int, Error> &&>);
+static_assert(applicable_inspect<decltype(fn_int_const_lvalue), expected<int, Error> const &&>);
 
 // cannot bind const to non-const lvalue-ref
-static_assert(not invocable_inspect<decltype(fn_int_lvalue), expected<int, Error>>);
+static_assert(not applicable_inspect<decltype(fn_int_lvalue), expected<int, Error>>);
 
 // cannot bind lvalue to const rvalue-ref
-static_assert(not invocable_inspect<decltype(fn_int_const_rvalue), expected<int, Error>>);
+static_assert(not applicable_inspect<decltype(fn_int_const_rvalue), expected<int, Error>>);
 
 // cannot bind lvalue to rvalue-ref
-static_assert(not invocable_inspect<decltype(fn_int_rvalue), expected<int, Error>>);
+static_assert(not applicable_inspect<decltype(fn_int_rvalue), expected<int, Error>>);
 } // namespace fn

--- a/tests/fn/inspect_error.cpp
+++ b/tests/fn/inspect_error.cpp
@@ -257,31 +257,31 @@ constexpr auto fn_int_rvalue = [](int &&) {};
 constexpr auto fn_int_const_rvalue = [](int const &&) {};
 } // namespace
 
-static_assert(invocable_inspect_error<decltype(fn_Error<void>), expected<int, Error>>);
-static_assert(invocable_inspect_error<decltype(fn_generic<void>), expected<void, Error>>);
-static_assert(invocable_inspect_error<decltype(fn_int<void>), expected<void, int>>);
-static_assert(not invocable_inspect_error<decltype(fn_int<int>), expected<void, int>>);    // wrong return type
-static_assert(not invocable_inspect_error<decltype(fn_int<void>), expected<void, Error>>); // wrong parameter type
-static_assert(invocable_inspect_error<decltype(fn_Error<void>), expected<void, Xerror>>);  // parameter type conversion
-static_assert(invocable_inspect_error<decltype(fn_generic<void>), expected<Value, Error>>);
-static_assert(not invocable_inspect_error<decltype(fn_int<void>), expected<Value, Error>>); // wrong parameter type
-static_assert(invocable_inspect_error<decltype(fn_generic<void>), optional<int>>);
-static_assert(not invocable_inspect_error<decltype(fn_generic<int>), optional<Value>>); // wrong return type
+static_assert(applicable_inspect_error<decltype(fn_Error<void>), expected<int, Error>>);
+static_assert(applicable_inspect_error<decltype(fn_generic<void>), expected<void, Error>>);
+static_assert(applicable_inspect_error<decltype(fn_int<void>), expected<void, int>>);
+static_assert(not applicable_inspect_error<decltype(fn_int<int>), expected<void, int>>);    // wrong return type
+static_assert(not applicable_inspect_error<decltype(fn_int<void>), expected<void, Error>>); // wrong parameter type
+static_assert(applicable_inspect_error<decltype(fn_Error<void>), expected<void, Xerror>>);  // parameter type conversion
+static_assert(applicable_inspect_error<decltype(fn_generic<void>), expected<Value, Error>>);
+static_assert(not applicable_inspect_error<decltype(fn_int<void>), expected<Value, Error>>); // wrong parameter type
+static_assert(applicable_inspect_error<decltype(fn_generic<void>), optional<int>>);
+static_assert(not applicable_inspect_error<decltype(fn_generic<int>), optional<Value>>); // wrong return type
 
 // binding to const lvalue-ref
-static_assert(invocable_inspect_error<decltype(fn_int_const_lvalue), expected<void, int>>);
-static_assert(invocable_inspect_error<decltype(fn_int_const_lvalue), expected<void, int> const>);
-static_assert(invocable_inspect_error<decltype(fn_int_const_lvalue), expected<void, int> &>);
-static_assert(invocable_inspect_error<decltype(fn_int_const_lvalue), expected<void, int> const &>);
-static_assert(invocable_inspect_error<decltype(fn_int_const_lvalue), expected<void, int> &&>);
-static_assert(invocable_inspect_error<decltype(fn_int_const_lvalue), expected<void, int> const &&>);
+static_assert(applicable_inspect_error<decltype(fn_int_const_lvalue), expected<void, int>>);
+static_assert(applicable_inspect_error<decltype(fn_int_const_lvalue), expected<void, int> const>);
+static_assert(applicable_inspect_error<decltype(fn_int_const_lvalue), expected<void, int> &>);
+static_assert(applicable_inspect_error<decltype(fn_int_const_lvalue), expected<void, int> const &>);
+static_assert(applicable_inspect_error<decltype(fn_int_const_lvalue), expected<void, int> &&>);
+static_assert(applicable_inspect_error<decltype(fn_int_const_lvalue), expected<void, int> const &&>);
 
 // cannot bind const to non-const lvalue-ref
-static_assert(not invocable_inspect_error<decltype(fn_int_lvalue), expected<void, int>>);
+static_assert(not applicable_inspect_error<decltype(fn_int_lvalue), expected<void, int>>);
 
 // cannot bind lvalue to const rvalue-ref
-static_assert(not invocable_inspect_error<decltype(fn_int_const_rvalue), expected<void, int>>);
+static_assert(not applicable_inspect_error<decltype(fn_int_const_rvalue), expected<void, int>>);
 
 // cannot bind lvalue to rvalue-ref
-static_assert(not invocable_inspect_error<decltype(fn_int_rvalue), expected<void, int>>);
+static_assert(not applicable_inspect_error<decltype(fn_int_rvalue), expected<void, int>>);
 } // namespace fn

--- a/tests/fn/optional.cpp
+++ b/tests/fn/optional.cpp
@@ -168,7 +168,7 @@ TEST_CASE("optional graded monad", "[optional][sum][graded][or_else][sum_value]"
     constexpr auto fn8 = []() -> fn::optional<fn::sum_for<Xint, int, long>> { throw 0; };
     static_assert(std::is_same_v<decltype(s.or_else(fn8)), fn::optional<fn::sum_for<Xint, int, long>>>);
 
-    // noexcept (extension): true only when the callback is nothrow-invocable, returns exactly
+    // noexcept (extension): true only when the callback is nothrow-applicable, returns exactly
     // optional<sum<int>> (no widening), and *this is nothrow-constructible from itself.
     constexpr auto nothrow_same = []() noexcept -> fn::optional<fn::sum<int>> { return {std::nullopt}; };
     static_assert(noexcept(s.or_else(nothrow_same)));
@@ -177,7 +177,7 @@ TEST_CASE("optional graded monad", "[optional][sum][graded][or_else][sum_value]"
     constexpr auto nothrow_widen = []() noexcept -> fn::optional<Xint> { return {std::nullopt}; };
     static_assert(noexcept(s.or_else(nothrow_widen))); // nothrow but widens to sum_for<Xint, int>);
 
-    // constraints (extension): a non-invocable argument drops or_else from the overload set via
+    // constraints (extension): a non-applicable argument drops or_else from the overload set via
     // SFINAE (the return-type-is-optional requirement is instead a Mandates static_assert inside).
     constexpr auto can_or_else
         = [](auto &&f) { return requires { std::declval<fn::optional<fn::sum<int>>>().or_else(f); }; };
@@ -242,7 +242,7 @@ TEST_CASE("optional pack support", "[optional][pack][and_then][transform][operat
   {
     using P = fn::optional<fn::pack<int, std::string_view>>;
 
-    // noexcept (extension): the spec asks fn's own nothrow-invocable trait, which asks the
+    // noexcept (extension): the spec asks fn's own nothrow-applicable trait, which asks the
     // dispatch that will actually run - one argument per element - so a multi-argument visitor is
     // weighed as it is called, not as std would call it on the pack itself.
     constexpr auto nothrow_two = [](int &, std::string_view &) noexcept -> fn::optional<bool> { return {true}; };
@@ -319,7 +319,7 @@ TEST_CASE("optional pack support", "[optional][pack][and_then][transform][operat
     SECTION("noexcept")
     {
       // a pack's callback is invoked through fn's own dispatch, taking one argument per element: it
-      // is not directly invocable on the pack, so only fn's nothrow-invocable trait can answer
+      // is not directly applicable on the pack, so only fn's nothrow-applicable trait can answer
       using T = fn::optional<fn::pack<int, double>>;
       static_assert(
           noexcept(std::declval<T &>().and_then([](int, double) noexcept -> fn::optional<bool> { return {true}; })));
@@ -695,7 +695,7 @@ TEST_CASE("optional and_then sum", "[optional][sum][and_then]")
 {
   using S = fn::optional<fn::sum_for<Xint, int>>;
 
-  // noexcept (extension): the spec asks fn's own nothrow-invocable trait, which asks the
+  // noexcept (extension): the spec asks fn's own nothrow-applicable trait, which asks the
   // per-alternative dispatch that will actually run - so a visitor set is weighed alternative by
   // alternative, and one throwing handler makes the whole dispatch throwing.
   constexpr auto nothrow_lval = fn::overload{[](int &) noexcept -> fn::optional<bool> { return {true}; },
@@ -705,7 +705,7 @@ TEST_CASE("optional and_then sum", "[optional][sum][and_then]")
   static_assert(noexcept(std::declval<S &>().and_then(nothrow_generic)));
 
   // constraints (extension): exhaustive invocability over the sum's alternatives is a
-  // constraint (optional.hpp:147) -- a partial or non-invocable visitor SFINAE-drops, and the
+  // constraint (optional.hpp:147) -- a partial or non-applicable visitor SFINAE-drops, and the
   // alternatives' value category is tracked
   constexpr auto can_and_then_lval = [](auto &&f) { return requires { std::declval<S &>().and_then(f); }; };
   constexpr auto can_and_then_rval = [](auto &&f) { return requires { std::declval<S &&>().and_then(f); }; };
@@ -813,7 +813,7 @@ TEST_CASE("optional and_then sum", "[optional][sum][and_then]")
 
   SECTION("noexcept")
   {
-    // the callback is invoked through fn's own dispatch, so only fn's nothrow-invocable trait can
+    // the callback is invoked through fn's own dispatch, so only fn's nothrow-applicable trait can
     // answer for it - and it is nothrow only if EVERY alternative's call is
     using T = fn::optional<fn::sum<double, int>>;
     static_assert(noexcept(std::declval<T &>().and_then([](auto) noexcept -> fn::optional<bool> { return {true}; })));

--- a/tests/fn/or_else.cpp
+++ b/tests/fn/or_else.cpp
@@ -51,14 +51,14 @@ TEST_CASE("or_else", "[or_else][expected][expected_value]")
 
   static_assert(is::invocable_with_any(fnError));
   static_assert(is::invocable_with_any(fnXerror));
-  static_assert(is::invocable_with_any([](auto...) -> operand_t { throw 0; }));                // allow generic call
-  static_assert(is::invocable_with_any([](Error) -> operand_t { throw 0; }));                  // allow copy
-  static_assert(is::invocable_with_any([](std::string_view) -> operand_t { throw 0; }));       // allow conversion
-  static_assert(is::invocable_with_any([](Error const &) -> operand_t { throw 0; }));          // binds to const ref
-  static_assert(is::invocable<lvalue>([](Error &) -> operand_t { throw 0; }));                 // binds to lvalue
-  static_assert(is::invocable<rvalue, prvalue>([](Error &&) -> operand_t { throw 0; }));       // can move
-  static_assert(is::invocable<rvalue, crvalue>([](Error const &&) -> operand_t { throw 0; })); // binds to const rvalue
-  static_assert(is::not_invocable_with_any([](Error) -> operand_other_t { throw 0; }));        // disallow conversion
+  static_assert(is::invocable_with_any([](auto...) -> operand_t { throw 0; }));                 // allow generic call
+  static_assert(is::invocable_with_any([](Error) -> operand_t { throw 0; }));                   // allow copy
+  static_assert(is::invocable_with_any([](std::string_view) -> operand_t { throw 0; }));        // allow conversion
+  static_assert(is::invocable_with_any([](Error const &) -> operand_t { throw 0; }));           // binds to const ref
+  static_assert(is::applicable<lvalue>([](Error &) -> operand_t { throw 0; }));                 // binds to lvalue
+  static_assert(is::applicable<rvalue, prvalue>([](Error &&) -> operand_t { throw 0; }));       // can move
+  static_assert(is::applicable<rvalue, crvalue>([](Error const &&) -> operand_t { throw 0; })); // binds to const rvalue
+  static_assert(is::not_invocable_with_any([](Error) -> operand_other_t { throw 0; }));         // disallow conversion
   static_assert(
       is::not_invocable<clvalue, crvalue, cvalue>([](Error &) -> operand_t { throw 0; })); // cannot remove const
   static_assert(is::not_invocable<rvalue>([](Error &) -> operand_t { throw 0; }));         // disallow bind
@@ -312,14 +312,14 @@ TEST_CASE("or_else", "[or_else][expected][expected_void]")
 
   static_assert(is::invocable_with_any(fnError));
   static_assert(is::invocable_with_any(fnXerror));
-  static_assert(is::invocable_with_any([](auto...) -> operand_t { throw 0; }));                // allow generic call
-  static_assert(is::invocable_with_any([](Error) -> operand_t { throw 0; }));                  // allow copy
-  static_assert(is::invocable_with_any([](std::string_view) -> operand_t { throw 0; }));       // allow conversion
-  static_assert(is::invocable_with_any([](Error const &) -> operand_t { throw 0; }));          // binds to const ref
-  static_assert(is::invocable<lvalue>([](Error &) -> operand_t { throw 0; }));                 // binds to lvalue
-  static_assert(is::invocable<rvalue, prvalue>([](Error &&) -> operand_t { throw 0; }));       // can move
-  static_assert(is::invocable<rvalue, crvalue>([](Error const &&) -> operand_t { throw 0; })); // binds to const rvalue
-  static_assert(is::not_invocable_with_any([](Error) -> operand_other_t { throw 0; }));        // disallow conversion
+  static_assert(is::invocable_with_any([](auto...) -> operand_t { throw 0; }));                 // allow generic call
+  static_assert(is::invocable_with_any([](Error) -> operand_t { throw 0; }));                   // allow copy
+  static_assert(is::invocable_with_any([](std::string_view) -> operand_t { throw 0; }));        // allow conversion
+  static_assert(is::invocable_with_any([](Error const &) -> operand_t { throw 0; }));           // binds to const ref
+  static_assert(is::applicable<lvalue>([](Error &) -> operand_t { throw 0; }));                 // binds to lvalue
+  static_assert(is::applicable<rvalue, prvalue>([](Error &&) -> operand_t { throw 0; }));       // can move
+  static_assert(is::applicable<rvalue, crvalue>([](Error const &&) -> operand_t { throw 0; })); // binds to const rvalue
+  static_assert(is::not_invocable_with_any([](Error) -> operand_other_t { throw 0; }));         // disallow conversion
   static_assert(
       is::not_invocable<clvalue, crvalue, cvalue>([](Error &) -> operand_t { throw 0; })); // cannot remove const
   static_assert(is::not_invocable<rvalue>([](Error &) -> operand_t { throw 0; }));         // disallow bind
@@ -555,26 +555,26 @@ template <typename T> constexpr auto fn_int_rvalue = [](int &&) -> T { throw 0; 
 } // namespace
 
 // clang-format off
-static_assert(invocable_or_else<decltype(fn_Error<expected<Value, Error>>), expected<Value, Error>>);
-static_assert(invocable_or_else<decltype(fn_generic<expected<int, int>>), expected<int, int>>);
-static_assert(invocable_or_else<decltype(fn_Error<expected<Value, Xerror>>), expected<Value, Error>>);   // error type conversion
-static_assert(invocable_or_else<decltype(fn_Error<expected<Value, Error>>), expected<Value, Xerror>>);   // error type conversion
-static_assert(invocable_or_else<decltype(fn_Error<expected<Value, int>>), expected<Value, Xerror>>);     // error type conversion
-static_assert(not invocable_or_else<decltype(fn_Error<expected<Value, int>>), expected<Value, int>>);    // wrong error_type
-static_assert(invocable_or_else<decltype(fn_Error<expected<Value, Error>>), expected<Value, Error>>);
-static_assert(not invocable_or_else<decltype(fn_Error<expected<Value, Error>>), expected<void, Error>>); // cannot change value_type
-static_assert(not invocable_or_else<decltype(fn_Error<expected<void, Error>>), expected<Value, Error>>); // cannot change value_type
-static_assert(not invocable_or_else<decltype(fn_generic<expected<Value, int>>), expected<int, int>>);    // cannot change value_type
+static_assert(applicable_or_else<decltype(fn_Error<expected<Value, Error>>), expected<Value, Error>>);
+static_assert(applicable_or_else<decltype(fn_generic<expected<int, int>>), expected<int, int>>);
+static_assert(applicable_or_else<decltype(fn_Error<expected<Value, Xerror>>), expected<Value, Error>>);   // error type conversion
+static_assert(applicable_or_else<decltype(fn_Error<expected<Value, Error>>), expected<Value, Xerror>>);   // error type conversion
+static_assert(applicable_or_else<decltype(fn_Error<expected<Value, int>>), expected<Value, Xerror>>);     // error type conversion
+static_assert(not applicable_or_else<decltype(fn_Error<expected<Value, int>>), expected<Value, int>>);    // wrong error_type
+static_assert(applicable_or_else<decltype(fn_Error<expected<Value, Error>>), expected<Value, Error>>);
+static_assert(not applicable_or_else<decltype(fn_Error<expected<Value, Error>>), expected<void, Error>>); // cannot change value_type
+static_assert(not applicable_or_else<decltype(fn_Error<expected<void, Error>>), expected<Value, Error>>); // cannot change value_type
+static_assert(not applicable_or_else<decltype(fn_generic<expected<Value, int>>), expected<int, int>>);    // cannot change value_type
 
-static_assert(not invocable_or_else<decltype(fn_generic<expected<Value, Error>>), optional<Value>>);     // mixed optional and expected
-static_assert(not invocable_or_else<decltype(fn_generic<optional<Value>>), expected<Value, Error>>);     // mixed optional and expected
-static_assert(invocable_or_else<decltype(fn_generic<optional<Value>>), optional<Value>>);
-static_assert(not invocable_or_else<decltype(fn_generic<optional<int>>), optional<Value>>);              // cannot change value_type
-static_assert(not invocable_or_else<decltype(fn_generic<optional<Value>>), optional<int>>);              // cannot change value_type
+static_assert(not applicable_or_else<decltype(fn_generic<expected<Value, Error>>), optional<Value>>);     // mixed optional and expected
+static_assert(not applicable_or_else<decltype(fn_generic<optional<Value>>), expected<Value, Error>>);     // mixed optional and expected
+static_assert(applicable_or_else<decltype(fn_generic<optional<Value>>), optional<Value>>);
+static_assert(not applicable_or_else<decltype(fn_generic<optional<int>>), optional<Value>>);              // cannot change value_type
+static_assert(not applicable_or_else<decltype(fn_generic<optional<Value>>), optional<int>>);              // cannot change value_type
 
-static_assert(not invocable_or_else<decltype(fn_int_lvalue<expected<int, int>>), expected<int, int>>);   // cannot bind temporary to lvalue
-static_assert(invocable_or_else<decltype(fn_int_lvalue<expected<int, int>>), expected<int, int> &>);
-static_assert(invocable_or_else<decltype(fn_int_rvalue<expected<int, int>>), expected<int, int>>);
-static_assert(not invocable_or_else<decltype(fn_int_rvalue<expected<int, int>>), expected<int, int> &>); // cannot bind lvalue to rvalue-ref
+static_assert(not applicable_or_else<decltype(fn_int_lvalue<expected<int, int>>), expected<int, int>>);   // cannot bind temporary to lvalue
+static_assert(applicable_or_else<decltype(fn_int_lvalue<expected<int, int>>), expected<int, int> &>);
+static_assert(applicable_or_else<decltype(fn_int_rvalue<expected<int, int>>), expected<int, int>>);
+static_assert(not applicable_or_else<decltype(fn_int_rvalue<expected<int, int>>), expected<int, int> &>); // cannot bind lvalue to rvalue-ref
 // clang-format on
 } // namespace fn

--- a/tests/fn/pack.cpp
+++ b/tests/fn/pack.cpp
@@ -25,14 +25,14 @@ struct A final {
 };
 
 template <typename V, typename Fn>
-concept pack_check = requires(V v, Fn fn) { FWD(v).invoke(FWD(fn), A{}); };
+concept pack_check = requires(V v, Fn fn) { FWD(v).apply(FWD(fn), A{}); };
 
 template <fn::pack<int, double> P> struct pack_nttp final {};
 template <fn::some_pack auto P> struct some_pack_nttp final {};
 template <fn::some_pack auto P> auto read_nttp() { return fn::get<0>(P); }
 
 template <typename V, typename R, typename Fn>
-concept can_invoke_r = requires(V v, Fn fn) { FWD(v).template invoke_r<R>(FWD(fn)); };
+concept can_invoke_r = requires(V v, Fn fn) { FWD(v).template apply_r<R>(FWD(fn)); };
 
 template <typename V, typename T, typename... Args>
 concept can_append_in_place = requires(V v, Args... args) { FWD(v).append(std::in_place_type<T>, args...); };
@@ -164,45 +164,45 @@ TEST_CASE("pack", "[pack]")
   static_assert(not pack_check<T, decltype(([](auto, auto, auto, auto, auto, auto) {}))>); // bad arity
 
   constexpr auto fn = [](auto... args) noexcept -> int { return (0 + ... + args); };
-  CHECK(v.invoke(fn) == 3 + 14 + 15 + 92);
-  CHECK(fn::invoke(fn, FWD(v)) == 3 + 14 + 15 + 92);
-  CHECK(v.invoke(fn, 65, 35) == 3 + 14 + 15 + 92 + 65 + 35);
-  CHECK(fn::invoke(fn, FWD(v), 65, 35) == 3 + 14 + 15 + 92 + 65 + 35);
-  static_assert(fn::invoke(fn, fn::pack{3, 14}, 15, 92) == 3 + 14 + 15 + 92);
+  CHECK(v.apply(fn) == 3 + 14 + 15 + 92);
+  CHECK(fn::apply(fn, FWD(v)) == 3 + 14 + 15 + 92);
+  CHECK(v.apply(fn, 65, 35) == 3 + 14 + 15 + 92 + 65 + 35);
+  CHECK(fn::apply(fn, FWD(v), 65, 35) == 3 + 14 + 15 + 92 + 65 + 35);
+  static_assert(fn::apply(fn, fn::pack{3, 14}, 15, 92) == 3 + 14 + 15 + 92);
 
   constexpr auto fn0 = [](int i, int j, int k, int l, A) noexcept -> int { return (i + j + k + l); };
-  CHECK(v.invoke(fn0, A{}) == 3 + 14 + 15 + 92);
-  CHECK(fn::invoke(fn0, FWD(v), A{}) == 3 + 14 + 15 + 92);
-  static_assert(fn::invoke(fn0, fn::pack{3, 14, 15, 92}, A{}) == 3 + 14 + 15 + 92);
+  CHECK(v.apply(fn0, A{}) == 3 + 14 + 15 + 92);
+  CHECK(fn::apply(fn0, FWD(v), A{}) == 3 + 14 + 15 + 92);
+  static_assert(fn::apply(fn0, fn::pack{3, 14, 15, 92}, A{}) == 3 + 14 + 15 + 92);
 
   A a;
   constexpr auto fn1 = [](int i, int j, int k, int l, A &dest) noexcept -> A & {
     dest.v = (i + j + k + l);
     return dest;
   };
-  CHECK(v.invoke(fn1, a).v == 3 + 14 + 15 + 92);
-  CHECK(v.invoke_r<A>(fn1, a).v == 3 + 14 + 15 + 92);
-  CHECK(v.invoke_r<long>([](auto... args) noexcept -> int { return (0 + ... + args); }, 65, 35)
+  CHECK(v.apply(fn1, a).v == 3 + 14 + 15 + 92);
+  CHECK(v.apply_r<A>(fn1, a).v == 3 + 14 + 15 + 92);
+  CHECK(v.apply_r<long>([](auto... args) noexcept -> int { return (0 + ... + args); }, 65, 35)
         == 3 + 14 + 15 + 92 + 65 + 35);
-  CHECK(fn::invoke_r<long>([](auto... args) noexcept -> int { return (0 + ... + args); }, FWD(v), 65, 35)
+  CHECK(fn::apply_r<long>([](auto... args) noexcept -> int { return (0 + ... + args); }, FWD(v), 65, 35)
         == 3 + 14 + 15 + 92 + 65 + 35);
   static_assert(
-      fn::invoke_r<long>([](auto... args) noexcept -> int { return (0 + ... + args); }, fn::pack{3, 14}, 15, 92)
+      fn::apply_r<long>([](auto... args) noexcept -> int { return (0 + ... + args); }, fn::pack{3, 14}, 15, 92)
       == 3 + 14 + 15 + 92);
-  CHECK(v.invoke_r<long>(fn0, A{}) == 3 + 14 + 15 + 92);
-  CHECK(fn::invoke_r<long>(fn0, FWD(v), A{}) == 3 + 14 + 15 + 92);
-  static_assert(fn::invoke_r<long>(fn0, fn::pack{3, 14, 15, 92}, A{}) == 3 + 14 + 15 + 92);
+  CHECK(v.apply_r<long>(fn0, A{}) == 3 + 14 + 15 + 92);
+  CHECK(fn::apply_r<long>(fn0, FWD(v), A{}) == 3 + 14 + 15 + 92);
+  static_assert(fn::apply_r<long>(fn0, fn::pack{3, 14, 15, 92}, A{}) == 3 + 14 + 15 + 92);
 
-  static_assert(std::is_same_v<decltype(v.invoke(fn1, a)), A &>);
-  static_assert(std::is_same_v<decltype(v.invoke_r<A>(fn1, a)), A>);
+  static_assert(std::is_same_v<decltype(v.apply(fn1, a)), A &>);
+  static_assert(std::is_same_v<decltype(v.apply_r<A>(fn1, a)), A>);
 
   constexpr auto fn2 = [](int, int, int, int, A &&dest) noexcept -> A && { return std::move(dest); };
-  static_assert(std::is_same_v<decltype(v.invoke(fn2, std::move(a))), A &&>);
-  static_assert(std::is_same_v<decltype(v.invoke_r<A>(fn2, std::move(a))), A>);
+  static_assert(std::is_same_v<decltype(v.apply(fn2, std::move(a))), A &&>);
+  static_assert(std::is_same_v<decltype(v.apply_r<A>(fn2, std::move(a))), A>);
 
   constexpr auto fn3 = [](int, int, int, int, A &&dest) noexcept -> A { return dest; };
-  static_assert(std::is_same_v<decltype(v.invoke(fn3, std::move(a))), A>);
-  static_assert(std::is_same_v<decltype(v.invoke_r<A>(fn3, std::move(a))), A>);
+  static_assert(std::is_same_v<decltype(v.apply(fn3, std::move(a))), A>);
+  static_assert(std::is_same_v<decltype(v.apply_r<A>(fn3, std::move(a))), A>);
 
   static_assert(pack<>::size == 0);
 
@@ -217,7 +217,7 @@ TEST_CASE("pack", "[pack]")
   static_assert(std::same_as<decltype(c1), fn::pack<> const>);
   constexpr auto c2 = fn::as_pack(true, 12);
   static_assert(std::same_as<decltype(c2), fn::pack<bool, int> const>);
-  static_assert(c2.invoke([](auto i, auto j) {
+  static_assert(c2.apply([](auto i, auto j) {
     if constexpr (std::is_same_v<decltype(i), bool> && std::is_same_v<decltype(j), int>)
       return i && j == 12;
     else
@@ -235,7 +235,7 @@ TEST_CASE("pack", "[pack]")
   static_assert(not std::is_same_v<some_pack_nttp<s1>, some_pack_nttp<s3>>);
   CHECK(read_nttp<s1>() == 3); // the template-parameter object is usable at runtime
 
-  SECTION("invoke_r return conversion")
+  SECTION("apply_r return conversion")
   {
     struct NotFromInt final {
       explicit NotFromInt(std::nullptr_t) {}
@@ -249,19 +249,19 @@ TEST_CASE("pack", "[pack]")
 
   SECTION("noexcept")
   {
-    // invoke and invoke_r weigh the callback they dispatch to, in every value category
+    // apply and apply_r weigh the callback they dispatch to, in every value category
     constexpr auto throwing = [](auto &&...) noexcept(false) -> int { return 0; };
     static_assert(not noexcept(throwing()));
-    static_assert(not noexcept(v.invoke(throwing)));
-    static_assert(not noexcept(std::as_const(v).invoke(throwing)));
-    static_assert(not noexcept(std::move(v).invoke(throwing)));
-    static_assert(not noexcept(std::move(std::as_const(v)).invoke(throwing)));
-    static_assert(not noexcept(v.invoke_r<long>(throwing)));
-    static_assert(not noexcept(std::move(v).invoke_r<long>(throwing)));
+    static_assert(not noexcept(v.apply(throwing)));
+    static_assert(not noexcept(std::as_const(v).apply(throwing)));
+    static_assert(not noexcept(std::move(v).apply(throwing)));
+    static_assert(not noexcept(std::move(std::as_const(v)).apply(throwing)));
+    static_assert(not noexcept(v.apply_r<long>(throwing)));
+    static_assert(not noexcept(std::move(v).apply_r<long>(throwing)));
 
     constexpr auto nothrow = [](auto &&...) noexcept -> int { return 0; };
-    static_assert(noexcept(v.invoke(nothrow)));
-    static_assert(noexcept(v.invoke_r<long>(nothrow)));
+    static_assert(noexcept(v.apply(nothrow)));
+    static_assert(noexcept(v.apply_r<long>(nothrow)));
 
     // an empty pack wraps nothing, so there is nothing that could throw (SECTION("as_pack") weighs
     // the arguments a non-empty one relocates)
@@ -272,7 +272,7 @@ TEST_CASE("pack", "[pack]")
   SECTION("constexpr")
   {
     constexpr fn::pack<int, int> v2{3, 14};
-    constexpr auto r2 = v2.invoke([](auto &&...args) constexpr noexcept -> int { return (0 + ... + args); });
+    constexpr auto r2 = v2.apply([](auto &&...args) constexpr noexcept -> int { return (0 + ... + args); });
     static_assert(r2 == 3 + 14);
     SUCCEED();
   }
@@ -317,34 +317,34 @@ TEST_CASE("append value categories", "[pack][append]")
 
     SECTION("constructor takes parameters")
     {
-      CHECK(s.append(std::in_place_type<B>, 5, 6).invoke(check));
-      CHECK(std::as_const(s).append(std::in_place_type<B>, 5, 6).invoke(check));
-      CHECK(std::move(std::as_const(s)).append(std::in_place_type<B>, 5, 6).invoke(check));
-      CHECK(std::move(s).append(std::in_place_type<B>, 5, 6).invoke(check));
+      CHECK(s.append(std::in_place_type<B>, 5, 6).apply(check));
+      CHECK(std::as_const(s).append(std::in_place_type<B>, 5, 6).apply(check));
+      CHECK(std::move(std::as_const(s)).append(std::in_place_type<B>, 5, 6).apply(check));
+      CHECK(std::move(s).append(std::in_place_type<B>, 5, 6).apply(check));
     }
 
-    SECTION("constructor takes parameters invoke_r")
+    SECTION("constructor takes parameters apply_r")
     {
-      CHECK(s.append(std::in_place_type<B>, 5, 6).invoke_r<bool>(check));
-      CHECK(std::as_const(s).append(std::in_place_type<B>, 5, 6).invoke_r<bool>(check));
-      CHECK(std::move(std::as_const(s)).append(std::in_place_type<B>, 5, 6).invoke_r<bool>(check));
-      CHECK(std::move(s).append(std::in_place_type<B>, 5, 6).invoke_r<bool>(check));
+      CHECK(s.append(std::in_place_type<B>, 5, 6).apply_r<bool>(check));
+      CHECK(std::as_const(s).append(std::in_place_type<B>, 5, 6).apply_r<bool>(check));
+      CHECK(std::move(std::as_const(s)).append(std::in_place_type<B>, 5, 6).apply_r<bool>(check));
+      CHECK(std::move(s).append(std::in_place_type<B>, 5, 6).apply_r<bool>(check));
     }
 
     SECTION("default constructor")
     {
-      CHECK(s.append(std::in_place_type<C>).invoke(check));
-      CHECK(std::as_const(s).append(std::in_place_type<C>).invoke(check));
-      CHECK(std::move(std::as_const(s)).append(std::in_place_type<C>).invoke(check));
-      CHECK(std::move(s).append(std::in_place_type<C>).invoke(check));
+      CHECK(s.append(std::in_place_type<C>).apply(check));
+      CHECK(std::as_const(s).append(std::in_place_type<C>).apply(check));
+      CHECK(std::move(std::as_const(s)).append(std::in_place_type<C>).apply(check));
+      CHECK(std::move(s).append(std::in_place_type<C>).apply(check));
     }
 
-    SECTION("default constructor invoke_r")
+    SECTION("default constructor apply_r")
     {
-      CHECK(s.append(std::in_place_type<C>).invoke_r<int>(check) == 1);
-      CHECK(std::as_const(s).append(std::in_place_type<C>).invoke_r<int>(check) == 1);
-      CHECK(std::move(std::as_const(s)).append(std::in_place_type<C>).invoke_r<int>(check) == 1);
-      CHECK(std::move(s).append(std::in_place_type<C>).invoke_r<int>(check) == 1);
+      CHECK(s.append(std::in_place_type<C>).apply_r<int>(check) == 1);
+      CHECK(std::as_const(s).append(std::in_place_type<C>).apply_r<int>(check) == 1);
+      CHECK(std::move(std::as_const(s)).append(std::in_place_type<C>).apply_r<int>(check) == 1);
+      CHECK(std::move(s).append(std::in_place_type<C>).apply_r<int>(check) == 1);
     }
 
     SECTION("aggregate forwarding")
@@ -352,10 +352,10 @@ TEST_CASE("append value categories", "[pack][append]")
       // braces elide through the aggregate: three ints construct the array element in place
       auto q = s.append(std::in_place_type<std::array<int, 3>>, 5, 6, 7);
       static_assert(std::same_as<decltype(q), T::append_type<std::array<int, 3>>>);
-      CHECK(q.invoke([](int, std::string_view, A, std::array<int, 3> const &a) //
-                     { return a[0] * 100 + a[1] * 10 + a[2]; })
+      CHECK(q.apply([](int, std::string_view, A, std::array<int, 3> const &a) //
+                    { return a[0] * 100 + a[1] * 10 + a[2]; })
             == 567);
-      static_assert(fn::pack<>{}.append(std::in_place_type<std::array<int, 3>>, 5, 6, 7).invoke([](auto const &a) {
+      static_assert(fn::pack<>{}.append(std::in_place_type<std::array<int, 3>>, 5, 6, 7).apply([](auto const &a) {
         return a[0] * 100 + a[1] * 10 + a[2];
       }) == 567);
     }
@@ -373,10 +373,10 @@ TEST_CASE("append value categories", "[pack][append]")
     static_assert(std::same_as<decltype(s.append(c2)), T::append_type<C &>>);
     static_assert(std::same_as<T::append_type<C &>, pack<int, std::string_view, A, C &>>);
 
-    CHECK(s.append(B{30}).invoke(check));
-    CHECK(std::as_const(s).append(B{30}).invoke(check));
-    CHECK(std::move(std::as_const(s)).append(B{30}).invoke(check));
-    CHECK(std::move(s).append(B{30}).invoke(check));
+    CHECK(s.append(B{30}).apply(check));
+    CHECK(std::as_const(s).append(B{30}).apply(check));
+    CHECK(std::move(std::as_const(s)).append(B{30}).apply(check));
+    CHECK(std::move(s).append(B{30}).apply(check));
   }
 
   SECTION("reference element")
@@ -386,15 +386,15 @@ TEST_CASE("append value categories", "[pack][append]")
     C c{};
     auto q = s.append(std::in_place_type<B &>, c);
     static_assert(std::same_as<decltype(q), T::append_type<B &>>);
-    CHECK(q.invoke([&c](int, std::string_view, A, B &b) { return &b == static_cast<B *>(&c); }));
+    CHECK(q.apply([&c](int, std::string_view, A, B &b) { return &b == static_cast<B *>(&c); }));
 
     auto r = s.append(c); // deduced, so the element type is C &
     static_assert(std::same_as<decltype(r), T::append_type<C &>>);
-    CHECK(r.invoke([&c](int, std::string_view, A, C &x) { return &x == &c; }));
+    CHECK(r.apply([&c](int, std::string_view, A, C &x) { return &x == &c; }));
 
     c.v = 77; // the same object, observed through both packs
-    CHECK(q.invoke([](int, std::string_view, A, B &b) { return b.v == 77; }));
-    CHECK(r.invoke([](int, std::string_view, A, C &x) { return x.v == 77; }));
+    CHECK(q.apply([](int, std::string_view, A, B &b) { return b.v == 77; }));
+    CHECK(r.apply([](int, std::string_view, A, C &x) { return x.v == 77; }));
 
     SECTION("constexpr")
     {
@@ -404,7 +404,7 @@ TEST_CASE("append value categories", "[pack][append]")
         auto q = p.append(std::in_place_type<B &>, b);
         auto r = p.append(b);
         b.v = 9;
-        return q.invoke([](int, B &x) { return x.v == 9; }) && r.invoke([](int, B &x) { return x.v == 9; });
+        return q.apply([](int, B &x) { return x.v == 9; }) && r.apply([](int, B &x) { return x.v == 9; });
       }());
       SUCCEED();
     }
@@ -416,13 +416,13 @@ TEST_CASE("append value categories", "[pack][append]")
     constexpr fn::pack<C, B> b{C{}, B{3, 4}};
     constexpr auto c1 = a.append(b);
     static_assert(std::same_as<decltype(c1), fn::pack<bool, int, B, C, B> const>);
-    static_assert(c1.invoke([](bool i, int j, B const &b1, C const &c, B const &b2) {
+    static_assert(c1.apply([](bool i, int j, B const &b1, C const &c, B const &b2) {
       return i && j == 3 && b1.v == 14 && c.v == 30 && b2.v == 12;
     }));
 
     auto c2 = a.append(fn::pack{C{}, B{4, 5}});
     static_assert(std::same_as<decltype(c2), fn::pack<bool, int, B, C, B>>);
-    CHECK(c2.invoke([](bool i, int j, B const &b1, C const &c, B const &b2) {
+    CHECK(c2.apply([](bool i, int j, B const &b1, C const &c, B const &b2) {
       return i && j == 3 && b1.v == 14 && c.v == 30 && b2.v == 20;
     }));
   }
@@ -556,17 +556,17 @@ TEST_CASE("pack noexcept", "[pack][noexcept]")
     };
     static_assert(not can_as_pack<NoMove>); // constrained on the same initialization ...
     static_assert(can_as_pack<NoMove &>);   // ... which a binding reference element satisfies
-    CHECK(fn::as_pack(t, 12).invoke([&t](Throwy const &x, int i) { return &x == &t && i == 12; }));
+    CHECK(fn::as_pack(t, 12).apply([&t](Throwy const &x, int i) { return &x == &t && i == 12; }));
   }
 
-  SECTION("invoke")
+  SECTION("apply")
   {
     constexpr auto nothrow_fn = [](auto &&...) noexcept { return 0; };
     constexpr auto throwing_fn = [](auto &&...) { return 0; };
-    static_assert(noexcept(std::declval<pack<int, bool> &>().invoke(nothrow_fn)));
-    static_assert(not noexcept(std::declval<pack<int, bool> &>().invoke(throwing_fn)));
-    static_assert(noexcept(std::declval<pack<int, bool> &>().template invoke_r<int>(nothrow_fn)));
-    static_assert(not noexcept(std::declval<pack<int, bool> &>().template invoke_r<int>(throwing_fn)));
+    static_assert(noexcept(std::declval<pack<int, bool> &>().apply(nothrow_fn)));
+    static_assert(not noexcept(std::declval<pack<int, bool> &>().apply(throwing_fn)));
+    static_assert(noexcept(std::declval<pack<int, bool> &>().template apply_r<int>(nothrow_fn)));
+    static_assert(not noexcept(std::declval<pack<int, bool> &>().template apply_r<int>(throwing_fn)));
 
     // Ret is entered by INVOKE<R>'s implicit conversion; the promise asks that call rather than
     // is_nothrow_constructible_v, whose direct-initialization would reach the explicit move
@@ -574,14 +574,14 @@ TEST_CASE("pack noexcept", "[pack][noexcept]")
     pack<int> p{1};
     Evil ev{};
     auto give_evil = [&ev](int) noexcept -> Evil && { return std::move(ev); };
-    static_assert(not noexcept(std::declval<pack<int> &>().template invoke_r<Evil>(give_evil)));
-    CHECK_THROWS_AS(p.invoke_r<Evil>(give_evil), std::runtime_error);
-    // exactly std::invoke_r's own promise - conservative for a prvalue result (the deed elides,
+    static_assert(not noexcept(std::declval<pack<int> &>().template apply_r<Evil>(give_evil)));
+    CHECK_THROWS_AS(p.apply_r<Evil>(give_evil), std::runtime_error);
+    // exactly std::apply_r's own promise - conservative for a prvalue result (the deed elides,
     // and indeed nothing throws below), but never a lie
     auto make_evil = [](int) noexcept -> Evil { return {}; };
-    static_assert(noexcept(std::declval<pack<int> &>().template invoke_r<Evil>(make_evil))
+    static_assert(noexcept(std::declval<pack<int> &>().template apply_r<Evil>(make_evil))
                   == std::is_nothrow_invocable_r_v<Evil, decltype(make_evil) &, int &>);
-    CHECK_NOTHROW(p.invoke_r<Evil>(make_evil));
+    CHECK_NOTHROW(p.apply_r<Evil>(make_evil));
   }
 }
 
@@ -607,7 +607,7 @@ TEST_CASE("pack with immovable data", "[pack][immovable]")
   ImmovableType const val2{92};
   T v{ImmovableType{3}, ImmovableType{14}, val1, val2};
 
-  constexpr auto can_invoke = [](auto &&fn) constexpr { return requires { std::declval<T>().invoke(fn); }; };
+  constexpr auto can_invoke = [](auto &&fn) constexpr { return requires { std::declval<T>().apply(fn); }; };
 
   static_assert(can_invoke([](auto &&...) {})); // generic call
   static_assert(can_invoke([](ImmovableType const &, ImmovableType const &, ImmovableType const &,
@@ -616,7 +616,7 @@ TEST_CASE("pack with immovable data", "[pack][immovable]")
   }));                                                             // bind rvalues and lvalues
   static_assert(not can_invoke([](ImmovableType, auto &&...) {})); // cannot pass immovable by value
 
-  CHECK(v.invoke([](auto &&...args) noexcept -> int { return (0 + ... + args.value); }) == 3 + 14 + 15 + 92);
+  CHECK(v.apply([](auto &&...args) noexcept -> int { return (0 + ... + args.value); }) == 3 + 14 + 15 + 92);
 }
 
 namespace {
@@ -675,67 +675,67 @@ template <typename S> constexpr bool join_battery()
                   pack<Bet, Gimel, Heh>, pack<Bet, Gimel, Vav>, pack<Bet, Gimel, Zayn>>;
     auto const r = S::template join<R>(sum<pack<Alef, Gimel>, pack<Bet, Gimel>>{pack{Alef{3}, Gimel{14}}},
                                        sum<Heh, Vav, Zayn>{Vav{15}});
-    ok = ok && r.template has_value<pack<Alef, Gimel, Vav>>() && r.invoke(join_witness) == 3 + 14 + 15;
+    ok = ok && r.template has_value<pack<Alef, Gimel, Vav>>() && r.apply(join_witness) == 3 + 14 + 15;
   }
   {                                                                     // sum of packs join sum of packs
     using R = sum<pack<Alef, Gimel, Heh, Zayn>, pack<Alef, Gimel, Vav>, //
                   pack<Bet, Gimel, Heh, Zayn>, pack<Bet, Gimel, Vav>>;
     auto const r = S::template join<R>(sum<pack<Alef, Gimel>, pack<Bet, Gimel>>{pack{Alef{3}, Gimel{14}}},
                                        sum<pack<Heh, Zayn>, pack<Vav>>{pack{Vav{15}}});
-    ok = ok && r.template has_value<pack<Alef, Gimel, Vav>>() && r.invoke(join_witness) == 3 + 14 + 15;
+    ok = ok && r.template has_value<pack<Alef, Gimel, Vav>>() && r.apply(join_witness) == 3 + 14 + 15;
   }
   { // sum of scalars join sum of scalars
     using R = sum<pack<Alef, Heh>, pack<Alef, Vav>, pack<Alef, Zayn>, pack<Bet, Heh>, pack<Bet, Vav>, pack<Bet, Zayn>,
                   pack<Gimel, Heh>, pack<Gimel, Vav>, pack<Gimel, Zayn>>;
     auto const r = S::template join<R>(sum<Alef, Bet, Gimel>{Gimel{3}}, sum<Heh, Vav, Zayn>{Vav{14}});
-    ok = ok && r.template has_value<pack<Gimel, Vav>>() && r.invoke(join_witness) == 3 + 14;
+    ok = ok && r.template has_value<pack<Gimel, Vav>>() && r.apply(join_witness) == 3 + 14;
   }
   {                                                                             // sum of scalars join sum of packs
     using R = sum<pack<Alef, Heh, Zayn>, pack<Alef, Vav>, pack<Bet, Heh, Zayn>, //
                   pack<Bet, Vav>, pack<Gimel, Heh, Zayn>, pack<Gimel, Vav>>;
     auto const r = S::template join<R>(sum<Alef, Bet, Gimel>{Gimel{3}}, sum<pack<Heh, Zayn>, pack<Vav>>{pack{Vav{14}}});
-    ok = ok && r.template has_value<pack<Gimel, Vav>>() && r.invoke(join_witness) == 3 + 14;
+    ok = ok && r.template has_value<pack<Gimel, Vav>>() && r.apply(join_witness) == 3 + 14;
   }
   { // sum of packs join scalar
     using R = sum<pack<Alef, Gimel, Vav>, pack<Bet, Gimel, Vav>>;
     auto const r = S::template join<R>(sum<pack<Alef, Gimel>, pack<Bet, Gimel>>{pack{Alef{3}, Gimel{14}}}, Vav{15});
-    ok = ok && r.template has_value<pack<Alef, Gimel, Vav>>() && r.invoke(join_witness) == 3 + 14 + 15;
+    ok = ok && r.template has_value<pack<Alef, Gimel, Vav>>() && r.apply(join_witness) == 3 + 14 + 15;
   }
   { // sum of packs join pack
     using R = sum<pack<Alef, Gimel, Vav>, pack<Bet, Gimel, Vav>>;
     auto const r = S::template join<R>(sum<pack<Alef, Gimel>, pack<Bet, Gimel>>{pack{Alef{3}, Gimel{14}}},
                                        pack<Vav>{pack{Vav{15}}});
-    ok = ok && r.template has_value<pack<Alef, Gimel, Vav>>() && r.invoke(join_witness) == 3 + 14 + 15;
+    ok = ok && r.template has_value<pack<Alef, Gimel, Vav>>() && r.apply(join_witness) == 3 + 14 + 15;
   }
   { // sum of scalars join scalar
     using R = sum<pack<Alef, Vav>, pack<Bet, Vav>, pack<Gimel, Vav>>;
     auto const r = S::template join<R>(sum<Alef, Bet, Gimel>{Gimel{3}}, Vav{14});
-    ok = ok && r.template has_value<pack<Gimel, Vav>>() && r.invoke(join_witness) == 3 + 14;
+    ok = ok && r.template has_value<pack<Gimel, Vav>>() && r.apply(join_witness) == 3 + 14;
   }
   { // sum of scalars join pack
     using R = sum<pack<Alef, Vav>, pack<Bet, Vav>, pack<Gimel, Vav>>;
     auto const r = S::template join<R>(sum<Alef, Bet, Gimel>{Gimel{3}}, pack<Vav>{pack{Vav{14}}});
-    ok = ok && r.template has_value<pack<Gimel, Vav>>() && r.invoke(join_witness) == 3 + 14;
+    ok = ok && r.template has_value<pack<Gimel, Vav>>() && r.apply(join_witness) == 3 + 14;
   }
   { // pack join sum of scalars
     using R = sum<pack<Alef, Gimel, Heh>, pack<Alef, Gimel, Vav>, pack<Alef, Gimel, Zayn>>;
     auto const r = S::template join<R>(pack<Alef, Gimel>{pack{Alef{3}, Gimel{14}}}, sum<Heh, Vav, Zayn>{Vav{15}});
-    ok = ok && r.template has_value<pack<Alef, Gimel, Vav>>() && r.invoke(join_witness) == 3 + 14 + 15;
+    ok = ok && r.template has_value<pack<Alef, Gimel, Vav>>() && r.apply(join_witness) == 3 + 14 + 15;
   }
   { // pack join sum of packs
     using R = sum<pack<Alef, Gimel, Heh, Zayn>, pack<Alef, Gimel, Vav>>;
     auto const r = S::template join<R>(pack<Alef, Gimel>{pack{Alef{3}, Gimel{14}}},
                                        sum<pack<Heh, Zayn>, pack<Vav>>{pack{Vav{15}}});
-    ok = ok && r.template has_value<pack<Alef, Gimel, Vav>>() && r.invoke(join_witness) == 3 + 14 + 15;
+    ok = ok && r.template has_value<pack<Alef, Gimel, Vav>>() && r.apply(join_witness) == 3 + 14 + 15;
   }
   { // pack join scalar
     auto const r = S::template join<pack<Alef, Gimel, Vav>>(pack<Alef, Gimel>{pack{Alef{3}, Gimel{14}}}, Vav{15});
-    ok = ok && r.invoke(join_witness) == 3 + 14 + 15;
+    ok = ok && r.apply(join_witness) == 3 + 14 + 15;
   }
   { // pack join pack
     auto const r = S::template join<pack<Alef, Gimel, Vav>>(pack<Alef, Gimel>{pack{Alef{3}, Gimel{14}}},
                                                             pack<Vav>{pack{Vav{15}}});
-    ok = ok && r.invoke(join_witness) == 3 + 14 + 15;
+    ok = ok && r.apply(join_witness) == 3 + 14 + 15;
   }
   return ok;
 }
@@ -752,20 +752,20 @@ constexpr bool join_value_lhs_battery()
   { // scalar join sum of scalars
     using R = sum<pack<Alef, Heh>, pack<Alef, Vav>, pack<Alef, Zayn>>;
     auto const r = S::join<R>(Alef{3}, sum<Heh, Vav, Zayn>{Vav{14}});
-    ok = ok && r.template has_value<pack<Alef, Vav>>() && r.invoke(join_witness) == 3 + 14;
+    ok = ok && r.template has_value<pack<Alef, Vav>>() && r.apply(join_witness) == 3 + 14;
   }
   { // scalar join sum of packs
     using R = sum<pack<Alef, Heh, Zayn>, pack<Alef, Vav>>;
     auto const r = S::join<R>(Alef{3}, sum<pack<Heh, Zayn>, pack<Vav>>{pack{Vav{14}}});
-    ok = ok && r.template has_value<pack<Alef, Vav>>() && r.invoke(join_witness) == 3 + 14;
+    ok = ok && r.template has_value<pack<Alef, Vav>>() && r.apply(join_witness) == 3 + 14;
   }
   { // scalar join scalar
     auto const r = S::join<pack<Alef, Vav>>(Alef{3}, Vav{14});
-    ok = ok && r.invoke(join_witness) == 3 + 14;
+    ok = ok && r.apply(join_witness) == 3 + 14;
   }
   { // scalar join pack
     auto const r = S::join<pack<Alef, Vav>>(Alef{3}, pack<Vav>{pack{Vav{14}}});
-    ok = ok && r.invoke(join_witness) == 3 + 14;
+    ok = ok && r.apply(join_witness) == 3 + 14;
   }
   return ok;
 }
@@ -794,7 +794,7 @@ TEST_CASE("operator &", "[pack][sum][operator_and]")
                     fn::pack<int, int, double, double, bool, bool>, //
                     fn::pack<int, int, double, double, bool, int>,  //
                     fn::pack<int, int, double, double, bool, double, int>> const>);
-  static_assert(r1.invoke([](auto &&...args) -> double { return (1 * ... * static_cast<double>(args)); })
+  static_assert(r1.apply([](auto &&...args) -> double { return (1 * ... * static_cast<double>(args)); })
                 == 12. * 3 * 2.5 * 0.5 * 1 * 1.5 * 12);
 
   constexpr auto r2
@@ -805,7 +805,7 @@ TEST_CASE("operator &", "[pack][sum][operator_and]")
                     fn::pack<int, int, double, double, bool, bool>, //
                     fn::pack<int, int, double, double, bool, int>,  //
                     fn::pack<int, int, double, double, bool, double, int>> const>);
-  static_assert(r2.invoke([](auto &&...args) -> double { return (1 * ... * static_cast<double>(args)); })
+  static_assert(r2.apply([](auto &&...args) -> double { return (1 * ... * static_cast<double>(args)); })
                 == 12. * 3 * 2.5 * 0.5 * 1 * 1.5 * 12);
 
   SECTION("noexcept")
@@ -837,7 +837,7 @@ TEST_CASE("pack get and tuple protocol", "[pack][get][tuple]")
   // the library's tuple_element<I, const T> propagates const onto value elements
   static_assert(std::same_as<std::tuple_element_t<0, pack<int, double, A> const>, int const>);
 
-  // get value categories mirror what invoke passes
+  // get value categories mirror what apply passes
   pack<int, double> p{2, 4};
   static_assert(std::same_as<decltype(get<0>(p)), int &>);
   static_assert(std::same_as<decltype(get<1>(p)), double &>);

--- a/tests/fn/recover.cpp
+++ b/tests/fn/recover.cpp
@@ -43,14 +43,14 @@ TEST_CASE("recover", "[recover][expected][expected_value]")
                                                    | recover([](auto...) -> unsigned { return 0; }))>);
 
   static_assert(is::invocable_with_any(fnError));
-  static_assert(is::invocable_with_any([](auto...) -> int { throw 0; }));          // allow generic call
-  static_assert(is::invocable_with_any([](Error) -> int { throw 0; }));            // allow copy
-  static_assert(is::invocable_with_any([](std::string_view) -> int { throw 0; })); // allow conversion
-  static_assert(is::invocable_with_any([](auto...) -> unsigned { throw 0; }));     // allow conversion to operand_t
-  static_assert(is::invocable_with_any([](Error const &) -> int { throw 0; }));    // binds to const ref
-  static_assert(is::invocable<lvalue>([](Error &) -> int { throw 0; }));           // binds to lvalue
-  static_assert(is::invocable<rvalue, prvalue>([](Error &&) -> int { throw 0; })); // can move
-  static_assert(is::invocable<rvalue, crvalue>([](Error const &&) -> int { throw 0; }));       // binds to const rvalue
+  static_assert(is::invocable_with_any([](auto...) -> int { throw 0; }));           // allow generic call
+  static_assert(is::invocable_with_any([](Error) -> int { throw 0; }));             // allow copy
+  static_assert(is::invocable_with_any([](std::string_view) -> int { throw 0; }));  // allow conversion
+  static_assert(is::invocable_with_any([](auto...) -> unsigned { throw 0; }));      // allow conversion to operand_t
+  static_assert(is::invocable_with_any([](Error const &) -> int { throw 0; }));     // binds to const ref
+  static_assert(is::applicable<lvalue>([](Error &) -> int { throw 0; }));           // binds to lvalue
+  static_assert(is::applicable<rvalue, prvalue>([](Error &&) -> int { throw 0; })); // can move
+  static_assert(is::applicable<rvalue, crvalue>([](Error const &&) -> int { throw 0; }));      // binds to const rvalue
   static_assert(is::not_invocable<clvalue, crvalue, cvalue>([](Error &) -> int { throw 0; })); // cannot remove const
   static_assert(is::not_invocable<rvalue>([](Error &) -> int { throw 0; }));                   // disallow bind
   static_assert(is::not_invocable<lvalue, clvalue, crvalue, cvalue>([](Error &&) -> int { throw 0; })); // cannot move
@@ -164,9 +164,9 @@ TEST_CASE("recover", "[recover][expected][expected_void]")
   static_assert(is::invocable_with_any([](Error) { throw 0; }));                        // allow copy
   static_assert(is::invocable_with_any([](std::string_view) { throw 0; }));             // allow conversion
   static_assert(is::invocable_with_any([](Error const &) { throw 0; }));                // binds to const ref
-  static_assert(is::invocable<lvalue>([](Error &) { throw 0; }));                       // binds to lvalue
-  static_assert(is::invocable<rvalue, prvalue>([](Error &&) { throw 0; }));             // can move
-  static_assert(is::invocable<rvalue, crvalue>([](Error const &&) { throw 0; }));       // binds to const rvalue
+  static_assert(is::applicable<lvalue>([](Error &) { throw 0; }));                      // binds to lvalue
+  static_assert(is::applicable<rvalue, prvalue>([](Error &&) { throw 0; }));            // can move
+  static_assert(is::applicable<rvalue, crvalue>([](Error const &&) { throw 0; }));      // binds to const rvalue
   static_assert(is::not_invocable<clvalue, crvalue, cvalue>([](Error &) { throw 0; })); // cannot remove const
   static_assert(is::not_invocable<rvalue>([](Error &) { throw 0; }));                   // disallow bind
   static_assert(is::not_invocable<lvalue, clvalue, crvalue, cvalue>([](Error &&) { throw 0; })); // cannot move
@@ -313,8 +313,8 @@ TEST_CASE("recover constraints", "[recover][constraints]")
   // A move-only value type is carried only where it can be moved out of - which is why the question
   // is `is_constructible_v<T, decltype(carried)>` and not `is_move_constructible_v<T>`
   using is = monadic_static_check<recover_t, fn::expected<helper_move_only, Error>>;
-  static_assert(is::invocable<rvalue, prvalue>(from_error));     // moved
-  static_assert(is::invocable<crvalue, cvalue>(from_error));     // const-moved
+  static_assert(is::applicable<rvalue, prvalue>(from_error));    // moved
+  static_assert(is::applicable<crvalue, cvalue>(from_error));    // const-moved
   static_assert(is::not_invocable<lvalue, clvalue>(from_error)); // would have to copy
 
   // A void-valued expected has no value to carry, so nothing constrains it
@@ -324,12 +324,12 @@ TEST_CASE("recover constraints", "[recover][constraints]")
   // cannot bind to the prvalue a callback returns
   using ref_t = fn::optional<int &>;
   static_assert(std::is_constructible_v<ref_t::value_type, int>);
-  static_assert(not invocable_recover<decltype([]() -> int { return 1; }) &, ref_t &>);
-  static_assert(invocable_recover<decltype([]() -> int & {
-                                    static int i = 1;
-                                    return i;
-                                  }) &,
-                                  ref_t &>);
+  static_assert(not applicable_recover<decltype([]() -> int { return 1; }) &, ref_t &>);
+  static_assert(applicable_recover<decltype([]() -> int & {
+                                     static int i = 1;
+                                     return i;
+                                   }) &,
+                                   ref_t &>);
   SUCCEED();
 }
 
@@ -347,19 +347,19 @@ constexpr auto fn_Error_rvalue = [](Error &&) -> int { throw 0; };
 
 // clang-format off
 // The callback consumes the error and must produce the operand's own value type.
-static_assert(invocable_recover<decltype(fn_Error<int>), expected<int, Error>>);
-static_assert(invocable_recover<decltype(fn_Error<unsigned>), expected<int, Error>>);    // conversion to value is enough
-static_assert(not invocable_recover<decltype(fn_Error<Value>), expected<int, Error>>);   // no conversion found
-static_assert(not invocable_recover<decltype(fn_nullary<int>), expected<int, Error>>);   // bad arity
-static_assert(invocable_recover<decltype(fn_generic<int>), expected<int, Error>>);
-static_assert(invocable_recover<decltype(fn_Error<void>), expected<void, Error>>);       // a void value wants void back
-static_assert(not invocable_recover<decltype(fn_Error<int>), expected<void, Error>>);    // never quietly discard a result
-static_assert(invocable_recover<decltype(fn_nullary<int>), optional<int>>);              // optional has no error: nullary
-static_assert(not invocable_recover<decltype(fn_Error<int>), optional<int>>);            // bad arity
-static_assert(not invocable_recover<decltype(fn_generic<int>), choice<int>>);            // no choice disjunct
-static_assert(not invocable_recover<decltype(fn_Error_lvalue), expected<int, Error>>);   // cannot bind temporary to lvalue
-static_assert(invocable_recover<decltype(fn_Error_lvalue), expected<int, Error> &>);
-static_assert(invocable_recover<decltype(fn_Error_rvalue), expected<int, Error>>);
-static_assert(not invocable_recover<decltype(fn_Error_rvalue), expected<int, Error> &>); // cannot bind lvalue to rvalue-ref
+static_assert(applicable_recover<decltype(fn_Error<int>), expected<int, Error>>);
+static_assert(applicable_recover<decltype(fn_Error<unsigned>), expected<int, Error>>);    // conversion to value is enough
+static_assert(not applicable_recover<decltype(fn_Error<Value>), expected<int, Error>>);   // no conversion found
+static_assert(not applicable_recover<decltype(fn_nullary<int>), expected<int, Error>>);   // bad arity
+static_assert(applicable_recover<decltype(fn_generic<int>), expected<int, Error>>);
+static_assert(applicable_recover<decltype(fn_Error<void>), expected<void, Error>>);       // a void value wants void back
+static_assert(not applicable_recover<decltype(fn_Error<int>), expected<void, Error>>);    // never quietly discard a result
+static_assert(applicable_recover<decltype(fn_nullary<int>), optional<int>>);              // optional has no error: nullary
+static_assert(not applicable_recover<decltype(fn_Error<int>), optional<int>>);            // bad arity
+static_assert(not applicable_recover<decltype(fn_generic<int>), choice<int>>);            // no choice disjunct
+static_assert(not applicable_recover<decltype(fn_Error_lvalue), expected<int, Error>>);   // cannot bind temporary to lvalue
+static_assert(applicable_recover<decltype(fn_Error_lvalue), expected<int, Error> &>);
+static_assert(applicable_recover<decltype(fn_Error_rvalue), expected<int, Error>>);
+static_assert(not applicable_recover<decltype(fn_Error_rvalue), expected<int, Error> &>); // cannot bind lvalue to rvalue-ref
 // clang-format on
 } // namespace fn

--- a/tests/fn/sum.cpp
+++ b/tests/fn/sum.cpp
@@ -40,7 +40,7 @@ template <fn::sum<bool, int> S> struct sum_nttp final {};
 template <fn::some_sum auto S> struct some_sum_nttp final {};
 template <fn::some_sum auto S> auto read_nttp()
 {
-  return S.invoke([](auto const &...args) { return (0.0 + ... + static_cast<double>(args)); });
+  return S.apply([](auto const &...args) { return (0.0 + ... + static_cast<double>(args)); });
 }
 
 // Every operation sum performs on an alternative - copy, move, compare - can throw here, so the
@@ -142,8 +142,8 @@ TEST_CASE("design: braces, not parentheses", "[sum][design]")
     static_assert(fn::detail::_initializable<A, int, int, int>);  // ... and this is the trait that does not
 
     sum<A> a{std::in_place_type<A>, 1, 2, 3};
-    CHECK(a.invoke([](A const &v) { return v[0] * 100 + v[1] * 10 + v[2]; }) == 123);
-    static_assert(sum<A>{std::in_place_type<A>, 1, 2, 3}.invoke([](A const &v) { return v[2]; }) == 3);
+    CHECK(a.apply([](A const &v) { return v[0] * 100 + v[1] * 10 + v[2]; }) == 123);
+    static_assert(sum<A>{std::in_place_type<A>, 1, 2, 3}.apply([](A const &v) { return v[2]; }) == 3);
   }
 
   SECTION("narrowing")
@@ -159,8 +159,8 @@ TEST_CASE("design: braces, not parentheses", "[sum][design]")
     // three zeroes here, and a sum holds the two elements it was written with
     using V = std::vector<int>;
     sum<V> v{std::in_place_type<V>, 3, 0};
-    CHECK(v.invoke([](V const &x) { return x.size(); }) == 2);
-    CHECK(v.invoke([](V const &x) { return x[0]; }) == 3);
+    CHECK(v.apply([](V const &x) { return x.size(); }) == 2);
+    CHECK(v.apply([](V const &x) { return x[0]; }) == 3);
   }
 
   SECTION("the traits must ask the brace question")
@@ -299,38 +299,38 @@ TEST_CASE("sum basic functionality tests", "[sum]")
     static_assert(std::same_as<fn::sum_for<double, fn::sum<>, fn::sum<bool, int>>, fn::sum<bool, double, int>>);
   }
 
-  SECTION("invocable")
+  SECTION("applicable")
   {
     using type = fn::sum_for<TestType, int>; // sum<...> order is platform-specific; sum_for normalizes per platform
-    static_assert(fn::typelist_invocable<decltype([](auto) {}), type &>);
-    static_assert(fn::typelist_invocable<decltype([](auto &) {}), type &>);
-    static_assert(fn::typelist_invocable<decltype([](auto const &) {}), type &>);
-    static_assert(fn::typelist_invocable<decltype(fn::overload{[](int &) {}, [](TestType &) {}}), type &>);
-    static_assert(fn::typelist_invocable<decltype(fn::overload{[](int) {}, [](TestType) {}}), type const &>);
+    static_assert(fn::typelist_applicable<decltype([](auto) {}), type &>);
+    static_assert(fn::typelist_applicable<decltype([](auto &) {}), type &>);
+    static_assert(fn::typelist_applicable<decltype([](auto const &) {}), type &>);
+    static_assert(fn::typelist_applicable<decltype(fn::overload{[](int &) {}, [](TestType &) {}}), type &>);
+    static_assert(fn::typelist_applicable<decltype(fn::overload{[](int) {}, [](TestType) {}}), type const &>);
 
-    static_assert(not fn::typelist_invocable<decltype([](TestType &) {}), type &>); // missing int
-    static_assert(not fn::typelist_invocable<decltype([](int &) {}), type &>);      // missing TestType
-    static_assert(not fn::typelist_invocable<decltype(fn::overload{[](int &&) {}, [](TestType &&) {}}),
-                                             type &>); // cannot bind lvalue to rvalue-reference
-    static_assert(not fn::typelist_invocable<decltype([](auto &) {}),
-                                             type &&>); // cannot bind rvalue to lvalue-reference
-    static_assert(not fn::typelist_invocable<decltype([](auto, auto &) {}), type &>); // bad arity
-    static_assert(not fn::typelist_invocable<decltype(fn::overload{[](int &) {}, [](TestType &) {}}),
-                                             type const &>); // cannot bind const to non-const reference
+    static_assert(not fn::typelist_applicable<decltype([](TestType &) {}), type &>); // missing int
+    static_assert(not fn::typelist_applicable<decltype([](int &) {}), type &>);      // missing TestType
+    static_assert(not fn::typelist_applicable<decltype(fn::overload{[](int &&) {}, [](TestType &&) {}}),
+                                              type &>); // cannot bind lvalue to rvalue-reference
+    static_assert(not fn::typelist_applicable<decltype([](auto &) {}),
+                                              type &&>); // cannot bind rvalue to lvalue-reference
+    static_assert(not fn::typelist_applicable<decltype([](auto, auto &) {}), type &>); // bad arity
+    static_assert(not fn::typelist_applicable<decltype(fn::overload{[](int &) {}, [](TestType &) {}}),
+                                              type const &>); // cannot bind const to non-const reference
 
-    static_assert(fn::typelist_invocable<decltype([](auto &) {}), sum<NonCopyable> &>);
-    static_assert(not fn::typelist_invocable<decltype([](auto) {}), NonCopyable &>); // copy-constructor not available
+    static_assert(fn::typelist_applicable<decltype([](auto &) {}), sum<NonCopyable> &>);
+    static_assert(not fn::typelist_applicable<decltype([](auto) {}), NonCopyable &>); // copy-constructor not available
 
     // variadic-generic callback, and a per-category sweep of an lvalue-only overload set
     using T2 = fn::sum<double, int>;
-    static_assert(fn::typelist_invocable<decltype([](auto...) {}), T2 &>);
+    static_assert(fn::typelist_applicable<decltype([](auto...) {}), T2 &>);
     constexpr auto fnLvalue = fn::overload{[](int &) {}, [](double &) {}};
-    static_assert(fn::typelist_invocable<decltype(fnLvalue), T2 &>);
-    static_assert(not fn::typelist_invocable<decltype(fnLvalue), T2 const &>);
-    static_assert(not fn::typelist_invocable<decltype(fnLvalue), T2>);
-    static_assert(not fn::typelist_invocable<decltype(fnLvalue), T2 const>);
-    static_assert(not fn::typelist_invocable<decltype(fnLvalue), T2 &&>);
-    static_assert(not fn::typelist_invocable<decltype(fnLvalue), T2 const &&>);
+    static_assert(fn::typelist_applicable<decltype(fnLvalue), T2 &>);
+    static_assert(not fn::typelist_applicable<decltype(fnLvalue), T2 const &>);
+    static_assert(not fn::typelist_applicable<decltype(fnLvalue), T2>);
+    static_assert(not fn::typelist_applicable<decltype(fnLvalue), T2 const>);
+    static_assert(not fn::typelist_applicable<decltype(fnLvalue), T2 &&>);
+    static_assert(not fn::typelist_applicable<decltype(fnLvalue), T2 const &&>);
   }
 
   SECTION("check destructor call")
@@ -384,10 +384,10 @@ TEST_CASE("sum basic functionality tests", "[sum]")
 
       ExplicitCopy e{42};
       sum<ExplicitCopy> a{e};
-      CHECK(a.invoke([](auto &&i) -> int { return i.v; }) == 42);
+      CHECK(a.apply([](auto &&i) -> int { return i.v; }) == 42);
 
       sum<ExplicitCopy> b{std::move(e)};
-      CHECK(b.invoke([](auto &&i) -> int { return i.v; }) == 42);
+      CHECK(b.apply([](auto &&i) -> int { return i.v; }) == 42);
 
       SECTION("constexpr")
       {
@@ -395,7 +395,7 @@ TEST_CASE("sum basic functionality tests", "[sum]")
           ExplicitCopy e{42};
           return sum<ExplicitCopy>{e};
         }();
-        static_assert(c.invoke([](auto &&i) -> int { return i.v; }) == 42);
+        static_assert(c.apply([](auto &&i) -> int { return i.v; }) == 42);
         SUCCEED();
       }
     }
@@ -412,7 +412,7 @@ TEST_CASE("sum basic functionality tests", "[sum]")
 
       constexpr auto c = sum{std::array<int, 3>{3, 14, 15}};
       static_assert(std::is_same_v<decltype(c), sum<std::array<int, 3>> const>);
-      static_assert(c.invoke([](auto &&a) -> bool { return a.size() == 3 && a[0] == 3 && a[1] == 14 && a[2] == 15; }));
+      static_assert(c.apply([](auto &&a) -> bool { return a.size() == 3 && a[0] == 3 && a[1] == 14 && a[2] == 15; }));
     }
 
     SECTION("move from rvalue")
@@ -445,7 +445,7 @@ TEST_CASE("sum basic functionality tests", "[sum]")
   SECTION("forwarding constructors (immovable)")
   {
     sum<NonCopyable> a{std::in_place_type<NonCopyable>, 42};
-    CHECK(a.invoke([](auto &i) -> bool { return i.v == 42; }));
+    CHECK(a.apply([](auto &i) -> bool { return i.v == 42; }));
 
     SECTION("CTAD")
     {
@@ -478,7 +478,7 @@ TEST_CASE("sum basic functionality tests", "[sum]")
       static_assert(not decltype(a)::has_type<int>);
       CHECK(a.has_value(std::in_place_type<std::array<int, 3>>));
       CHECK(a.template has_value<std::array<int, 3>>());
-      CHECK(a.invoke([](auto &i) -> bool {
+      CHECK(a.apply([](auto &i) -> bool {
         return std::same_as<std::array<int, 3> &, decltype(i)> && i.size() == 3 && i[0] == 1 && i[1] == 2 && i[2] == 3;
       }));
     }
@@ -490,7 +490,7 @@ TEST_CASE("sum basic functionality tests", "[sum]")
       static_assert(not decltype(a)::has_type<int>);
       static_assert(a.has_value(std::in_place_type<std::array<int, 3>>));
       static_assert(a.template has_value<std::array<int, 3>>());
-      static_assert(a.invoke([](auto &i) -> bool {
+      static_assert(a.apply([](auto &i) -> bool {
         return std::same_as<std::array<int, 3> const &, decltype(i)> && i.size() == 3 && i[0] == 1 && i[1] == 2
                && i[2] == 3;
       }));
@@ -527,7 +527,7 @@ TEST_CASE("sum basic functionality tests", "[sum]")
       S const a{std::in_place_type<int>, 42};
       T b{a};
       CHECK(b.has_value(std::in_place_type<int>));
-      CHECK(b.invoke([](auto &&i) -> int { return static_cast<int>(i); }) == 42);
+      CHECK(b.apply([](auto &&i) -> int { return static_cast<int>(i); }) == 42);
       CHECK(a.has_value(std::in_place_type<int>)); // the source is copied, not consumed
     }
 
@@ -536,7 +536,7 @@ TEST_CASE("sum basic functionality tests", "[sum]")
       S a{std::in_place_type<int>, 42};
       T b{std::move(a)};
       CHECK(b.has_value(std::in_place_type<int>));
-      CHECK(b.invoke([](auto &&i) -> int { return static_cast<int>(i); }) == 42);
+      CHECK(b.apply([](auto &&i) -> int { return static_cast<int>(i); }) == 42);
     }
 
     SECTION("in_place_type names the source sum")
@@ -544,7 +544,7 @@ TEST_CASE("sum basic functionality tests", "[sum]")
       S const a{std::in_place_type<bool>, true};
       T b{std::in_place_type<S>, a};
       CHECK(b.has_value(std::in_place_type<bool>));
-      CHECK(b.invoke([](auto &&i) -> bool { return static_cast<bool>(i); }));
+      CHECK(b.apply([](auto &&i) -> bool { return static_cast<bool>(i); }));
     }
 
     SECTION("constexpr")
@@ -762,62 +762,62 @@ TEST_CASE("sum basic functionality tests", "[sum]")
     }
   }
 
-  SECTION("invoke")
+  SECTION("apply")
   {
     sum<int> a{std::in_place_type<int>, 42};
 
     SECTION("noexcept")
     {
-      // invoke weighs the callback it dispatches to, in every value category
+      // apply weighs the callback it dispatches to, in every value category
       constexpr auto throwing = [](int i) noexcept(false) -> bool { return i == 42; };
       static_assert(not noexcept(throwing(42)));
-      static_assert(not noexcept(a.invoke(throwing)));
-      static_assert(not noexcept(std::as_const(a).invoke(throwing)));
-      static_assert(not noexcept(std::move(a).invoke(throwing)));
-      static_assert(not noexcept(std::move(std::as_const(a)).invoke(throwing)));
+      static_assert(not noexcept(a.apply(throwing)));
+      static_assert(not noexcept(std::as_const(a).apply(throwing)));
+      static_assert(not noexcept(std::move(a).apply(throwing)));
+      static_assert(not noexcept(std::move(std::as_const(a)).apply(throwing)));
 
       constexpr auto throwing2 = [](int i, std::monostate) noexcept(false) -> bool { return i == 42; };
-      static_assert(not noexcept(a.invoke(throwing2, std::monostate{}))); // extra arguments, same promise
+      static_assert(not noexcept(a.apply(throwing2, std::monostate{}))); // extra arguments, same promise
 
       constexpr auto nothrow = [](int i) noexcept -> bool { return i == 42; };
-      static_assert(noexcept(a.invoke(nothrow)));
-      static_assert(noexcept(std::move(a).invoke(nothrow)));
+      static_assert(noexcept(a.apply(nothrow)));
+      static_assert(noexcept(std::move(a).apply(nothrow)));
       SUCCEED();
     }
 
     SECTION("value only")
     {
-      static_assert(std::is_same_v<bool, decltype(a.invoke(fn::overload{[](auto) -> bool { throw 1; },
-                                                                        [](int) -> bool { return true; }}))>);
+      static_assert(std::is_same_v<bool, decltype(a.apply(fn::overload{[](auto) -> bool { throw 1; },
+                                                                       [](int) -> bool { return true; }}))>);
 
       // a result type other than bool, to witness the deduced return
       constexpr auto fn1 = [](auto i) noexcept -> std::size_t { return sizeof(i); };
-      static_assert(std::is_same_v<std::size_t, decltype(a.invoke(fn1))>);
-      CHECK(a.invoke(fn1) == sizeof(int));
+      static_assert(std::is_same_v<std::size_t, decltype(a.apply(fn1))>);
+      CHECK(a.apply(fn1) == sizeof(int));
       CHECK(a.data.v0 == 42); // white-box: the value went into the first alternative
 
-      CHECK(a.invoke(fn::overload{[](auto) -> bool { throw 1; }, [](int &i) -> bool { return i == 42; },
-                                  [](int const &) -> bool { throw 0; }, [](int &&) -> bool { throw 0; },
-                                  [](int const &&) -> bool { throw 0; }}));
-      CHECK(std::as_const(a).invoke(fn::overload{
+      CHECK(a.apply(fn::overload{[](auto) -> bool { throw 1; }, [](int &i) -> bool { return i == 42; },
+                                 [](int const &) -> bool { throw 0; }, [](int &&) -> bool { throw 0; },
+                                 [](int const &&) -> bool { throw 0; }}));
+      CHECK(std::as_const(a).apply(fn::overload{
           [](auto) -> bool { throw 1; }, [](int &) -> bool { throw 0; }, [](int const &i) -> bool { return i == 42; },
           [](int &&) -> bool { throw 0; }, [](int const &&) -> bool { throw 0; }}));
       CHECK(std::move(std::as_const(a))
-                .invoke(fn::overload{[](auto) -> bool { throw 1; }, [](int &) -> bool { throw 0; },
-                                     [](int const &) -> bool { throw 0; }, [](int &&) -> bool { throw 0; },
-                                     [](int const &&i) -> bool { return i == 42; }}));
-      CHECK(std::move(a).invoke(fn::overload{
+                .apply(fn::overload{[](auto) -> bool { throw 1; }, [](int &) -> bool { throw 0; },
+                                    [](int const &) -> bool { throw 0; }, [](int &&) -> bool { throw 0; },
+                                    [](int const &&i) -> bool { return i == 42; }}));
+      CHECK(std::move(a).apply(fn::overload{
           [](auto) -> bool { throw 1; }, [](int &) -> bool { throw 0; }, [](int const &) -> bool { throw 0; },
           [](int &&i) -> bool { return i == 42; }, [](int const &&) -> bool { throw 0; }}));
 
       SECTION("constexpr")
       {
         constexpr sum<int> a{std::in_place_type<int>, 42};
-        static_assert(a.invoke(fn::overload{
+        static_assert(a.apply(fn::overload{
             [](auto) -> std::false_type { return {}; }, //
             [](int &) -> std::false_type { return {}; }, [](int const &) -> std::true_type { return {}; },
             [](int &&) -> std::false_type { return {}; }, [](int const &&) -> std::false_type { return {}; }}));
-        static_assert(std::move(a).invoke(fn::overload{
+        static_assert(std::move(a).apply(fn::overload{
             [](auto) -> std::false_type { return {}; }, //
             [](int &) -> std::false_type { return {}; }, [](int const &) -> std::false_type { return {}; },
             [](int &&) -> std::false_type { return {}; }, [](int const &&) -> std::true_type { return {}; }}));
@@ -826,134 +826,133 @@ TEST_CASE("sum basic functionality tests", "[sum]")
 
     SECTION("extra arguments")
     {
-      static_assert(std::is_same_v<bool, decltype(a.invoke([](int, int) -> bool { return true; }, 12))>);
+      static_assert(std::is_same_v<bool, decltype(a.apply([](int, int) -> bool { return true; }, 12))>);
 
-      CHECK(a.invoke(fn::overload{                                                      //
-                                  [](auto const &...) -> bool { throw 1; },             //
-                                  [](int &, std::monostate) -> bool { return true; },   //
-                                  [](int const &, std::monostate) -> bool { throw 0; }, //
-                                  [](int &&, std::monostate) -> bool { throw 0; },      //
-                                  [](int const &&, std::monostate) -> bool { throw 0; }},
-                     std::monostate{}));
-      CHECK(std::as_const(a).invoke(fn::overload{                                                          //
-                                                 [](auto const &...) -> bool { throw 1; },                 //
-                                                 [](int &, std::monostate) -> bool { throw 0; },           //
-                                                 [](int const &, std::monostate) -> bool { return true; }, //
-                                                 [](int &&, std::monostate) -> bool { throw 0; },          //
-                                                 [](int const &&, std::monostate) -> bool { throw 0; }},
-                                    std::monostate{}));
+      CHECK(a.apply(fn::overload{                                                      //
+                                 [](auto const &...) -> bool { throw 1; },             //
+                                 [](int &, std::monostate) -> bool { return true; },   //
+                                 [](int const &, std::monostate) -> bool { throw 0; }, //
+                                 [](int &&, std::monostate) -> bool { throw 0; },      //
+                                 [](int const &&, std::monostate) -> bool { throw 0; }},
+                    std::monostate{}));
+      CHECK(std::as_const(a).apply(fn::overload{                                                          //
+                                                [](auto const &...) -> bool { throw 1; },                 //
+                                                [](int &, std::monostate) -> bool { throw 0; },           //
+                                                [](int const &, std::monostate) -> bool { return true; }, //
+                                                [](int &&, std::monostate) -> bool { throw 0; },          //
+                                                [](int const &&, std::monostate) -> bool { throw 0; }},
+                                   std::monostate{}));
       CHECK(std::move(std::as_const(a))
-                .invoke(fn::overload{                                                      //
-                                     [](auto const &...) -> bool { throw 1; },             //
-                                     [](int &, std::monostate) -> bool { throw 0; },       //
-                                     [](int const &, std::monostate) -> bool { throw 0; }, //
-                                     [](int &&, std::monostate) -> bool { throw 0; },      //
-                                     [](int const &&, std::monostate) -> bool { return true; }},
-                        std::monostate{}));
-      CHECK(std::move(a).invoke(fn::overload{                                                      //
-                                             [](auto const &...) -> bool { throw 1; },             //
-                                             [](int &, std::monostate) -> bool { throw 0; },       //
-                                             [](int const &, std::monostate) -> bool { throw 0; }, //
-                                             [](int &&, std::monostate) -> bool { return true; },  //
-                                             [](int const &&, std::monostate) -> bool { throw 0; }},
-                                std::monostate{}));
+                .apply(fn::overload{                                                      //
+                                    [](auto const &...) -> bool { throw 1; },             //
+                                    [](int &, std::monostate) -> bool { throw 0; },       //
+                                    [](int const &, std::monostate) -> bool { throw 0; }, //
+                                    [](int &&, std::monostate) -> bool { throw 0; },      //
+                                    [](int const &&, std::monostate) -> bool { return true; }},
+                       std::monostate{}));
+      CHECK(std::move(a).apply(fn::overload{                                                      //
+                                            [](auto const &...) -> bool { throw 1; },             //
+                                            [](int &, std::monostate) -> bool { throw 0; },       //
+                                            [](int const &, std::monostate) -> bool { throw 0; }, //
+                                            [](int &&, std::monostate) -> bool { return true; },  //
+                                            [](int const &&, std::monostate) -> bool { throw 0; }},
+                               std::monostate{}));
 
       SECTION("constexpr")
       {
         constexpr sum<int> a{std::in_place_type<int>, 42};
-        static_assert(a.invoke(fn::overload{[](auto...) -> bool { return false; }, //
-                                            [](int &, std::monostate) -> bool { return false; },
-                                            [](int const &, std::monostate) -> bool { return true; },
-                                            [](int &&, std::monostate) -> bool { return false; },
-                                            [](int const &&, std::monostate) -> bool { return false; }},
-                               std::monostate{}));
-        static_assert(std::move(a).invoke(fn::overload{[](auto...) -> bool { return false; }, //
-                                                       [](int &, std::monostate) -> bool { return false; },
-                                                       [](int const &, std::monostate) -> bool { return false; },
-                                                       [](int &&, std::monostate) -> bool { return false; },
-                                                       [](int const &&, std::monostate) -> bool { return true; }},
-                                          std::monostate{}));
-        static_assert(fn::invoke([](int i, std::monostate) -> bool { return i == 42; }, a, std::monostate{}));
+        static_assert(a.apply(fn::overload{[](auto...) -> bool { return false; }, //
+                                           [](int &, std::monostate) -> bool { return false; },
+                                           [](int const &, std::monostate) -> bool { return true; },
+                                           [](int &&, std::monostate) -> bool { return false; },
+                                           [](int const &&, std::monostate) -> bool { return false; }},
+                              std::monostate{}));
+        static_assert(std::move(a).apply(fn::overload{[](auto...) -> bool { return false; }, //
+                                                      [](int &, std::monostate) -> bool { return false; },
+                                                      [](int const &, std::monostate) -> bool { return false; },
+                                                      [](int &&, std::monostate) -> bool { return false; },
+                                                      [](int const &&, std::monostate) -> bool { return true; }},
+                                         std::monostate{}));
+        static_assert(fn::apply([](int i, std::monostate) -> bool { return i == 42; }, a, std::monostate{}));
 
         constexpr auto fn = [](auto &&...a) { return (0 + ... + static_cast<int>(a)); };
-        static_assert(sum<bool, int>{2}.invoke(fn, 3) == 5);
+        static_assert(sum<bool, int>{2}.apply(fn, 3) == 5);
       }
     }
   }
 
-  SECTION("invoke_r")
+  SECTION("apply_r")
   {
     sum<int> a{std::in_place_type<int>, 42};
 
     SECTION("noexcept")
     {
-      // the same weighing as invoke, the conversion to Ret included
+      // the same weighing as apply, the conversion to Ret included
       constexpr auto throwing = [](int i) noexcept(false) -> bool { return i == 42; };
-      static_assert(not noexcept(a.template invoke_r<bool>(throwing)));
-      static_assert(not noexcept(std::as_const(a).template invoke_r<bool>(throwing)));
-      static_assert(not noexcept(std::move(a).template invoke_r<bool>(throwing)));
-      static_assert(not noexcept(std::move(std::as_const(a)).template invoke_r<bool>(throwing)));
-      static_assert(not noexcept(a.template invoke_r<long>(throwing))); // converting the result, too
+      static_assert(not noexcept(a.template apply_r<bool>(throwing)));
+      static_assert(not noexcept(std::as_const(a).template apply_r<bool>(throwing)));
+      static_assert(not noexcept(std::move(a).template apply_r<bool>(throwing)));
+      static_assert(not noexcept(std::move(std::as_const(a)).template apply_r<bool>(throwing)));
+      static_assert(not noexcept(a.template apply_r<long>(throwing))); // converting the result, too
 
       constexpr auto nothrow = [](int i) noexcept -> bool { return i == 42; };
-      static_assert(noexcept(a.template invoke_r<bool>(nothrow)));
-      static_assert(noexcept(a.template invoke_r<long>(nothrow)));
+      static_assert(noexcept(a.template apply_r<bool>(nothrow)));
+      static_assert(noexcept(a.template apply_r<long>(nothrow)));
       SUCCEED();
     }
 
     SECTION("value only")
     {
-      static_assert(std::is_same_v<bool, decltype(a.template invoke_r<bool>(fn::overload{
+      static_assert(std::is_same_v<bool, decltype(a.template apply_r<bool>(fn::overload{
                                              [](auto) -> bool { throw 1; }, [](int) -> bool { return true; }}))>);
       static_assert(
-          std::is_same_v<int, decltype(a.template invoke_r<int>(fn::overload{[](auto) -> bool { throw 1; }, //
-                                                                             [](int) -> int { return true; }}))>);
+          std::is_same_v<int, decltype(a.template apply_r<int>(fn::overload{[](auto) -> bool { throw 1; }, //
+                                                                            [](int) -> int { return true; }}))>);
 
-      CHECK(a.template invoke_r<bool>(fn::overload{
-          [](auto) -> bool { throw 1; }, [](int &) -> bool { return true; }, [](int const &) -> bool { throw 0; },
-          [](int &&) -> bool { throw 0; }, [](int const &&) -> bool { throw 0; }}));
-      CHECK(std::as_const(a).template invoke_r<bool>(fn::overload{
+      CHECK(a.template apply_r<bool>(fn::overload{[](auto) -> bool { throw 1; }, [](int &) -> bool { return true; },
+                                                  [](int const &) -> bool { throw 0; }, [](int &&) -> bool { throw 0; },
+                                                  [](int const &&) -> bool { throw 0; }}));
+      CHECK(std::as_const(a).template apply_r<bool>(fn::overload{
           [](auto) -> bool { throw 1; }, [](int &) -> bool { throw 0; }, [](int const &) -> bool { return true; },
           [](int &&) -> bool { throw 0; }, [](int const &&) -> bool { throw 0; }}));
       CHECK(std::move(std::as_const(a))
-                .template invoke_r<bool>(fn::overload{
+                .template apply_r<bool>(fn::overload{
                     [](auto) -> bool { throw 1; }, [](int &) -> bool { throw 0; }, [](int const &) -> bool { throw 0; },
                     [](int &&) -> bool { throw 0; }, [](int const &&) -> bool { return true; }}));
-      CHECK(std::move(a).template invoke_r<bool>(fn::overload{
+      CHECK(std::move(a).template apply_r<bool>(fn::overload{
           [](auto) -> bool { throw 1; }, [](int &) -> bool { throw 0; }, [](int const &) -> bool { throw 0; },
           [](int &&) -> bool { return true; }, [](int const &&) -> bool { throw 0; }}));
 
       SECTION("constexpr")
       {
         constexpr sum<int> a{std::in_place_type<int>, 42};
-        static_assert(a.template invoke_r<bool>(fn::overload{
+        static_assert(a.template apply_r<bool>(fn::overload{
             [](auto) -> std::false_type { return {}; }, //
             [](int &) -> std::false_type { return {}; }, [](int const &) -> std::true_type { return {}; },
             [](int &&) -> std::false_type { return {}; }, [](int const &&) -> std::false_type { return {}; }}));
-        static_assert(std::move(a).template invoke_r<bool>(fn::overload{
+        static_assert(std::move(a).template apply_r<bool>(fn::overload{
             [](auto) -> std::false_type { return {}; }, //
             [](int &) -> std::false_type { return {}; }, [](int const &) -> std::false_type { return {}; },
             [](int &&) -> std::false_type { return {}; }, [](int const &&) -> std::true_type { return {}; }}));
-        static_assert(
-            fn::invoke_r<bool>([](int, std::monostate) -> std::true_type { return {}; }, a, std::monostate{}));
+        static_assert(fn::apply_r<bool>([](int, std::monostate) -> std::true_type { return {}; }, a, std::monostate{}));
       }
     }
 
     SECTION("extra arguments")
     {
-      static_assert(std::is_same_v<bool, decltype(a.template invoke_r<bool>(fn::overload{
+      static_assert(std::is_same_v<bool, decltype(a.template apply_r<bool>(fn::overload{
                                              [](auto) -> bool { throw 1; }, [](int) -> bool { return true; }}))>);
       static_assert(
-          std::is_same_v<int, decltype(a.template invoke_r<int>(fn::overload{[](auto) -> bool { throw 1; }, //
-                                                                             [](int) -> int { return true; }}))>);
-      CHECK(a.template invoke_r<bool>(fn::overload{                                                      //
-                                                   [](auto const &...) -> bool { throw 1; },             //
-                                                   [](int &, std::monostate) -> bool { return true; },   //
-                                                   [](int const &, std::monostate) -> bool { throw 0; }, //
-                                                   [](int &&, std::monostate) -> bool { throw 0; },      //
-                                                   [](int const &&, std::monostate) -> bool { throw 0; }},
-                                      std::monostate{}));
-      CHECK(std::as_const(a).template invoke_r<bool>(
+          std::is_same_v<int, decltype(a.template apply_r<int>(fn::overload{[](auto) -> bool { throw 1; }, //
+                                                                            [](int) -> int { return true; }}))>);
+      CHECK(a.template apply_r<bool>(fn::overload{                                                      //
+                                                  [](auto const &...) -> bool { throw 1; },             //
+                                                  [](int &, std::monostate) -> bool { return true; },   //
+                                                  [](int const &, std::monostate) -> bool { throw 0; }, //
+                                                  [](int &&, std::monostate) -> bool { throw 0; },      //
+                                                  [](int const &&, std::monostate) -> bool { throw 0; }},
+                                     std::monostate{}));
+      CHECK(std::as_const(a).template apply_r<bool>(
           fn::overload{                                                          //
                        [](auto const &...) -> bool { throw 1; },                 //
                        [](int &, std::monostate) -> bool { throw 0; },           //
@@ -962,32 +961,32 @@ TEST_CASE("sum basic functionality tests", "[sum]")
                        [](int const &&, std::monostate) -> bool { throw 0; }},
           std::monostate{}));
       CHECK(std::move(std::as_const(a))
-                .template invoke_r<bool>(fn::overload{                                                      //
-                                                      [](auto const &...) -> bool { throw 1; },             //
-                                                      [](int &, std::monostate) -> bool { throw 0; },       //
-                                                      [](int const &, std::monostate) -> bool { throw 0; }, //
-                                                      [](int &&, std::monostate) -> bool { throw 0; },      //
-                                                      [](int const &&, std::monostate) -> bool { return true; }},
-                                         std::monostate{}));
-      CHECK(std::move(a).template invoke_r<bool>(fn::overload{                                                      //
-                                                              [](auto const &...) -> bool { throw 1; },             //
-                                                              [](int &, std::monostate) -> bool { throw 0; },       //
-                                                              [](int const &, std::monostate) -> bool { throw 0; }, //
-                                                              [](int &&, std::monostate) -> bool { return true; },  //
-                                                              [](int const &&, std::monostate) -> bool { throw 0; }},
-                                                 std::monostate{}));
+                .template apply_r<bool>(fn::overload{                                                      //
+                                                     [](auto const &...) -> bool { throw 1; },             //
+                                                     [](int &, std::monostate) -> bool { throw 0; },       //
+                                                     [](int const &, std::monostate) -> bool { throw 0; }, //
+                                                     [](int &&, std::monostate) -> bool { throw 0; },      //
+                                                     [](int const &&, std::monostate) -> bool { return true; }},
+                                        std::monostate{}));
+      CHECK(std::move(a).template apply_r<bool>(fn::overload{                                                      //
+                                                             [](auto const &...) -> bool { throw 1; },             //
+                                                             [](int &, std::monostate) -> bool { throw 0; },       //
+                                                             [](int const &, std::monostate) -> bool { throw 0; }, //
+                                                             [](int &&, std::monostate) -> bool { return true; },  //
+                                                             [](int const &&, std::monostate) -> bool { throw 0; }},
+                                                std::monostate{}));
 
       SECTION("constexpr")
       {
         constexpr sum<int> a{std::in_place_type<int>, 42};
         static_assert(
-            a.template invoke_r<bool>(fn::overload{[](auto...) -> std::false_type { return {}; }, //
-                                                   [](int &, std::monostate) -> std::false_type { return {}; },
-                                                   [](int const &, std::monostate) -> std::true_type { return {}; },
-                                                   [](int &&, std::monostate) -> std::false_type { return {}; },
-                                                   [](int const &&, std::monostate) -> std::false_type { return {}; }},
-                                      std::monostate{}));
-        static_assert(std::move(a).template invoke_r<bool>(
+            a.template apply_r<bool>(fn::overload{[](auto...) -> std::false_type { return {}; }, //
+                                                  [](int &, std::monostate) -> std::false_type { return {}; },
+                                                  [](int const &, std::monostate) -> std::true_type { return {}; },
+                                                  [](int &&, std::monostate) -> std::false_type { return {}; },
+                                                  [](int const &&, std::monostate) -> std::false_type { return {}; }},
+                                     std::monostate{}));
+        static_assert(std::move(a).template apply_r<bool>(
             fn::overload{[](auto...) -> std::false_type { return {}; }, //
                          [](int &, std::monostate) -> std::false_type { return {}; },
                          [](int const &, std::monostate) -> std::false_type { return {}; },
@@ -996,7 +995,7 @@ TEST_CASE("sum basic functionality tests", "[sum]")
             std::monostate{}));
 
         constexpr auto fn = [](auto &&...a) { return (0 + ... + static_cast<int>(a)); };
-        static_assert(sum<bool, int>{2}.template invoke_r<long>(fn, 3) == 5l);
+        static_assert(sum<bool, int>{2}.template apply_r<long>(fn, 3) == 5l);
       }
     }
   }
@@ -1010,22 +1009,22 @@ TEST_CASE("sum basic functionality tests", "[sum]")
     SECTION("constexpr")
     {
       constexpr auto b
-          = a.invoke([]<std::size_t I>(char const(&)[I], int i, double d) { return I + i + static_cast<int>(d); });
+          = a.apply([]<std::size_t I>(char const(&)[I], int i, double d) { return I + i + static_cast<int>(d); });
       static_assert(b == 4 + 42 + 12);
 
       constexpr sum<pack<int, int, int, int>, pack<int, int, int>, pack<int, int>, pack<int>> c = pack{3, 14, 15};
-      static_assert(c.invoke([](std::integral auto... args) -> int { return (... + args); }) == 3 + 14 + 15);
+      static_assert(c.apply([](std::integral auto... args) -> int { return (... + args); }) == 3 + 14 + 15);
 
       SUCCEED();
     }
 
     SECTION("runtime")
     {
-      auto const b = a.invoke([](char const *s, int i, double d) { return std::strlen(s) + i + static_cast<int>(d); });
+      auto const b = a.apply([](char const *s, int i, double d) { return std::strlen(s) + i + static_cast<int>(d); });
       CHECK(b == 3 + 42 + 12);
 
       constexpr sum<pack<int, int, int, int>, pack<int, int, int>, pack<int, int>, pack<int>> c = pack{3, 14, 15, 92};
-      CHECK(c.invoke([](std::integral auto... args) -> int { return (... + args); }) == 3 + 14 + 15 + 92);
+      CHECK(c.apply([](std::integral auto... args) -> int { return (... + args); }) == 3 + 14 + 15 + 92);
     }
   }
 
@@ -1110,17 +1109,17 @@ TEST_CASE("sum noexcept", "[sum][noexcept]")
     constexpr auto nothrow_fn = [](auto) noexcept { return 0; };
     constexpr auto throwing_fn = [](auto) { return 0; };
 
-    static_assert(noexcept(std::declval<S &>().invoke(nothrow_fn)));
-    static_assert(not noexcept(std::declval<S &>().invoke(throwing_fn)));
-    static_assert(noexcept(std::declval<S &>().template invoke_r<int>(nothrow_fn)));
-    static_assert(not noexcept(std::declval<S &>().template invoke_r<int>(throwing_fn)));
+    static_assert(noexcept(std::declval<S &>().apply(nothrow_fn)));
+    static_assert(not noexcept(std::declval<S &>().apply(throwing_fn)));
+    static_assert(noexcept(std::declval<S &>().template apply_r<int>(nothrow_fn)));
+    static_assert(not noexcept(std::declval<S &>().template apply_r<int>(throwing_fn)));
     static_assert(noexcept(std::declval<S &>().transform(nothrow_fn)));
     static_assert(not noexcept(std::declval<S &>().transform(throwing_fn)));
 
     // which alternative runs is a run-time choice, so one throwing handler makes the whole
     // dispatch throwing
     constexpr auto mixed = fn::overload{[](int) noexcept { return 0; }, [](bool) { return 0; }};
-    static_assert(not noexcept(std::declval<S &>().invoke(mixed)));
+    static_assert(not noexcept(std::declval<S &>().apply(mixed)));
     SUCCEED();
   }
 
@@ -1236,7 +1235,7 @@ TEST_CASE("sum type collapsing", "[sum][transform][normalized]")
   using ::fn::overload;
   using ::fn::sum;
   using ::fn::detail::_collapsing_sum_tag;
-  using ::fn::detail::_sum_invoke_result;
+  using ::fn::detail::_sum_apply_result;
   using ::fn::detail::_typelist_collapsing_sum;
 
   struct sum_double_int {};
@@ -1248,7 +1247,7 @@ TEST_CASE("sum type collapsing", "[sum][transform][normalized]")
     constexpr auto fn = PassThrough{};
     using type = sum<double>;
     static_assert(
-        std::same_as<typename _sum_invoke_result<_collapsing_sum_tag, decltype(fn), type &>::type, sum<double>>);
+        std::same_as<typename _sum_apply_result<_collapsing_sum_tag, decltype(fn), type &>::type, sum<double>>);
   }
 
   SECTION("two elements")
@@ -1256,15 +1255,14 @@ TEST_CASE("sum type collapsing", "[sum][transform][normalized]")
     constexpr auto fn = PassThrough{};
     using type = sum<double, int>;
     static_assert(
-        std::same_as<typename _sum_invoke_result<_collapsing_sum_tag, decltype(fn), type &>::type, sum<double, int>>);
+        std::same_as<typename _sum_apply_result<_collapsing_sum_tag, decltype(fn), type &>::type, sum<double, int>>);
   }
 
   SECTION("one sum, one element only")
   {
     constexpr auto fn = [](sum_bool const &) -> sum<bool> && { throw 0; };
     using type = sum<sum_bool>;
-    static_assert(
-        std::same_as<typename _sum_invoke_result<_collapsing_sum_tag, decltype(fn), type &>::type, sum<bool>>);
+    static_assert(std::same_as<typename _sum_apply_result<_collapsing_sum_tag, decltype(fn), type &>::type, sum<bool>>);
   }
 
   SECTION("element and one sum with one element")
@@ -1273,7 +1271,7 @@ TEST_CASE("sum type collapsing", "[sum][transform][normalized]")
                                  [](sum_bool const &) -> sum<bool> && { throw 0; }};
     using type = sum<double, sum_bool>;
     static_assert(
-        std::same_as<typename _sum_invoke_result<_collapsing_sum_tag, decltype(fn), type &>::type, sum<bool, double>>);
+        std::same_as<typename _sum_apply_result<_collapsing_sum_tag, decltype(fn), type &>::type, sum<bool, double>>);
   }
 
   SECTION("one sum with two elements")
@@ -1281,7 +1279,7 @@ TEST_CASE("sum type collapsing", "[sum][transform][normalized]")
     constexpr auto fn = [](sum_bool_int const &) -> sum<bool, int> && { throw 0; };
     using type = sum<sum_bool_int>;
     static_assert(
-        std::same_as<typename _sum_invoke_result<_collapsing_sum_tag, decltype(fn), type &>::type, sum<bool, int>>);
+        std::same_as<typename _sum_apply_result<_collapsing_sum_tag, decltype(fn), type &>::type, sum<bool, int>>);
   }
 
   SECTION("sum with two elements and sum with one element")
@@ -1290,7 +1288,7 @@ TEST_CASE("sum type collapsing", "[sum][transform][normalized]")
                                  [](sum_bool const &) -> sum<bool> && { throw 0; }};
     using type = sum<sum_bool_int, sum_bool>;
     static_assert(
-        std::same_as<typename _sum_invoke_result<_collapsing_sum_tag, decltype(fn), type &>::type, sum<bool, int>>);
+        std::same_as<typename _sum_apply_result<_collapsing_sum_tag, decltype(fn), type &>::type, sum<bool, int>>);
   }
 
   SECTION("two sums with two elements and two elements")
@@ -1298,7 +1296,7 @@ TEST_CASE("sum type collapsing", "[sum][transform][normalized]")
     constexpr auto fn = overload{PassThrough{}, [](sum_double_int const &) -> sum<double, int> { throw 0; },
                                  [](sum_bool_int const &) -> sum<bool, int> const { throw 0; }};
     using type = sum<sum_bool_int, sum_double_int, double, int>;
-    static_assert(std::same_as<typename _sum_invoke_result<_collapsing_sum_tag, decltype(fn), type &>::type,
+    static_assert(std::same_as<typename _sum_apply_result<_collapsing_sum_tag, decltype(fn), type &>::type,
                                sum<bool, double, int>>);
   }
 
@@ -1435,7 +1433,7 @@ TEST_CASE("sum move and copy", "[sum][has_value][get_ptr]")
     {
       using T = sum<std::string>;
       T a{std::in_place_type<std::string>, "baz"};
-      CHECK(a.invoke([](auto &&i) { return i; }) == "baz");
+      CHECK(a.apply([](auto &&i) { return i; }) == "baz");
 
       static_assert([](auto &&a) { // OK copy
         return requires { static_cast<T>(FWD(a)); };
@@ -1451,18 +1449,18 @@ TEST_CASE("sum move and copy", "[sum][has_value][get_ptr]")
       }(std::move(std::as_const(a))));
 
       T b{a};
-      CHECK(a.invoke([](auto &&i) { return i; }) == "baz");
-      CHECK(b.invoke([](auto &&i) { return i; }) == "baz");
+      CHECK(a.apply([](auto &&i) { return i; }) == "baz");
+      CHECK(b.apply([](auto &&i) { return i; }) == "baz");
 
       T c{std::move(a)};
-      CHECK(c.invoke([](auto &&i) { return i; }) == "baz");
+      CHECK(c.apply([](auto &&i) { return i; }) == "baz");
     }
 
     SECTION("mixed with other types")
     {
       using T = sum<std::string, std::string_view>;
       T a{std::in_place_type<std::string>, "baz"};
-      CHECK(a.invoke([](auto &&i) { return std::string(i); }) == "baz");
+      CHECK(a.apply([](auto &&i) { return std::string(i); }) == "baz");
 
       static_assert([](auto &&a) { // OK copy
         return requires { static_cast<T>(FWD(a)); };
@@ -1478,11 +1476,11 @@ TEST_CASE("sum move and copy", "[sum][has_value][get_ptr]")
       }(std::move(std::as_const(a))));
 
       T b{a};
-      CHECK(a.invoke([](auto &&i) { return std::string(i); }) == "baz");
-      CHECK(b.invoke([](auto &&i) { return std::string(i); }) == "baz");
+      CHECK(a.apply([](auto &&i) { return std::string(i); }) == "baz");
+      CHECK(b.apply([](auto &&i) { return std::string(i); }) == "baz");
 
       T c{std::move(a)};
-      CHECK(c.invoke([](auto &&i) { return std::string(i); }) == "baz");
+      CHECK(c.apply([](auto &&i) { return std::string(i); }) == "baz");
     }
   }
 
@@ -1492,7 +1490,7 @@ TEST_CASE("sum move and copy", "[sum][has_value][get_ptr]")
     {
       using T = sum<CopyOnly>;
       T a{std::in_place_type<CopyOnly>, 12};
-      CHECK(a.invoke([](auto &&i) { return static_cast<int>(i); }) == 12);
+      CHECK(a.apply([](auto &&i) { return static_cast<int>(i); }) == 12);
 
       static_assert([](auto &&a) { // OK copy
         return requires { static_cast<T>(FWD(a)); };
@@ -1508,15 +1506,15 @@ TEST_CASE("sum move and copy", "[sum][has_value][get_ptr]")
       }(std::move(std::as_const(a))));
 
       T b{a};
-      CHECK(a.invoke([](auto &&i) { return static_cast<int>(i); }) == 12);
-      CHECK(b.invoke([](auto &&i) { return static_cast<int>(i); }) == 12);
+      CHECK(a.apply([](auto &&i) { return static_cast<int>(i); }) == 12);
+      CHECK(b.apply([](auto &&i) { return static_cast<int>(i); }) == 12);
     }
 
     SECTION("mixed with other types")
     {
       using T = fn::sum_for<CopyOnly, double, int>; // sum_for: canonical order is platform-specific
       T a{std::in_place_type<CopyOnly>, 12};
-      CHECK(a.invoke([](auto &&i) { return static_cast<int>(i); }) == 12);
+      CHECK(a.apply([](auto &&i) { return static_cast<int>(i); }) == 12);
 
       static_assert([](auto &&a) { // OK copy
         return requires { static_cast<T>(FWD(a)); };
@@ -1532,8 +1530,8 @@ TEST_CASE("sum move and copy", "[sum][has_value][get_ptr]")
       }(std::move(std::as_const(a))));
 
       T b{a};
-      CHECK(a.invoke([](auto &&i) { return static_cast<int>(i); }) == 12);
-      CHECK(b.invoke([](auto &&i) { return static_cast<int>(i); }) == 12);
+      CHECK(a.apply([](auto &&i) { return static_cast<int>(i); }) == 12);
+      CHECK(b.apply([](auto &&i) { return static_cast<int>(i); }) == 12);
     }
   }
 
@@ -1543,7 +1541,7 @@ TEST_CASE("sum move and copy", "[sum][has_value][get_ptr]")
     {
       using T = sum<MoveOnly>;
       T a{std::in_place_type<MoveOnly>, 12};
-      CHECK(a.invoke([](auto &&i) { return static_cast<int>(i); }) == 12);
+      CHECK(a.apply([](auto &&i) { return static_cast<int>(i); }) == 12);
 
       static_assert([](auto &&a) { // cannot copy from lvalue
         return not requires { static_cast<T>(FWD(a)); };
@@ -1559,15 +1557,15 @@ TEST_CASE("sum move and copy", "[sum][has_value][get_ptr]")
       }(std::move(std::as_const(a))));
 
       T b{std::move(a)};
-      CHECK(a.invoke([](auto &&i) { return static_cast<int>(i); }) == -1);
-      CHECK(b.invoke([](auto &&i) { return static_cast<int>(i); }) == 12);
+      CHECK(a.apply([](auto &&i) { return static_cast<int>(i); }) == -1);
+      CHECK(b.apply([](auto &&i) { return static_cast<int>(i); }) == 12);
     }
 
     SECTION("mixed with other types")
     {
       using T = fn::sum_for<MoveOnly, double, int>; // sum_for: canonical order is platform-specific
       T a{std::in_place_type<MoveOnly>, 12};
-      CHECK(a.invoke([](auto &&i) { return static_cast<int>(i); }) == 12);
+      CHECK(a.apply([](auto &&i) { return static_cast<int>(i); }) == 12);
 
       static_assert([](auto &&a) { // cannot copy from lvalue
         return not requires { static_cast<T>(FWD(a)); };
@@ -1583,8 +1581,8 @@ TEST_CASE("sum move and copy", "[sum][has_value][get_ptr]")
       }(std::move(std::as_const(a))));
 
       T b{std::move(a)};
-      CHECK(a.invoke([](auto &&i) { return static_cast<int>(i); }) == -1);
-      CHECK(b.invoke([](auto &&i) { return static_cast<int>(i); }) == 12);
+      CHECK(a.apply([](auto &&i) { return static_cast<int>(i); }) == -1);
+      CHECK(b.apply([](auto &&i) { return static_cast<int>(i); }) == 12);
     }
   }
 
@@ -1594,7 +1592,7 @@ TEST_CASE("sum move and copy", "[sum][has_value][get_ptr]")
     {
       using T = sum<NonCopyable>;
       T a{std::in_place_type<NonCopyable>, 12};
-      CHECK(a.invoke([](auto &&i) { return static_cast<int>(i); }) == 12);
+      CHECK(a.apply([](auto &&i) { return static_cast<int>(i); }) == 12);
 
       static_assert([](auto &&a) { // cannot copy from lvalue
         return not requires { static_cast<T>(FWD(a)); };
@@ -1614,7 +1612,7 @@ TEST_CASE("sum move and copy", "[sum][has_value][get_ptr]")
     {
       using T = fn::sum_for<NonCopyable, double, int>; // sum_for: canonical order is platform-specific
       T a{std::in_place_type<NonCopyable>, 12};
-      CHECK(a.invoke([](auto &&i) { return static_cast<int>(i); }) == 12);
+      CHECK(a.apply([](auto &&i) { return static_cast<int>(i); }) == 12);
 
       static_assert([](auto &&a) { // cannot copy from lvalue
         return not requires { static_cast<T>(FWD(a)); };
@@ -1646,8 +1644,8 @@ TEST_CASE("sum move and copy", "[sum][has_value][get_ptr]")
 
     sum<MoveOnly> a{std::in_place_type<MoveOnly>, 12};
     fn::sum_for<MoveOnly, int> b{std::move(a)};
-    CHECK(b.invoke([](auto &&i) { return static_cast<int>(i); }) == 12);
-    CHECK(a.invoke([](auto &&i) { return static_cast<int>(i); }) == -1); // moved from
+    CHECK(b.apply([](auto &&i) { return static_cast<int>(i); }) == 12);
+    CHECK(a.apply([](auto &&i) { return static_cast<int>(i); }) == -1); // moved from
   }
 
   SECTION("noexcept")
@@ -1734,16 +1732,16 @@ TEST_CASE("sum assignment", "[sum][assignment]")
 
     T a{std::in_place_type<Tracked>, 7};
     a = T{std::in_place_type<Tracked>, 5};
-    CHECK(a.invoke(probe) == 5); // assigned, in place
+    CHECK(a.apply(probe) == 5); // assigned, in place
 
     a = T{12}; // a different alternative is replaced by construction ...
     a = T{std::in_place_type<Tracked>, 3};
-    CHECK(a.invoke(probe) == -3); // ... so this Tracked was constructed, not assigned
+    CHECK(a.apply(probe) == -3); // ... so this Tracked was constructed, not assigned
 
     static_assert([] {
       T a{std::in_place_type<Tracked>, 7};
       a = T{std::in_place_type<Tracked>, 5};
-      return a.invoke([](auto const &t) {
+      return a.apply([](auto const &t) {
         if constexpr (std::is_same_v<std::remove_cvref_t<decltype(t)>, Tracked>)
           return t.assigned && t.v == 5;
         else
@@ -2110,18 +2108,18 @@ TEST_CASE("sum assignment", "[sum][assignment]")
       sum<SnapAssign> a{SnapAssign{7}};
       sum<SnapAssign> const bad{SnapAssign{0}};
       CHECK_THROWS_AS(a = bad, std::runtime_error);
-      CHECK(a.invoke(value) == 7); // restored
+      CHECK(a.apply(value) == 7); // restored
 
       // the same arm, completing
       sum<SnapAssign> const good{SnapAssign{5}};
       a = good;
-      CHECK(a.invoke(value) == 5);
+      CHECK(a.apply(value) == 5);
 
       static_assert([] {
         sum<SnapAssign> a{SnapAssign{7}};
         sum<SnapAssign> const good{SnapAssign{5}};
         a = good; // the snapshot arm, in a constant expression
-        return a.invoke([](SnapAssign const &t) { return t.v; }) == 5;
+        return a.apply([](SnapAssign const &t) { return t.v; }) == 5;
       }());
     }
 
@@ -2156,17 +2154,17 @@ TEST_CASE("sum assignment", "[sum][assignment]")
       sum<TempAssign> a{TempAssign{7}};
       sum<TempAssign> const bad{TempAssign{0}};
       CHECK_THROWS_AS(a = bad, std::runtime_error); // the copy into the temporary throws
-      CHECK(a.invoke(value) == 7);                  // untouched
+      CHECK(a.apply(value) == 7);                   // untouched
 
       sum<TempAssign> const good{TempAssign{5}};
       a = good;
-      CHECK(a.invoke(value) == 5);
+      CHECK(a.apply(value) == 5);
 
       static_assert([] {
         sum<TempAssign> a{TempAssign{7}};
         sum<TempAssign> const good{TempAssign{5}};
         a = good; // the temporary arm, in a constant expression
-        return a.invoke([](TempAssign const &t) { return t.v; }) == 5;
+        return a.apply([](TempAssign const &t) { return t.v; }) == 5;
       }());
     }
 
@@ -2202,17 +2200,17 @@ TEST_CASE("sum assignment", "[sum][assignment]")
       M m{std::in_place_type<ThrowingMove>, 7}; // in place: its move would throw
       M const bad_copy{ThrowingCopy{0}};
       CHECK_THROWS_AS(m = bad_copy, std::runtime_error); // the copy into the temporary throws
-      CHECK(m.invoke(value) == 7);                       // ... and the ThrowingMove is still there
+      CHECK(m.apply(value) == 7);                        // ... and the ThrowingMove is still there
 
       M const good{std::in_place_type<ThrowingMove>, 3};
       m = good; // the same alternative: assigned in place, its throwing move never used
-      CHECK(m.invoke(value) == 3);
+      CHECK(m.apply(value) == 3);
 
       // ... and the same temporary arm run to completion: a throwing-path test alone never lets
       // the replacement finish, so this copy succeeds and the old alternative is destroyed
       M const good_copy{ThrowingCopy{5}};
       m = good_copy;
-      CHECK(m.invoke(value) == 5);
+      CHECK(m.apply(value) == 5);
     }
   }
 

--- a/tests/fn/transform.cpp
+++ b/tests/fn/transform.cpp
@@ -43,9 +43,9 @@ TEST_CASE("transform", "[transform][expected][expected_value][pack]")
   static_assert(is::invocable_with_any([](int) -> int { throw 0; }));                        // allow copy
   static_assert(is::invocable_with_any([](unsigned) -> int { throw 0; }));                   // allow conversion
   static_assert(is::invocable_with_any([](int const &) -> int { throw 0; }));                // binds to const ref
-  static_assert(is::invocable<lvalue>([](int &) -> int { throw 0; }));                       // binds to lvalue
-  static_assert(is::invocable<rvalue, prvalue>([](int &&) -> int { throw 0; }));             // can move
-  static_assert(is::invocable<rvalue, crvalue>([](int const &&) -> int { throw 0; }));       // binds to const rvalue
+  static_assert(is::applicable<lvalue>([](int &) -> int { throw 0; }));                      // binds to lvalue
+  static_assert(is::applicable<rvalue, prvalue>([](int &&) -> int { throw 0; }));            // can move
+  static_assert(is::applicable<rvalue, crvalue>([](int const &&) -> int { throw 0; }));      // binds to const rvalue
   static_assert(is::not_invocable<clvalue, crvalue, cvalue>([](int &) -> int { throw 0; })); // cannot remove const
   static_assert(is::not_invocable<rvalue>([](int &) -> int { throw 0; }));                   // disallow bind
   static_assert(is::not_invocable<lvalue, clvalue, crvalue, cvalue>([](int &&) -> int { throw 0; })); // cannot move
@@ -365,9 +365,9 @@ TEST_CASE("transform", "[transform][optional][pack]")
   static_assert(is::invocable_with_any([](int) -> int { throw 0; }));                        // allow copy
   static_assert(is::invocable_with_any([](unsigned) -> int { throw 0; }));                   // allow conversion
   static_assert(is::invocable_with_any([](int const &) -> int { throw 0; }));                // binds to const ref
-  static_assert(is::invocable<lvalue>([](int &) -> int { throw 0; }));                       // binds to lvalue
-  static_assert(is::invocable<rvalue, prvalue>([](int &&) -> int { throw 0; }));             // can move
-  static_assert(is::invocable<rvalue, crvalue>([](int const &&) -> int { throw 0; }));       // binds to const rvalue
+  static_assert(is::applicable<lvalue>([](int &) -> int { throw 0; }));                      // binds to lvalue
+  static_assert(is::applicable<rvalue, prvalue>([](int &&) -> int { throw 0; }));            // can move
+  static_assert(is::applicable<rvalue, crvalue>([](int const &&) -> int { throw 0; }));      // binds to const rvalue
   static_assert(is::not_invocable<clvalue, crvalue, cvalue>([](int &) -> int { throw 0; })); // cannot remove const
   static_assert(is::not_invocable<rvalue>([](int &) -> int { throw 0; }));                   // disallow bind
   static_assert(is::not_invocable<lvalue, clvalue, crvalue, cvalue>([](int &&) -> int { throw 0; })); // cannot move
@@ -576,13 +576,13 @@ TEST_CASE("transform choice", "[transform][choice]")
   constexpr auto fnXabs = [](int i) -> Xint { return Xint{std::abs(8 - i)}; };
 
   static_assert(is::invocable_with_any(fnValue));
-  static_assert(is::invocable_with_any([](int) -> operand_t { throw 0; }));                   // allow copy
-  static_assert(is::invocable_with_any([](unsigned) -> operand_t { throw 0; }));              // allow conversion
-  static_assert(is::invocable_with_any([](int) -> operand_other_t { throw 0; }));             // allow conversion
-  static_assert(is::invocable_with_any([](int const &) -> operand_t { throw 0; }));           // binds to const ref
-  static_assert(is::invocable<lvalue>([](auto &) -> operand_t { throw 0; }));                 // binds to lvalue
-  static_assert(is::invocable<rvalue, prvalue>([](auto &&) -> operand_t { throw 0; }));       // can move
-  static_assert(is::invocable<rvalue, crvalue>([](auto const &&) -> operand_t { throw 0; })); // binds to const rvalue
+  static_assert(is::invocable_with_any([](int) -> operand_t { throw 0; }));                    // allow copy
+  static_assert(is::invocable_with_any([](unsigned) -> operand_t { throw 0; }));               // allow conversion
+  static_assert(is::invocable_with_any([](int) -> operand_other_t { throw 0; }));              // allow conversion
+  static_assert(is::invocable_with_any([](int const &) -> operand_t { throw 0; }));            // binds to const ref
+  static_assert(is::applicable<lvalue>([](auto &) -> operand_t { throw 0; }));                 // binds to lvalue
+  static_assert(is::applicable<rvalue, prvalue>([](auto &&) -> operand_t { throw 0; }));       // can move
+  static_assert(is::applicable<rvalue, crvalue>([](auto const &&) -> operand_t { throw 0; })); // binds to const rvalue
 
   constexpr auto fnLvalue = fn::overload{[](bool &) -> operand_t { throw 0; },   //
                                          [](double &) -> operand_t { throw 0; }, //
@@ -699,32 +699,32 @@ constexpr auto fn_int_rvalue = [](int &&) -> int { throw 0; };
 
 // clang-format off
 // The callback returns a plain value, which must convert into the operand's own monad.
-static_assert(invocable_transform<decltype(fn_int<int>), expected<int, Error>>);
-static_assert(invocable_transform<decltype(fn_int<Value>), expected<int, Error>>);              // may change the type
-static_assert(not invocable_transform<decltype(fn_int<int>), expected<Value, Error>>);          // wrong parameter type
-static_assert(invocable_transform<decltype(fn_generic<int>), expected<Value, Error>>);
-static_assert(invocable_transform<decltype(fn_generic<int>), expected<void, Error>>);           // void: nullary callback
-static_assert(not invocable_transform<decltype(fn_int<int>), expected<void, Error>>);           // void: unary is bad arity
-static_assert(invocable_transform<decltype(fn_int<void>), expected<int, Error>>); // a void return transforms the value
+static_assert(applicable_transform<decltype(fn_int<int>), expected<int, Error>>);
+static_assert(applicable_transform<decltype(fn_int<Value>), expected<int, Error>>);              // may change the type
+static_assert(not applicable_transform<decltype(fn_int<int>), expected<Value, Error>>);          // wrong parameter type
+static_assert(applicable_transform<decltype(fn_generic<int>), expected<Value, Error>>);
+static_assert(applicable_transform<decltype(fn_generic<int>), expected<void, Error>>);           // void: nullary callback
+static_assert(not applicable_transform<decltype(fn_int<int>), expected<void, Error>>);           // void: unary is bad arity
+static_assert(applicable_transform<decltype(fn_int<void>), expected<int, Error>>); // a void return transforms the value
                                                                                   // side to expected<void, Error>
-static_assert(invocable_transform<decltype(fn_int<int>), optional<int>>);
-static_assert(not invocable_transform<decltype(fn_int<int>), optional<Value>>);                 // wrong parameter type
-static_assert(invocable_transform<decltype(fn_generic<int>), optional<Value>>);
-static_assert(not invocable_transform<decltype(fn_int<void>), optional<int>>);                 // void return: no optional<void>
-static_assert(invocable_transform<decltype(fn_generic<int>), choice<int>>);
-static_assert(not invocable_transform<decltype(fn_int<int>), choice<Value>>);            // must serve every alternative
-static_assert(not invocable_transform<decltype(fn_int<void>), choice<int>>);             // a void result has no place in a choice
-static_assert(not invocable_transform<decltype(fn_int_lvalue), expected<int, Error>>);   // cannot bind temporary to lvalue
-static_assert(invocable_transform<decltype(fn_int_lvalue), expected<int, Error> &>);
-static_assert(invocable_transform<decltype(fn_int_rvalue), expected<int, Error>>);
-static_assert(not invocable_transform<decltype(fn_int_rvalue), expected<int, Error> &>); // cannot bind lvalue to rvalue-ref
+static_assert(applicable_transform<decltype(fn_int<int>), optional<int>>);
+static_assert(not applicable_transform<decltype(fn_int<int>), optional<Value>>);                 // wrong parameter type
+static_assert(applicable_transform<decltype(fn_generic<int>), optional<Value>>);
+static_assert(not applicable_transform<decltype(fn_int<void>), optional<int>>);                 // void return: no optional<void>
+static_assert(applicable_transform<decltype(fn_generic<int>), choice<int>>);
+static_assert(not applicable_transform<decltype(fn_int<int>), choice<Value>>);            // must serve every alternative
+static_assert(not applicable_transform<decltype(fn_int<void>), choice<int>>);             // a void result has no place in a choice
+static_assert(not applicable_transform<decltype(fn_int_lvalue), expected<int, Error>>);   // cannot bind temporary to lvalue
+static_assert(applicable_transform<decltype(fn_int_lvalue), expected<int, Error> &>);
+static_assert(applicable_transform<decltype(fn_int_rvalue), expected<int, Error>>);
+static_assert(not applicable_transform<decltype(fn_int_rvalue), expected<int, Error> &>); // cannot bind lvalue to rvalue-ref
 
 // A sum value dispatches through sum::transform, which requires the callback to cover ALL alternatives.
-static_assert(invocable_transform<decltype(fn_generic<int>), expected<sum_for<Value, int>, Error>>);
-static_assert(not invocable_transform<decltype(fn_int<int>), expected<sum_for<Value, int>, Error>>); // int alone is not exhaustive
-static_assert(invocable_transform<decltype(fn_generic<int>), optional<sum_for<Value, int>>>);
-static_assert(not invocable_transform<decltype(fn_int<int>), optional<sum_for<Value, int>>>);
-static_assert(not invocable_transform<decltype(fn_generic<void>), expected<sum_for<Value, int>, Error>>); // a void result has no place in a sum
-static_assert(not invocable_transform<decltype(fn_generic<void>), optional<sum_for<Value, int>>>);
+static_assert(applicable_transform<decltype(fn_generic<int>), expected<sum_for<Value, int>, Error>>);
+static_assert(not applicable_transform<decltype(fn_int<int>), expected<sum_for<Value, int>, Error>>); // int alone is not exhaustive
+static_assert(applicable_transform<decltype(fn_generic<int>), optional<sum_for<Value, int>>>);
+static_assert(not applicable_transform<decltype(fn_int<int>), optional<sum_for<Value, int>>>);
+static_assert(not applicable_transform<decltype(fn_generic<void>), expected<sum_for<Value, int>, Error>>); // a void result has no place in a sum
+static_assert(not applicable_transform<decltype(fn_generic<void>), optional<sum_for<Value, int>>>);
 // clang-format on
 } // namespace fn

--- a/tests/fn/transform_error.cpp
+++ b/tests/fn/transform_error.cpp
@@ -41,13 +41,13 @@ TEST_CASE("transform_error", "[transform_error][expected]")
   constexpr auto fnVoid = [](Error) {};
 
   static_assert(is::invocable_with_any(fnError));
-  static_assert(is::invocable_with_any([](auto...) -> Error { throw 0; }));                // allow generic call
-  static_assert(is::invocable_with_any([](Error) -> Error { throw 0; }));                  // allow copy
-  static_assert(is::invocable_with_any([](std::string_view) -> Error { throw 0; }));       // allow conversion
-  static_assert(is::invocable_with_any([](Error const &) -> Error { throw 0; }));          // binds to const ref
-  static_assert(is::invocable<lvalue>([](Error &) -> Error { throw 0; }));                 // binds to lvalue
-  static_assert(is::invocable<rvalue, prvalue>([](Error &&) -> Error { throw 0; }));       // can move
-  static_assert(is::invocable<rvalue, crvalue>([](Error const &&) -> Error { throw 0; })); // binds to const rvalue
+  static_assert(is::invocable_with_any([](auto...) -> Error { throw 0; }));                 // allow generic call
+  static_assert(is::invocable_with_any([](Error) -> Error { throw 0; }));                   // allow copy
+  static_assert(is::invocable_with_any([](std::string_view) -> Error { throw 0; }));        // allow conversion
+  static_assert(is::invocable_with_any([](Error const &) -> Error { throw 0; }));           // binds to const ref
+  static_assert(is::applicable<lvalue>([](Error &) -> Error { throw 0; }));                 // binds to lvalue
+  static_assert(is::applicable<rvalue, prvalue>([](Error &&) -> Error { throw 0; }));       // can move
+  static_assert(is::applicable<rvalue, crvalue>([](Error const &&) -> Error { throw 0; })); // binds to const rvalue
   static_assert(is::not_invocable<clvalue, crvalue, cvalue>([](Error &) -> Error { throw 0; })); // cannot remove const
   static_assert(is::not_invocable<rvalue>([](Error &) -> Error { throw 0; }));                   // disallow bind
   static_assert(is::not_invocable<lvalue, clvalue, crvalue, cvalue>([](Error &&) -> Error { throw 0; })); // cannot move
@@ -261,21 +261,21 @@ constexpr auto fn_Error_rvalue = [](Error &&) -> Xerror { throw 0; };
 
 // clang-format off
 // The callback maps the error; what it returns must convert into an unexpected.
-static_assert(invocable_transform_error<decltype(fn_Error<Xerror>), expected<int, Error>>);
-static_assert(invocable_transform_error<decltype(fn_Error<Xerror>), expected<void, Error>>);      // void value is fine
-static_assert(invocable_transform_error<decltype(fn_generic<Xerror>), expected<Value, Error>>);
-static_assert(not invocable_transform_error<decltype(fn_Error<Xerror>), expected<int, Value>>);   // wrong parameter type
-static_assert(not invocable_transform_error<decltype(fn_Error<void>), expected<int, Error>>);     // no unexpected<void> to convert to
-static_assert(not invocable_transform_error<decltype(fn_generic<Xerror>), optional<int>>);        // optional has no error to map
-static_assert(not invocable_transform_error<decltype(fn_generic<Xerror>), choice<int>>);          // neither has choice
-static_assert(not invocable_transform_error<decltype(fn_Error_lvalue), expected<int, Error>>);    // cannot bind temporary to lvalue
-static_assert(invocable_transform_error<decltype(fn_Error_lvalue), expected<int, Error> &>);
-static_assert(invocable_transform_error<decltype(fn_Error_rvalue), expected<int, Error>>);
-static_assert(not invocable_transform_error<decltype(fn_Error_rvalue), expected<int, Error> &>);  // cannot bind lvalue to rvalue-ref
+static_assert(applicable_transform_error<decltype(fn_Error<Xerror>), expected<int, Error>>);
+static_assert(applicable_transform_error<decltype(fn_Error<Xerror>), expected<void, Error>>);      // void value is fine
+static_assert(applicable_transform_error<decltype(fn_generic<Xerror>), expected<Value, Error>>);
+static_assert(not applicable_transform_error<decltype(fn_Error<Xerror>), expected<int, Value>>);   // wrong parameter type
+static_assert(not applicable_transform_error<decltype(fn_Error<void>), expected<int, Error>>);     // no unexpected<void> to convert to
+static_assert(not applicable_transform_error<decltype(fn_generic<Xerror>), optional<int>>);        // optional has no error to map
+static_assert(not applicable_transform_error<decltype(fn_generic<Xerror>), choice<int>>);          // neither has choice
+static_assert(not applicable_transform_error<decltype(fn_Error_lvalue), expected<int, Error>>);    // cannot bind temporary to lvalue
+static_assert(applicable_transform_error<decltype(fn_Error_lvalue), expected<int, Error> &>);
+static_assert(applicable_transform_error<decltype(fn_Error_rvalue), expected<int, Error>>);
+static_assert(not applicable_transform_error<decltype(fn_Error_rvalue), expected<int, Error> &>);  // cannot bind lvalue to rvalue-ref
 
 // A sum error dispatches through sum::transform - the callback must cover ALL alternatives.
-static_assert(invocable_transform_error<decltype(fn_generic<Xerror>), expected<int, sum_for<Error, Value>>>);
-static_assert(not invocable_transform_error<decltype(fn_Error<Xerror>), expected<int, sum_for<Error, Value>>>); // not exhaustive
-static_assert(not invocable_transform_error<decltype(fn_generic<void>), expected<int, sum_for<Error, Value>>>); // a void result has no place in a sum
+static_assert(applicable_transform_error<decltype(fn_generic<Xerror>), expected<int, sum_for<Error, Value>>>);
+static_assert(not applicable_transform_error<decltype(fn_Error<Xerror>), expected<int, sum_for<Error, Value>>>); // not exhaustive
+static_assert(not applicable_transform_error<decltype(fn_generic<void>), expected<int, sum_for<Error, Value>>>); // a void result has no place in a sum
 // clang-format on
 } // namespace fn

--- a/tests/fn/value_or.cpp
+++ b/tests/fn/value_or.cpp
@@ -216,8 +216,8 @@ TEST_CASE("value_or constraints", "[value_or][constraints]")
   // latter would accept every category below, including the two that would have to copy.
   using move_only_t = fn::expected<helper_move_only, Error>;
   using is = monadic_static_check<value_or_t, move_only_t>;
-  static_assert(is::invocable<rvalue, prvalue>(1));     // moved
-  static_assert(is::invocable<crvalue, cvalue>(1));     // const-moved
+  static_assert(is::applicable<rvalue, prvalue>(1));    // moved
+  static_assert(is::applicable<crvalue, cvalue>(1));    // const-moved
   static_assert(is::not_invocable<lvalue, clvalue>(1)); // would have to copy
 
   // A reference optional binds its referent rather than carrying it - so an immovable referent is
@@ -225,9 +225,9 @@ TEST_CASE("value_or constraints", "[value_or][constraints]")
   // type alone cannot answer this: it is the referent, which a prvalue constructs happily.
   using ref_t = fn::optional<int &>;
   static_assert(std::is_constructible_v<ref_t::value_type, int>);
-  static_assert(not invocable_value_or<ref_t &, int>); // a temporary to bind to: rejected
-  static_assert(invocable_value_or<ref_t &, int &>);
-  static_assert(invocable_value_or<fn::optional<helper_immovable &> &, helper_immovable &>);
+  static_assert(not applicable_value_or<ref_t &, int>); // a temporary to bind to: rejected
+  static_assert(applicable_value_or<ref_t &, int &>);
+  static_assert(applicable_value_or<fn::optional<helper_immovable &> &, helper_immovable &>);
   SUCCEED();
 }
 
@@ -239,15 +239,15 @@ struct Value final {};
 
 // clang-format off
 // Not a callable verb: the arguments must construct the operand's own value type.
-static_assert(invocable_value_or<expected<int, Error>, int>);
-static_assert(invocable_value_or<expected<int, Error>, unsigned>);                 // conversion is enough
-static_assert(invocable_value_or<expected<helper_move_only, Error>, int, int>);    // multi-argument construction
-static_assert(not invocable_value_or<expected<int, Error>, char const *>);         // no conversion found
-static_assert(not invocable_value_or<expected<int, Error>, int, int>);             // too many initialisers
-static_assert(not invocable_value_or<expected<Value, Error>, int>);                // wrong type
-static_assert(not invocable_value_or<expected<void, Error>, int>);                 // void has no value to fall back to
-static_assert(invocable_value_or<optional<int>, int>);
-static_assert(not invocable_value_or<optional<int>, char const *>);
-static_assert(not invocable_value_or<choice<int>, int>);                           // no choice disjunct
+static_assert(applicable_value_or<expected<int, Error>, int>);
+static_assert(applicable_value_or<expected<int, Error>, unsigned>);                 // conversion is enough
+static_assert(applicable_value_or<expected<helper_move_only, Error>, int, int>);    // multi-argument construction
+static_assert(not applicable_value_or<expected<int, Error>, char const *>);         // no conversion found
+static_assert(not applicable_value_or<expected<int, Error>, int, int>);             // too many initialisers
+static_assert(not applicable_value_or<expected<Value, Error>, int>);                // wrong type
+static_assert(not applicable_value_or<expected<void, Error>, int>);                 // void has no value to fall back to
+static_assert(applicable_value_or<optional<int>, int>);
+static_assert(not applicable_value_or<optional<int>, char const *>);
+static_assert(not applicable_value_or<choice<int>, int>);                           // no choice disjunct
 // clang-format on
 } // namespace fn

--- a/tests/util/static_check.hpp
+++ b/tests/util/static_check.hpp
@@ -41,7 +41,7 @@ template <typename OperandType> struct prvalue {
 
 struct static_check {
   template <typename CheckType> struct bind {
-    [[nodiscard]] static constexpr auto invocable(auto &&...fns) noexcept -> bool
+    [[nodiscard]] static constexpr auto applicable(auto &&...fns) noexcept -> bool
       requires(std::is_invocable_r_v<bool, CheckType, decltype(fns)...>)
     {
       return CheckType()(std::forward<decltype(fns)>(fns)...);
@@ -50,16 +50,16 @@ struct static_check {
     [[nodiscard]] static constexpr auto not_invocable(auto &&...fns) noexcept -> bool
       requires(std::is_invocable_r_v<bool, CheckType, decltype(fns)...>)
     {
-      return not invocable(std::forward<decltype(fns)>(fns)...);
+      return not applicable(std::forward<decltype(fns)>(fns)...);
     }
   };
 };
 
 template <typename OperandType, template <typename> typename CommandType> struct static_check_with_value_categories {
   template <template <typename> typename... Categories>
-  [[nodiscard]] static constexpr auto invocable(auto &&...fns) noexcept -> bool
+  [[nodiscard]] static constexpr auto applicable(auto &&...fns) noexcept -> bool
   {
-    return (static_check::bind<CommandType<typename Categories<OperandType>::type>>::invocable(
+    return (static_check::bind<CommandType<typename Categories<OperandType>::type>>::applicable(
                 std::forward<decltype(fns)>(fns)...)
             && ...);
   }
@@ -74,7 +74,7 @@ template <typename OperandType, template <typename> typename CommandType> struct
 
   [[nodiscard]] static constexpr auto invocable_with_any(auto &&...fns) noexcept -> bool
   {
-    return invocable<lvalue, cvalue, rvalue, clvalue, crvalue, prvalue>(std::forward<decltype(fns)>(fns)...);
+    return applicable<lvalue, cvalue, rvalue, clvalue, crvalue, prvalue>(std::forward<decltype(fns)>(fns)...);
   }
 
   [[nodiscard]] static constexpr auto not_invocable_with_any(auto &&...fns) noexcept -> bool
@@ -123,9 +123,9 @@ public:
   }
 
   template <template <typename> typename... Categories>
-  [[nodiscard]] static constexpr auto invocable(auto &&...fns) noexcept -> bool
+  [[nodiscard]] static constexpr auto applicable(auto &&...fns) noexcept -> bool
   {
-    return bind::template invocable<Categories...>(std::forward<decltype(fns)>(fns)...);
+    return bind::template applicable<Categories...>(std::forward<decltype(fns)>(fns)...);
   }
 
   template <template <typename> typename... Categories>


### PR DESCRIPTION
Closes #84

The multidispatch verb is higher-level than `std::invoke` — the implementation reaches `std::invoke` at the bottom of its own dispatch — and closest to `std::apply` in mechanism: unpack packs, dispatch sums, fold several operands into one. The name follows the mechanism, together with its whole vocabulary, which lands on the standard's own: C++26's P1317R2 gave `std::apply` the `apply_result`/`is_applicable` trait family (#325 polyfilled it), and `fn`'s variadic, sum-aware traits now extend those names, exactly as `fn::apply` extends the verb.

**Commit 1 — the rename.** `fn::apply`/`apply_r` and the members on `sum`, `choice` and `pack`; the `apply_result(_t)`, `is_applicable(_v)`, `is_applicable_r(_v)`, `is_nothrow_applicable[_r](_v)` traits; the `applicable`, `regular_applicable`, `typelist_applicable(_r)` and per-verb (`applicable_and_then`, ...) concepts; the detail engine (`_apply_detail`, `_apply`, `_apply_r`, the trait machinery) and the value-path union dispatch (`apply_variadic_union`, which routes through the engine). Names that do not multidispatch keep theirs: the type-indexed internals (`invoke_type_variadic_union`, `_invoke_type`, `_is_type_invocable`, `sum::_invoke` — #268's future surface) and true `std::invoke`-level names (`monadic_invocable` probes `std::invocable` of the functor protocol's `apply` hook, whose name now reads rather well).

**Commit 2 — `fn::apply` serves `std::apply`'s own domain.** A lone tuple-like argument unpacks through `pfn::apply` itself (and an element-level mirror through `pfn::invoke_r` for `apply_r`), so `fn::apply` and `pfn::apply` agree on the entire std domain by shared implementation — the pfn validation TU polices that core for both, and switching a call site from `pfn::apply` to `fn::apply` changes nothing until packs or sums enter. The design points, each pinned by a test:
- **std's meaning prevails on std's domain**: where both unpacking and pass-whole are viable (a generic callable), the non-variadic arm wins partial ordering and unpacks, as `std::apply` would — an intentional behaviour change for generic callables over tuples, recorded in the CHANGELOG;
- **pass-whole survives** where unpacking is not viable (a callable taking the whole tuple), and a tuple-like among further arguments still passes whole — the arm is exactly `std::apply`'s shape, one tuple-like argument and nothing else;
- **elements are terminal**: a `sum` element of a tuple is handed over whole, never dispatched — re-entering fn dispatch would diverge from `pfn::apply` on the shared domain;
- **`fn::pack` is not tuple-like** ([tuple.like] is an enumeration): packs keep fn's own dispatch.

Because every trait and concept probes the dispatch itself (probe==deed), the whole trait surface extended coherently with the one new overload; the negative `is_applicable_r` probe pins the constraint that keeps a non-viable call a substitution failure rather than a noexcept-specifier hard error.

Tests are the renamed suite (Catch2 counts unchanged for the pure-rename TUs) plus a new tuple-like battery in `tests/fn/functional.cpp` covering the four design points, with runtime and constexpr twins. Verified on gcc 16 and clang 22 (libc++), Debug and Release, C++20 and C++23-validation, plus a local MSVC 2022 build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
