### PR TITLE
Reject a nested pack element in pack

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,8 +2,9 @@
 
 Design history of libfn, newest first. The living documents — [README.md](README.md), [CONTRIBUTING.md](CONTRIBUTING.md), [docs/](docs/) — describe only the present state of the design; when a decision makes an earlier idea obsolete, this file is where the transition is recorded and explained.
 
-## `pack` hands elements over whole — 16 July 2026
+## `pack` splices in every append spelling, and hands elements over whole — 16 July 2026
 
+- **The tag form of `append` now constructs the named pack from its arguments and splices it** ([#328](https://github.com/libfn/functional/issues/328)): appending a pack means concatenation however it is spelled, joining the two spellings that always spliced — a deduced pack value, and a tag with a prebuilt matching pack, the route `operator&`'s fold takes. The tag spelling costs one relocation per element more than appending the elements directly; the result never differs. A tag that merely names an ill-formed pack answers instead of hard-erroring.
 - **Pack machinery consumes values through `INVOKE`, never through `fn::apply`'s engine.** Since the tuple-like arm (below), routing the splice relocation and `pack::apply`'s elements through the engine gave a *lone* tuple-like element `std::apply`'s meaning: appending a pack whose only element is a `std::tuple` was a hard error, and `pack<std::tuple<A, B>>::apply` unpacked the element that the same call hands over whole whenever a sibling or extra argument accompanies it. Elements are terminal, and the engine's unpacking belongs to the deliberate elimination boundary alone — `std::invoke` is useful exactly as defined, which is what #84 renamed the multidispatch *away* from.
 
 ## `pack` rejects a nested `pack` element — 16 July 2026

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 Design history of libfn, newest first. The living documents — [README.md](README.md), [CONTRIBUTING.md](CONTRIBUTING.md), [docs/](docs/) — describe only the present state of the design; when a decision makes an earlier idea obsolete, this file is where the transition is recorded and explained.
 
+## `pack` rejects a nested `pack` element — 16 July 2026
+
+- **The element mandate that has always rejected a `sum` now also rejects a `pack`** ([#328](https://github.com/libfn/functional/issues/328)). A nested pack was representable and incoherent: `apply` flattened it (a callback over `pack<pack<A, B>, C>` saw three arguments) while the tuple protocol preserved it (`tuple_size` answered two) — and since the tuple-like arm below, the same position answered differently by kind, an own `pack` element flattening where a `std::tuple` element passes whole. The product is associative, so the nested spelling was a non-canonical duplicate of the flat one — the same self-normalization `sum` has always applied to itself. Nothing is lost: appending a whole pack has always spliced, and grouped data keeps its home in an opaque atom — `std::tuple`, `std::array`, a user wrapper, or `choice`, which the algebra never opens.
+
 ## `invoke` became `apply` — 15 July 2026
 
 - **The multidispatch verb and its whole vocabulary renamed** ([#84](https://github.com/libfn/functional/issues/84)): `fn::apply`/`apply_r`, the members on `sum`, `choice` and `pack`, the `apply_result`/`is_applicable` traits and the `applicable`/`typelist_applicable` concepts. The dispatch — unpack packs, dispatch sums, fold several operands into one — extends `std::apply`'s mechanism, not `std::invoke`'s: the implementation reaches `std::invoke` at the bottom, which is precisely why the old name overpromised. Type-indexed internals and true `std::invoke`-level names keep theirs.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 Design history of libfn, newest first. The living documents — [README.md](README.md), [CONTRIBUTING.md](CONTRIBUTING.md), [docs/](docs/) — describe only the present state of the design; when a decision makes an earlier idea obsolete, this file is where the transition is recorded and explained.
 
+## `pack` hands elements over whole — 16 July 2026
+
+- **Pack machinery consumes values through `INVOKE`, never through `fn::apply`'s engine.** Since the tuple-like arm (below), routing the splice relocation and `pack::apply`'s elements through the engine gave a *lone* tuple-like element `std::apply`'s meaning: appending a pack whose only element is a `std::tuple` was a hard error, and `pack<std::tuple<A, B>>::apply` unpacked the element that the same call hands over whole whenever a sibling or extra argument accompanies it. Elements are terminal, and the engine's unpacking belongs to the deliberate elimination boundary alone — `std::invoke` is useful exactly as defined, which is what #84 renamed the multidispatch *away* from.
+
 ## `pack` rejects a nested `pack` element — 16 July 2026
 
 - **The element mandate that has always rejected a `sum` now also rejects a `pack`** ([#328](https://github.com/libfn/functional/issues/328)). A nested pack was representable and incoherent: `apply` flattened it (a callback over `pack<pack<A, B>, C>` saw three arguments) while the tuple protocol preserved it (`tuple_size` answered two) — and since the tuple-like arm below, the same position answered differently by kind, an own `pack` element flattening where a `std::tuple` element passes whole. The product is associative, so the nested spelling was a non-canonical duplicate of the flat one — the same self-normalization `sum` has always applied to itself. Nothing is lost: appending a whole pack has always spliced, and grouped data keeps its home in an opaque atom — `std::tuple`, `std::array`, a user wrapper, or `choice`, which the algebra never opens.

--- a/include/fn/detail/pack_impl.hpp
+++ b/include/fn/detail/pack_impl.hpp
@@ -6,12 +6,14 @@
 #ifndef INCLUDE_FN_DETAIL_PACK_IMPL
 #define INCLUDE_FN_DETAIL_PACK_IMPL
 
-#include <fn/detail/functional.hpp>
 #include <fn/detail/fwd.hpp>
 #include <fn/detail/macro_fwd.hpp>
 #include <fn/detail/meta.hpp>
 #include <fn/detail/traits.hpp>
 
+#include <pfn/functional.hpp>
+
+#include <functional>
 #include <type_traits>
 #include <utility>
 
@@ -114,24 +116,27 @@ struct pack_impl<::std::index_sequence<Is...>, Ts...> : _element<Is, Ts>... {
                          static_cast<apply_const_lvalue_t<Self, Ts &&>>(FWD(self)._element<Is, Ts>::v)...);
   }
 
+  // The pack's elements are the argument list, and every argument is terminal: handed over whole
+  // via INVOKE, never re-entering elimination. Routing through the engine instead would give a
+  // lone tuple-like element std::apply's meaning, making its treatment depend on its siblings.
   template <typename Self, typename Fn, typename... Args>
     requires(not(... || (_some_pack<Args> || _some_sum<Args>)))
   static constexpr auto _apply(Self &&self, Fn &&fn, Args &&...args) //
-      noexcept(_is_nothrow_applicable<Fn &&, apply_const_lvalue_t<Self, Ts &&>..., Args &&...>::value)
-          -> _apply_result<Fn &&, apply_const_lvalue_t<Self, Ts &&>..., Args &&...>::type
-    requires(_is_applicable<Fn &&, apply_const_lvalue_t<Self, Ts &&>..., Args && ...>::value)
+      noexcept(::std::is_nothrow_invocable_v<Fn &&, apply_const_lvalue_t<Self, Ts &&>..., Args &&...>)
+          -> ::std::invoke_result<Fn &&, apply_const_lvalue_t<Self, Ts &&>..., Args &&...>::type
+    requires(::std::is_invocable<Fn &&, apply_const_lvalue_t<Self, Ts &&>..., Args && ...>::value)
   {
-    return ::fn::detail::_apply(
-        FWD(fn), static_cast<apply_const_lvalue_t<Self, Ts &&>>(FWD(self)._element<Is, Ts>::v)..., FWD(args)...);
+    return ::std::invoke(FWD(fn), static_cast<apply_const_lvalue_t<Self, Ts &&>>(FWD(self)._element<Is, Ts>::v)...,
+                         FWD(args)...);
   }
 
   template <typename Ret, typename Self, typename Fn, typename... Args>
     requires(not(... || (_some_pack<Args> || _some_sum<Args>)))
   static constexpr auto _apply_r(Self &&self, Fn &&fn, Args &&...args) //
-      noexcept(_is_nothrow_applicable_r<Ret, Fn &&, apply_const_lvalue_t<Self, Ts &&>..., Args &&...>::value) -> Ret
-    requires(_is_applicable_r<Ret, Fn &&, apply_const_lvalue_t<Self, Ts &&>..., Args && ...>::value)
+      noexcept(::std::is_nothrow_invocable_r_v<Ret, Fn &&, apply_const_lvalue_t<Self, Ts &&>..., Args &&...>) -> Ret
+    requires(::std::is_invocable_r<Ret, Fn &&, apply_const_lvalue_t<Self, Ts &&>..., Args && ...>::value)
   {
-    return ::fn::detail::_apply_r<Ret>(
+    return ::pfn::invoke_r<Ret>(
         FWD(fn), static_cast<apply_const_lvalue_t<Self, Ts &&>>(FWD(self)._element<Is, Ts>::v)..., FWD(args)...);
   }
 
@@ -165,6 +170,9 @@ struct pack_impl<::std::index_sequence<Is...>, Ts...> : _element<Is, Ts>... {
             _make_element<T>(FWD(args)...)};
   }
 
+  // Splicing is normalization, not elimination: the appended pack's elements relocate through
+  // INVOKE, so a lone tuple-like element arrives whole instead of taking std::apply's meaning
+  // through the engine's tuple arm.
   template <typename T, typename Self>
   static constexpr auto _append(Self &&self, auto &&other) //
       noexcept(_nothrow_relocatable<Self>
@@ -175,7 +183,7 @@ struct pack_impl<::std::index_sequence<Is...>, Ts...> : _element<Is, Ts>... {
   _relocatable<decltype(other)>
   {
     using type = _pack_append<::std::remove_cvref_t<T>, Ts...>::impl;
-    return FWD(other)._apply(FWD(other), [&self](auto &&...args) {
+    return FWD(other)._swap_invoke(FWD(other), [&self](auto &&...args) {
       return type{static_cast<apply_const_lvalue_t<Self, Ts &&>>(FWD(self)._element<Is, Ts>::v)..., FWD(args)...};
     });
   }

--- a/include/fn/detail/pack_impl.hpp
+++ b/include/fn/detail/pack_impl.hpp
@@ -56,12 +56,21 @@ concept _relocatable_element = requires { E{::std::declval<Src>()}; };
 template <typename E, typename Src>
 concept _nothrow_relocatable_element = requires { requires noexcept(E{::std::declval<Src>()}); };
 
+// The algebra's own constructors are not elements: a sum must distribute over the product, and a
+// nested pack is a non-canonical spelling of the flat product with no consistent shape (apply
+// flattens it, the tuple protocol preserves it). Foreign structured types stay opaque atoms.
+template <typename T> static constexpr bool _is_valid_pack_element = (not _some_sum<T>) && (not _some_pack<T>);
+
+template <typename T> constexpr inline bool _spliceable_pack = false;
+template <typename... Tx>
+constexpr inline bool _spliceable_pack<::fn::pack<Tx...>> = (... && _is_valid_pack_element<Tx>);
+
 template <typename, typename... Ts> struct pack_impl;
 
 template <typename... Ts> struct _pack_append;
 // A pack never holds a sum. The specialization is defined but has no `type`, so naming
 // `append_type<sum>` is a substitution failure rather than a use of an incomplete type; and the
-// two specializations must exclude each other, or both match a sum and the choice is ambiguous.
+// specializations must exclude each other, or more than one matches and the choice is ambiguous.
 template <typename T, typename... Ts>
   requires _some_sum<T>
 struct _pack_append<T, Ts...> {};
@@ -77,8 +86,14 @@ template <typename... Tx, typename... Ts> struct _pack_append_pack<::fn::pack<Tx
   using impl = pack_impl<::std::index_sequence_for<Ts..., Tx...>, Ts..., Tx...>;
   using type = ::fn::pack<Ts..., Tx...>;
 };
+// A tag can NAME a pack type whose own elements are invalid without instantiating it; splicing it
+// would instantiate the ill-formed result. Same shape as the sum case: defined without `type`, so
+// asking stays a substitution failure.
 template <typename T, typename... Ts>
-  requires _some_pack<T>
+  requires _some_pack<T> && (not _spliceable_pack<::std::remove_cvref_t<T>>)
+struct _pack_append<T, Ts...> {};
+template <typename T, typename... Ts>
+  requires _some_pack<T> && _spliceable_pack<::std::remove_cvref_t<T>>
 struct _pack_append<T, Ts...> {
   using impl = _pack_append_pack<::std::remove_cvref_t<T>, Ts...>::impl;
   using type = _pack_append_pack<::std::remove_cvref_t<T>, Ts...>::type;

--- a/include/fn/detail/pack_impl.hpp
+++ b/include/fn/detail/pack_impl.hpp
@@ -187,6 +187,28 @@ struct pack_impl<::std::index_sequence<Is...>, Ts...> : _element<Is, Ts>... {
       return type{static_cast<apply_const_lvalue_t<Self, Ts &&>>(FWD(self)._element<Is, Ts>::v)..., FWD(args)...};
     });
   }
+
+  // The tag form constructs the named pack from the arguments, then splices it: appending a pack
+  // means concatenation in every spelling. One relocation per element more than appending the
+  // elements directly - the spelling of an append is a performance knob, never a result change.
+  template <typename T, typename Self>
+  static constexpr auto _append(Self &&self, auto &&...args) //
+      noexcept(_nothrow_relocatable<Self> && _nothrow_initializable<::std::remove_cvref_t<T>, decltype(args)...>
+               && ::std::remove_cvref_t<T>::_impl::template _nothrow_relocatable<::std::remove_cvref_t<T>>) -> //
+      typename _pack_append<::std::remove_cvref_t<T>, Ts...>::impl
+    requires _some_pack<T>
+             && (not(sizeof...(args) == 1
+                     && (... && ::std::is_same_v<::std::remove_cvref_t<decltype(args)>, ::std::remove_cvref_t<T>>)))
+             && _relocatable<Self> && _initializable<::std::remove_cvref_t<T>, decltype(args)...>
+             && ::std::remove_cvref_t<T>::_impl::template
+  _relocatable<::std::remove_cvref_t<T>>
+  {
+    using pack_t = ::std::remove_cvref_t<T>;
+    using type = _pack_append<pack_t, Ts...>::impl;
+    return pack_t::_impl::_swap_invoke(pack_t{FWD(args)...}, [&self](auto &&...elems) {
+      return type{static_cast<apply_const_lvalue_t<Self, Ts &&>>(FWD(self)._element<Is, Ts>::v)..., FWD(elems)...};
+    });
+  }
 };
 
 } // namespace fn::detail

--- a/include/fn/pack.hpp
+++ b/include/fn/pack.hpp
@@ -33,7 +33,7 @@ concept some_pack = detail::_some_pack<T>;
  */
 template <typename... Ts> struct pack : detail::pack_impl<::std::index_sequence_for<Ts...>, Ts...> {
   using _impl = detail::pack_impl<::std::index_sequence_for<Ts...>, Ts...>;
-  static_assert((... && (not some_sum<Ts>)));
+  static_assert((... && detail::_is_valid_pack_element<Ts>));
 
   template <typename T> using append_type = _impl::template append_type<T>;
 

--- a/tests/fn/pack.cpp
+++ b/tests/fn/pack.cpp
@@ -5,6 +5,7 @@
 
 #include "util/helper_types.hpp"
 
+#include <fn/choice.hpp>
 #include <fn/functional.hpp>
 #include <fn/optional.hpp>
 #include <fn/pack.hpp>
@@ -235,6 +236,25 @@ TEST_CASE("pack", "[pack]")
   static_assert(not std::is_same_v<some_pack_nttp<s1>, some_pack_nttp<s3>>);
   CHECK(read_nttp<s1>() == 3); // the template-parameter object is usable at runtime
 
+  SECTION("element mandate")
+  {
+    // the algebra's own constructors are not elements; everything else is an opaque atom
+    static_assert(fn::detail::_is_valid_pack_element<int>);
+    static_assert(fn::detail::_is_valid_pack_element<int &>);
+    static_assert(fn::detail::_is_valid_pack_element<int const>);
+    static_assert(fn::detail::_is_valid_pack_element<std::tuple<int, A>>);
+    static_assert(fn::detail::_is_valid_pack_element<std::array<int, 2>>);
+    static_assert(fn::detail::_is_valid_pack_element<fn::choice<int>>);
+    static_assert(not fn::detail::_is_valid_pack_element<fn::pack<int>>);
+    static_assert(not fn::detail::_is_valid_pack_element<fn::pack<>>);
+    static_assert(not fn::detail::_is_valid_pack_element<fn::sum<int>>);
+
+    // witnesses that the permitted atoms instantiate
+    static_assert(pack<std::tuple<int, int>, int>::size == 2);
+    static_assert(pack<fn::choice<int>, int>::size == 2);
+    SUCCEED();
+  }
+
   SECTION("apply_r return conversion")
   {
     struct NotFromInt final {
@@ -453,6 +473,18 @@ TEST_CASE("append value categories", "[pack][append]")
     static_assert(not can_append<T &, fn::sum<int> &>);
     static_assert(not can_append_in_place<T &, fn::sum<int>, fn::sum<int>>);
     static_assert(not can_append_in_place<T &, fn::sum_for<bool, int>, fn::sum_for<bool, int>>);
+
+    // A pack never holds a pack either: appending one splices, in every value category of the
+    // subject - and asking must answer, not hard-error, including a tag that merely NAMES an
+    // ill-formed pack
+    static_assert(std::same_as<T::append_type<fn::pack<B, C>>, pack<int, std::string_view, A, B, C>>);
+    static_assert(can_append<T &, fn::pack<int>>);
+    static_assert(can_append<T &, fn::pack<int> &>);
+    static_assert(can_append<T const &, fn::pack<int>>);
+    static_assert(can_append<T &&, fn::pack<int>>);
+    static_assert(can_append<T const &&, fn::pack<int>>);
+    static_assert(not can_append_in_place<T &, fn::pack<fn::pack<int>>, int>);
+    static_assert(not can_append_in_place<T &, fn::pack<fn::sum<int>>, int>);
 
     // relocation is part of the question: the elements already held move into the new pack in the
     // pack's own value category, and an element which cannot make that move rejects the append

--- a/tests/fn/pack.cpp
+++ b/tests/fn/pack.cpp
@@ -255,6 +255,31 @@ TEST_CASE("pack", "[pack]")
     SUCCEED();
   }
 
+  SECTION("elements are terminal")
+  {
+    // every element is handed over whole via INVOKE - a lone tuple-like element included, exactly
+    // as it is treated when siblings or extra arguments accompany it
+    constexpr auto arity = [](auto &&...args) noexcept -> int { return (0 + ... + (static_cast<void>(args), 1)); };
+    CHECK(pack<std::tuple<int, int>>{std::tuple{1, 2}}.apply(arity) == 1);
+    CHECK(pack<std::tuple<int, int>, int>{std::tuple{1, 2}, 3}.apply(arity) == 2);
+    CHECK(pack<std::tuple<int, int>>{std::tuple{1, 2}}.apply(arity, 0) == 2);
+    CHECK(pack<std::tuple<int, int>>{std::tuple{1, 2}}.apply_r<long>(arity) == 1L);
+
+    // the callable is served for the whole element, never its pieces
+    constexpr auto whole = [](std::tuple<int, int> const &t) noexcept -> int { return std::get<0>(t); };
+    CHECK(pack<std::tuple<int, int>>{std::tuple{1, 2}}.apply(whole) == 1);
+    static_assert(not can_invoke_r<pack<std::tuple<int, int>>, int, decltype([](int, int) -> int { return 0; })>);
+
+    SECTION("constexpr")
+    {
+      static_assert(pack<std::tuple<int, int>>{std::tuple{1, 2}}.apply(arity) == 1);
+      static_assert(pack<std::tuple<int, int>, int>{std::tuple{1, 2}, 3}.apply(arity) == 2);
+      static_assert(pack<std::tuple<int, int>>{std::tuple{1, 2}}.apply(arity, 0) == 2);
+      static_assert(pack<std::tuple<int, int>>{std::tuple{1, 2}}.apply(whole) == 1);
+      SUCCEED();
+    }
+  }
+
   SECTION("apply_r return conversion")
   {
     struct NotFromInt final {
@@ -445,6 +470,11 @@ TEST_CASE("append value categories", "[pack][append]")
     CHECK(c2.apply([](bool i, int j, B const &b1, C const &c, B const &b2) {
       return i && j == 3 && b1.v == 14 && c.v == 30 && b2.v == 20;
     }));
+
+    // a pack whose only element is tuple-like splices it whole, never unpacked
+    constexpr auto c3 = a.append(fn::pack<std::tuple<int, int>>{std::tuple{2, 3}});
+    static_assert(std::same_as<decltype(c3), fn::pack<bool, int, B, std::tuple<int, int>> const>);
+    static_assert(std::get<0>(fn::get<3>(c3)) == 2);
   }
 
   SECTION("constraints")
@@ -839,6 +869,11 @@ TEST_CASE("operator &", "[pack][sum][operator_and]")
                     fn::pack<int, int, double, double, bool, double, int>> const>);
   static_assert(r2.apply([](auto &&...args) -> double { return (1 * ... * static_cast<double>(args)); })
                 == 12. * 3 * 2.5 * 0.5 * 1 * 1.5 * 12);
+
+  // a pack whose only element is tuple-like splices whole through the join
+  constexpr auto r3 = fn::as_sum(12) & fn::pack<std::tuple<int, int>>{std::tuple{1, 2}};
+  static_assert(std::is_same_v<decltype(r3), fn::sum<fn::pack<int, std::tuple<int, int>>> const>);
+  static_assert(r3.apply([](int i, std::tuple<int, int> const &t) { return i == 12 && std::get<0>(t) == 1; }));
 
   SECTION("noexcept")
   {

--- a/tests/fn/pack.cpp
+++ b/tests/fn/pack.cpp
@@ -477,6 +477,32 @@ TEST_CASE("append value categories", "[pack][append]")
     static_assert(std::get<0>(fn::get<3>(c3)) == 2);
   }
 
+  SECTION("pack on the right side, tag form")
+  {
+    // the tag form splices too: a prebuilt matching pack relocates directly, any other arguments
+    // construct the named pack first - either way the result is the flat concatenation
+    constexpr fn::pack<bool, int> a{true, 3};
+    constexpr auto c1 = a.append(std::in_place_type<fn::pack<C, B>>, fn::pack<C, B>{C{}, B{3, 4}});
+    static_assert(std::same_as<decltype(c1), fn::pack<bool, int, C, B> const>);
+    static_assert(
+        c1.apply([](bool i, int j, C const &c, B const &b) { return i && j == 3 && c.v == 30 && b.v == 12; }));
+
+    constexpr auto c2 = a.append(std::in_place_type<fn::pack<C, B>>, C{}, B{4, 5});
+    static_assert(std::same_as<decltype(c2), fn::pack<bool, int, C, B> const>);
+    static_assert(
+        c2.apply([](bool i, int j, C const &c, B const &b) { return i && j == 3 && c.v == 30 && b.v == 20; }));
+
+    constexpr auto c3 = a.append(std::in_place_type<fn::pack<>>);
+    static_assert(std::same_as<decltype(c3), fn::pack<bool, int> const>);
+
+    constexpr auto c4 = a.append(std::in_place_type<fn::pack<std::tuple<int, int>>>, std::tuple{2, 3});
+    static_assert(std::same_as<decltype(c4), fn::pack<bool, int, std::tuple<int, int>> const>);
+    static_assert(std::get<0>(fn::get<2>(c4)) == 2);
+
+    auto c5 = a.append(std::in_place_type<fn::pack<C, B>>, C{}, B{4, 6});
+    CHECK(c5.apply([](bool i, int j, C const &c, B const &b) { return i && j == 3 && c.v == 30 && b.v == 24; }));
+  }
+
   SECTION("constraints")
   {
     static_assert(can_append_in_place<T &, B, int>);
@@ -504,15 +530,28 @@ TEST_CASE("append value categories", "[pack][append]")
     static_assert(not can_append_in_place<T &, fn::sum<int>, fn::sum<int>>);
     static_assert(not can_append_in_place<T &, fn::sum_for<bool, int>, fn::sum_for<bool, int>>);
 
-    // A pack never holds a pack either: appending one splices, in every value category of the
-    // subject - and asking must answer, not hard-error, including a tag that merely NAMES an
-    // ill-formed pack
+    // A pack never holds a pack either: appending one splices, in every spelling and every value
+    // category of the subject - the deduced form relocates the given pack's elements, the tag form
+    // constructs the named pack from the arguments and splices that
     static_assert(std::same_as<T::append_type<fn::pack<B, C>>, pack<int, std::string_view, A, B, C>>);
     static_assert(can_append<T &, fn::pack<int>>);
     static_assert(can_append<T &, fn::pack<int> &>);
     static_assert(can_append<T const &, fn::pack<int>>);
     static_assert(can_append<T &&, fn::pack<int>>);
     static_assert(can_append<T const &&, fn::pack<int>>);
+    static_assert(can_append_in_place<T &, fn::pack<int>, int>);
+    static_assert(can_append_in_place<T const &, fn::pack<int>, int>);
+    static_assert(can_append_in_place<T &&, fn::pack<int>, int>);
+    static_assert(can_append_in_place<T const &&, fn::pack<int>, int>);
+    static_assert(can_append_in_place<T &, fn::pack<double, int>, double, int>);
+    static_assert(can_append_in_place<T &, fn::pack<int>>); // value-initialized element
+    static_assert(can_append_in_place<T &, fn::pack<>>);    // zero elements contributed
+    // the construction is asked the brace question, and asking must answer, not hard-error -
+    // including a tag that merely NAMES an ill-formed pack
+    static_assert(not can_append_in_place<T &, fn::pack<B>>);                       // B has no default constructor
+    static_assert(not can_append_in_place<T &, fn::pack<B>, char const *>);         // B is not constructible from it
+    static_assert(not can_append_in_place<T &, fn::pack<int>, int, int>);           // one too many
+    static_assert(not can_append_in_place<T &, fn::pack<double>, fn::pack<float>>); // not the tag's pack
     static_assert(not can_append_in_place<T &, fn::pack<fn::pack<int>>, int>);
     static_assert(not can_append_in_place<T &, fn::pack<fn::sum<int>>, int>);
 


### PR DESCRIPTION
Closes #328, in three commits.

**Reject a nested pack element in pack** — the element mandate that has always rejected a `sum` now also rejects a `pack`, via the named boundary `detail::_is_valid_pack_element` (the testable surface, mirroring `_is_valid_sum_subtype`). A nested pack was representable and incoherent — `apply` flattened it while the tuple protocol preserved it, and since #84 the same position answered differently by kind (an own `pack` element flattened where a `std::tuple` element passes whole). The splice alias is guarded so a tag that merely *names* an ill-formed pack answers instead of hard-erroring. The issue's `choice` parenthetical is deliberately not implemented: #323 closed invalid, `choice` is an atom, and the tests pin it as a *legal* element.

**Hand pack elements over whole via INVOKE** — a regression found while implementing this: the whole-pack splice and `pack::apply`'s elements were routed through `fn::apply`'s engine, whose tuple-like arm (#84) gives a *lone* tuple-like argument `std::apply`'s meaning. Appending a pack whose only element is a `std::tuple` was a hard error (reaching `operator&`'s fold), and `pack<std::tuple<A, B>>::apply` unpacked the element its two-element sibling passes whole. Elements are terminal: the machinery now relocates and consumes through `std::invoke`/`pfn::invoke_r`, and the engine's meaning stays at the deliberate elimination boundary — `std::invoke` is useful exactly as defined, which is what #84 renamed the multidispatch *away* from.

**Construct and splice a pack named by the append tag** — `append(in_place_type<pack<Us...>>, args...)` constructs the named pack from the arguments and splices it: appending a pack means concatenation in every spelling, joining the deduced form and the prebuilt-matching-pack tag form (the fold's route), which always spliced. One relocation per element more than appending the elements directly; the result never differs.

Test batteries per commit (mandate boundary + atom witnesses; terminality of a lone tuple-like element across member `apply`/`apply_r`, deduced splice, and the `&`-join; tag-form splice across value categories with the brace-question negatives), and a dated CHANGELOG entry per design change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
