### PR TITLE
Build pull request coverage at the head, and pin it

### DIFF
--- a/.github/actions/collect-pr-workspace/action.yml
+++ b/.github/actions/collect-pr-workspace/action.yml
@@ -10,6 +10,12 @@ inputs:
   artifact-name:
     required: true
     description: Name for the uploaded artifact carrying the packaged `.build` outputs and PR metadata.
+  build-sha:
+    required: true
+    description: >
+      The revision this build is made from: pass `actions/checkout`'s `commit` output, which reports
+      what it resolved rather than what it was asked for, so downstream validation can reject coverage
+      built against anything but the pull request head.
 
 runs:
   using: composite
@@ -86,6 +92,7 @@ runs:
       shell: bash
       env:
         ARTIFACT_NAME: ${{ inputs.artifact-name }}
+        BUILD_SHA: ${{ inputs.build-sha }}
         PR_NUMBER: ${{ github.event.pull_request.number }}
         PR_HEAD_SHA: ${{ github.event.pull_request.head.sha }}
         PR_HEAD_REF: ${{ github.event.pull_request.head.ref }}
@@ -97,9 +104,7 @@ runs:
         printf "%s\n" "$PR_HEAD_SHA" > .pr-meta/head_sha
         printf "%s\n" "$PR_HEAD_REF" > .pr-meta/head_ref
         printf "%s\n" "$PR_BASE_REF" > .pr-meta/base_ref
-        # Read back from the tree rather than the checkout input, so the downstream head_sha
-        # comparison can catch a checkout that silently resolved elsewhere (#332).
-        git rev-parse HEAD           > .pr-meta/build_sha
+        printf "%s\n" "$BUILD_SHA"   > .pr-meta/build_sha
         # shellcheck disable=SC2046  # find emits one path per result; intentional word-splitting into tar arg list
         tar -czf "$ARTIFACT_NAME.tar.gz" \
           .build/compile_commands.json \

--- a/.github/actions/collect-pr-workspace/action.yml
+++ b/.github/actions/collect-pr-workspace/action.yml
@@ -97,6 +97,9 @@ runs:
         printf "%s\n" "$PR_HEAD_SHA" > .pr-meta/head_sha
         printf "%s\n" "$PR_HEAD_REF" > .pr-meta/head_ref
         printf "%s\n" "$PR_BASE_REF" > .pr-meta/base_ref
+        # Read back from the tree rather than the checkout input, so the downstream head_sha
+        # comparison can catch a checkout that silently resolved elsewhere (#332).
+        git rev-parse HEAD           > .pr-meta/build_sha
         # shellcheck disable=SC2046  # find emits one path per result; intentional word-splitting into tar arg list
         tar -czf "$ARTIFACT_NAME.tar.gz" \
           .build/compile_commands.json \

--- a/.github/scripts/validate-pr-artifact.sh
+++ b/.github/scripts/validate-pr-artifact.sh
@@ -51,6 +51,20 @@ ref='^[A-Za-z0-9._/+@-]+$'
 number=$(read_field number   '^[0-9]+$')         || exit 1
 head_sha=$(read_field head_sha '^[0-9a-f]{40}$') || exit 1
 head_ref=$(read_field head_ref "$ref")           || exit 1
+# The consumers check out head_sha and report it to SonarCloud/codecov, so coverage built against any
+# other revision is scanned against the wrong source: line numbers drift once the base moves ahead,
+# and only sonar notices (codecov mis-attributes in silence). build_sha is what the producer actually
+# built, so the two must agree.
+if [ ! -f "$META/build_sha" ]; then
+  printf '::error::Artifact carries no build_sha; its producer predates the check. Rebase the pull request onto main.\n' >&2
+  exit 1
+fi
+build_sha=$(read_field build_sha '^[0-9a-f]{40}$') || exit 1
+if [ "$build_sha" != "$head_sha" ]; then
+  printf '::error::Coverage was built at %s but the pull request head is %s. Rebase the pull request onto main.\n' \
+    "$build_sha" "$head_sha" >&2
+  exit 1
+fi
 {
   echo "number=$number"
   echo "head_sha=$head_sha"

--- a/.github/workflows/codecov.yml
+++ b/.github/workflows/codecov.yml
@@ -32,6 +32,9 @@ jobs:
 
     steps:
     - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+      with:
+        # Head, not checkout's default merge commit: coverage must describe the SHA reported downstream.
+        ref: ${{ github.event.pull_request.head.sha }}
 
     - name: Build coverage and package pull request workspace
       uses: ./.github/actions/collect-pr-workspace

--- a/.github/workflows/codecov.yml
+++ b/.github/workflows/codecov.yml
@@ -32,6 +32,7 @@ jobs:
 
     steps:
     - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+      id: checkout
       with:
         # Head, not checkout's default merge commit: coverage must describe the SHA reported downstream.
         ref: ${{ github.event.pull_request.head.sha }}
@@ -40,6 +41,7 @@ jobs:
       uses: ./.github/actions/collect-pr-workspace
       with:
         artifact-name: codecov-pr-inputs
+        build-sha: ${{ steps.checkout.outputs.commit }}
 
     # Non-PR events carry secrets and upload inline; PRs hand off via the artifact above. Not gated on
     # CODECOV_TOKEN since tokenless uploads work but are throttled; a set token lifts the throttling.

--- a/.github/workflows/sonarcloud.yml
+++ b/.github/workflows/sonarcloud.yml
@@ -20,6 +20,7 @@ jobs:
 
     steps:
     - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+      id: checkout
       with:
         # Head, not checkout's default merge commit: coverage must describe the SHA reported downstream.
         ref: ${{ github.event.pull_request.head.sha }}
@@ -29,6 +30,7 @@ jobs:
       uses: ./.github/actions/collect-pr-workspace
       with:
         artifact-name: sonarcloud-pr-inputs
+        build-sha: ${{ steps.checkout.outputs.commit }}
 
     - name: Resolve SonarCloud project
       id: sonar

--- a/.github/workflows/sonarcloud.yml
+++ b/.github/workflows/sonarcloud.yml
@@ -21,6 +21,8 @@ jobs:
     steps:
     - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
       with:
+        # Head, not checkout's default merge commit: coverage must describe the SHA reported downstream.
+        ref: ${{ github.event.pull_request.head.sha }}
         fetch-depth: 0  # Full history for blame info
 
     - name: Build coverage and package pull request workspace


### PR DESCRIPTION
Closes #332.

On a `pull_request` event `GITHUB_SHA` is the merge commit, and `actions/checkout` defaults to it — so `sonarcloud.yml` and `codecov.yml` built coverage against the pull request *merged into current main*, while both consumers check out the *head* and report it (`-Dsonar.scm.revision`, codecov's `override_commit`). The artifact even records `head_sha` next to coverage built from a different tree.

They agree only while the pull request's base is current. Once `main` moves ahead with a change to a covered file, line numbers drift: sonar dies citing a file the pull request never touched, and codecov silently mis-attributes.

### Build the head

The head is already the documented source of truth downstream — `sonarcloud-pr-scan.yml`'s header spells out why the merge commit cannot serve SCM status or decoration (it is unreachable on the head branch). The producers were the only part disagreeing, so they now check the head out too:

```yaml
ref: ${{ github.event.pull_request.head.sha }}
```

The expression is empty on `push` and `workflow_dispatch`, where `actions/checkout` falls back to its default — those paths are unchanged. Checking out a head SHA is already proven here: both consumers do exactly that, including for fork pull requests.

### Pin it

`collect-pr-workspace` records `build_sha` — read back from the tree with `git rev-parse HEAD`, not echoed from the `ref` input, or the check would be vacuous. `validate-pr-artifact.sh` then rejects an artifact whose coverage does not match the head it claims. Both consumers already `bash` that script, so neither workflow needed changing.

This is the part that matters for codecov: sonar's out-of-range crash is at least a signal, whereas codecov has none. Now a mismatch fails at validation, before either tool is fed.

Verified against the real script with synthetic artifacts:

| case | result |
|---|---|
| `build_sha == head_sha` | pass, emits outputs |
| `build_sha != head_sha` | fail — *Coverage was built at X but the pull request head is Y. Rebase…* |
| `build_sha` absent | fail — *Artifact carries no build_sha; its producer predates the check. Rebase…* |
| `build_sha` malformed | fail — *Invalid build_sha in artifact metadata* |

### Notes for review

`build_sha` is **required**, not optional like `base_ref`. Changing the artifact contract reddens every in-flight pull request — the producer comes from the branch, the consumer from `main` — and there are currently **no other open pull requests** but this one and #335, so the cost is nil. A pull request later raised from a branch that predates this will fail with an actionable "rebase onto main" rather than silently skipping the check.

**This pull request cannot exercise its own guard.** `workflow_run` consumers run `main`'s copy of the script, so this branch's `build_sha` is validated by the *old* validator, which ignores it (it passes the allowlist as `.pr-meta/**`). The check only goes live once merged, and the first real exercise is the next pull request raised afterwards.
