### PR TITLE
Diagnose sort-key collisions in type normalization

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 Design history of libfn, newest first. The living documents — [README.md](README.md), [CONTRIBUTING.md](CONTRIBUTING.md), [docs/](docs/) — describe only the present state of the design; when a decision makes an earlier idea obsolete, this file is where the transition is recorded and explained.
 
+## Type normalization diagnoses sort-key collisions — 16 July 2026
+
+- **`normalized` asserts that distinct types have distinct sort keys** ([#326](https://github.com/libfn/functional/issues/326)). The type ordering scrapes compiler type spellings, and two distinct types could share one — gcc prints same-scope lambdas identically, clang prints same-named function-local types bare — so `sum_for<A, B>` silently became `sum<A>`: a genuine alternative vanished, and with tied keys the order had no canonical answer either. A collision is now a mandate error at the point of use ("two distinct types share a sort key"), on every supported compiler; distinct keys are untouched and genuine duplicates still deduplicate. The scrape and its assert both retire with `std::type_order` (P2830, C++26 — its motivation cites this library).
+
 ## `pack` splices in every append spelling, and hands elements over whole — 16 July 2026
 
 - **The tag form of `append` now constructs the named pack from its arguments and splices it** ([#328](https://github.com/libfn/functional/issues/328)): appending a pack means concatenation however it is spelled, joining the two spellings that always spliced — a deduced pack value, and a tag with a prebuilt matching pack, the route `operator&`'s fold takes. The tag spelling costs one relocation per element more than appending the elements directly; the result never differs. A tag that merely names an ill-formed pack answers instead of hard-erroring.

--- a/include/fn/detail/meta.hpp
+++ b/include/fn/detail/meta.hpp
@@ -141,6 +141,11 @@ template <typename T> [[nodiscard]] static constexpr auto _make_sortkey() -> ::s
 
 template <typename T> constexpr inline ::std::string_view type_sortkey_v = sortkey::_make_sortkey<T>();
 
+// How many distinct types (by identity, not by key): a type counts unless it recurs later.
+template <typename... Ts> constexpr inline ::std::size_t _distinct_types = 0;
+template <typename T, typename... Ts>
+constexpr inline ::std::size_t _distinct_types<T, Ts...> = _distinct_types<Ts...> + (type_one_of<T, Ts...> ? 0 : 1);
+
 // NOTE Normalized order of types - order based on type_sortkey_v
 template <typename... Ts> struct normalized final {
   static constexpr ::std::size_t N = sizeof...(Ts);
@@ -163,6 +168,13 @@ template <typename... Ts> struct normalized final {
   }
 
   static constexpr _uniqued _indices_v = _indices();
+
+  // Key injectivity is load-bearing twice over: with a tied key the sort has no canonical order and
+  // unique() silently drops a genuine alternative. The same type always prints the same key, so a
+  // count mismatch is exactly two distinct types sharing one. Known colliders: same-scope lambdas
+  // (gcc prints no positional disambiguator), same-named function-local types (clang prints no
+  // scope). The scrape retires with std::type_order (P2830).
+  static_assert(_distinct_types<Ts...> == _indices_v.count, "fn: two distinct types share a sort key - see issue #326");
 
   template <template <typename...> typename F, ::std::size_t... Is>
   static constexpr auto _normalized_f(::std::index_sequence<Is...> const &)

--- a/include/fn/detail/meta.hpp
+++ b/include/fn/detail/meta.hpp
@@ -169,12 +169,12 @@ template <typename... Ts> struct normalized final {
 
   static constexpr _uniqued _indices_v = _indices();
 
-  // Key injectivity is load-bearing twice over: with a tied key the sort has no canonical order and
-  // unique() silently drops a genuine alternative. The same type always prints the same key, so a
+  // The collision floor (#326): dedup and canonical order both rest on key injectivity, so
   // count mismatch is exactly two distinct types sharing one. Known colliders: same-scope lambdas
-  // (gcc prints no positional disambiguator), same-named function-local types (clang prints no
-  // scope). The scrape retires with std::type_order (P2830).
-  static_assert(_distinct_types<Ts...> == _indices_v.count, "fn: two distinct types share a sort key - see issue #326");
+  // (no positional disambiguator in gcc), same-named function-local types (clang prints no scope).
+  // If this assert fires, the user project should rename one of the colliding types to a unique
+  // name (or move it to a different scope); or upgrade to C++26 and switch to std::type_order
+  static_assert(_distinct_types<Ts...> == _indices_v.count, "distinct types must not share a sort key");
 
   template <template <typename...> typename F, ::std::size_t... Is>
   static constexpr auto _normalized_f(::std::index_sequence<Is...> const &)

--- a/tests/fn/detail/meta.cpp
+++ b/tests/fn/detail/meta.cpp
@@ -137,8 +137,8 @@ TEST_CASE("normalized", "[normalized]")
 #ifdef __clang__
   // clang keys a lambda by position (file:line:col), so the same-scope pair gcc collides on is
   // distinct here
-  auto l1 = [] {};
-  auto l2 = [] {};
+  [[maybe_unused]] auto l1 = [] {};
+  [[maybe_unused]] auto l2 = [] {};
   static_assert(type_sortkey_v<decltype(l1)> != type_sortkey_v<decltype(l2)>);
   static_assert(normalized<decltype(l1), decltype(l2)>::size == 2);
 #endif

--- a/tests/fn/detail/meta.cpp
+++ b/tests/fn/detail/meta.cpp
@@ -42,6 +42,30 @@ TEST_CASE("type index", "[type_index]")
 namespace {
 template <typename... Ts> struct type_list {};
 template <typename... Ts> struct types {};
+
+// two lambdas from different scopes: key-distinct on every supported pretty-printing path
+[[maybe_unused]] auto lambda1()
+{
+  return [] {};
+}
+[[maybe_unused]] auto lambda2()
+{
+  return [] {};
+}
+
+#if defined(__GNUC__) && !defined(__clang__)
+// gcc keys a local type by its scope, so the same-named pair clang collides on is distinct here
+[[maybe_unused]] auto local1()
+{
+  struct X final {};
+  return X{};
+}
+[[maybe_unused]] auto local2()
+{
+  struct X final {};
+  return X{};
+}
+#endif
 } // namespace
 
 TEST_CASE("normalized", "[normalized]")
@@ -95,6 +119,32 @@ TEST_CASE("normalized", "[normalized]")
   static_assert(type_sortkey_v<_ts<bool, int>> == "struct fn::detail::_ts<bool,int>");
 #else
   static_assert(type_sortkey_v<_ts<bool, int>> == "fn::detail::_ts<bool, int>");
+#endif
+
+  // The collision floor (#326): dedup and canonical order both rest on key injectivity, so
+  // normalized asserts distinct-type count == distinct-key count. The known colliders (same-scope
+  // lambdas on gcc, same-named function-local types on clang) are mandate hard errors by design and
+  // cannot appear here; these pin the counting and each printer's neighbouring good cases.
+  static_assert(_distinct_types<> == 0);
+  static_assert(_distinct_types<int> == 1);
+  static_assert(_distinct_types<int, int> == 1);
+  static_assert(_distinct_types<int, bool, int> == 2);
+  static_assert(_distinct_types<int, int const, int &> == 3);
+
+  static_assert(type_sortkey_v<decltype(lambda1())> != type_sortkey_v<decltype(lambda2())>);
+  static_assert(normalized<decltype(lambda1()), decltype(lambda2())>::size == 2);
+
+#ifdef __clang__
+  // clang keys a lambda by position (file:line:col), so the same-scope pair gcc collides on is
+  // distinct here
+  auto l1 = [] {};
+  auto l2 = [] {};
+  static_assert(type_sortkey_v<decltype(l1)> != type_sortkey_v<decltype(l2)>);
+  static_assert(normalized<decltype(l1), decltype(l2)>::size == 2);
+#endif
+#if defined(__GNUC__) && !defined(__clang__)
+  static_assert(type_sortkey_v<decltype(local1())> != type_sortkey_v<decltype(local2())>);
+  static_assert(normalized<decltype(local1()), decltype(local2())>::size == 2);
 #endif
 
   SUCCEED();


### PR DESCRIPTION
Closes #326.

**The floor**: `normalized` now asserts that the number of distinct types (by `is_same` identity, counted by the new `detail::_distinct_types`) equals the number of distinct sort keys. The same type always prints the same key, so a count mismatch is exactly two distinct types sharing one — previously a silent wrong answer (`sum_for<A, B>` became `sum<A>`, and tied keys left the canonical order unspecified), now a mandate error at the point of use on every supported compiler, the MSVC `__FUNCSIG__` path included. Both known colliders were re-verified while implementing: gcc 16 keys same-scope lambdas identically, clang 22 keys same-named function-local types bare; each fires the new assert on its compiler and is well-formed on the other, which the tests pin as the per-printer good cases alongside the portable ones (different-scope lambdas, anonymous-namespace types, genuine duplicates still deduplicating). The assert also runs inside every existing `sum`/`choice` test via their `normalized` instantiations — the suite found zero collisions in legal code.

**The issue's part 2 (reject anonymous-namespace types) is deliberately not implemented.** Anonymous-namespace types are pervasive, intentional, and safe as alternatives — the test suite's own fixtures use them throughout — and the within-TU collision that part 2 targeted (same-named anon types from different headers) is caught by the floor. The cross-TU concern involves types that are per-TU distinct anyway (internal linkage), so rejection would break legitimate code to prevent a hazard the type system already fences.

**The issue's part 3 audit**: `type_sortkey_v` has no consumers outside `normalized`; `is_superset_of`, `type_one_of` and `type_index` are already `is_same`-based. One fix site covers the library.

The scrape and its assert both retire with `std::type_order` (P2830, C++26 — its motivation cites this library).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
