### PR TITLE
Run the codecov jobs on whatever the platform provides

### DIFF
--- a/.github/actions/collect-pr-workspace/action.yml
+++ b/.github/actions/collect-pr-workspace/action.yml
@@ -51,9 +51,11 @@ runs:
           fi
           printf '%s=%s ok: %s\n' "$var" "$tool" "$first"
         }
-        verify CC   'gcc' 'clang'
-        verify CXX  'g++' 'clang'
-        verify GCOV 'gcov' 'LLVM'   # llvm-cov reports `LLVM (http://llvm.org/):`
+        # The trailing words are load-bearing: `clang-format version` and `gcov-tool (` would
+        # otherwise pass as a compiler and a gcov.
+        verify CC   'gcc' 'clang version'
+        verify CXX  'g++' 'clang version'
+        verify GCOV 'gcov (' 'LLVM'
         exit "$status"
 
     - name: Build with coverage instrumentation and compilation database

--- a/.github/actions/collect-pr-workspace/action.yml
+++ b/.github/actions/collect-pr-workspace/action.yml
@@ -28,7 +28,7 @@ runs:
         set -euo pipefail
         status=0
         verify() {
-          local var=$1; shift  # remaining args: accepted `--help` first-line fragments
+          local var=$1; shift  # remaining args: accepted `--version` first-line fragments
           local tool=${!var-}
           if [ -z "$tool" ]; then
             printf '::error::%s is not set\n' "$var" >&2
@@ -36,9 +36,9 @@ runs:
           fi
           local first
           # Unquoted on purpose: GCOV may be a multi-word command such as `llvm-cov gcov`. A bad value
-          # is caught below by its --help output not matching, so no separate existence check is needed.
+          # is caught below by its --version output not matching, so no separate existence check is needed.
           # shellcheck disable=SC2086
-          first=$($tool --help 2>&1 | head -1) || true
+          first=$($tool --version 2>&1 | head -1) || true
           local want matched=
           for want in "$@"; do
             case $first in
@@ -46,16 +46,14 @@ runs:
             esac
           done
           if [ -z "$matched" ]; then
-            printf '::error::%s=%s is not a recognised tool (--help gave: %s)\n' "$var" "$tool" "$first" >&2
+            printf '::error::%s=%s is not a recognised tool (--version gave: %s)\n' "$var" "$tool" "$first" >&2
             status=1; return
           fi
           printf '%s=%s ok: %s\n' "$var" "$tool" "$first"
         }
-        verify CC   'Usage: gcc [options] file...' 'OVERVIEW: clang LLVM compiler'
-        verify CXX  'Usage: g++ [options] file...' 'OVERVIEW: clang LLVM compiler'
-        verify GCOV 'Usage: gcov [OPTION...] SOURCE|OBJ...' \
-                    'Usage: llvm-cov {export|gcov|report|show} [OPTION]...' \
-                    'OVERVIEW: LLVM code coverage tool'
+        verify CC   'gcc' 'clang'
+        verify CXX  'g++' 'clang'
+        verify GCOV 'gcov' 'LLVM'   # llvm-cov reports `LLVM (http://llvm.org/):`
         exit "$status"
 
     - name: Build with coverage instrumentation and compilation database

--- a/.github/actions/select-gcc/action.yml
+++ b/.github/actions/select-gcc/action.yml
@@ -46,8 +46,12 @@ runs:
             continue
           fi
           # All three must agree: a gcov that cannot read the compiler's .gcno reports a plausible
-          # and wrong result rather than failing, so a mixed set is worse than no set.
-          v=$(major "$cc") vx=$(major "$cxx") vg=$(major "$gcov")
+          # and wrong result rather than failing, so a mixed set is worse than no set. A candidate
+          # that will not say what it is is one to skip, so `|| v=''` keeps -e from ending the hunt.
+          v='' vx='' vg=''
+          v=$(major "$cc")    || v=''
+          vx=$(major "$cxx")  || vx=''
+          vg=$(major "$gcov") || vg=''
           if [ -z "$v" ] || [ "$v" != "$vx" ] || [ "$v" != "$vg" ]; then
             printf '  gcc%-4s versions disagree (gcc=%s g++=%s gcov=%s), skipping\n' \
               "${sfx:-(none)}" "${v:-?}" "${vx:-?}" "${vg:-?}"

--- a/.github/actions/select-gcc/action.yml
+++ b/.github/actions/select-gcc/action.yml
@@ -1,0 +1,73 @@
+name: select-gcc
+description: >
+  Export CC, CXX and GCOV for the newest complete gcc/g++/gcov trio in `/usr/bin`, whether it is
+  installed unsuffixed (as an image's own toolchain is, via update-alternatives) or as `gcc-N`
+  beside others (as a distribution's are). Selection is by the version each binary REPORTS, so a
+  name is never taken on trust and an image's unsuffixed gcc competes on equal terms with a
+  distribution's versioned one.
+
+inputs:
+  min-version:
+    required: false
+    default: '12'
+    description: >
+      Oldest acceptable gcc major, defaulting to the project's own floor. Nothing older is
+      selected: a coverage build on an unsupported compiler is a failure, not a fallback.
+
+runs:
+  using: composite
+  steps:
+    - name: Select the newest complete GCC
+      shell: bash
+      env:
+        MIN_VERSION: ${{ inputs.min-version }}
+      run: |
+        set -euo pipefail
+
+        # Every way a toolchain shows up in /usr/bin: unsuffixed, and each `gcc-N`. The `[0-9]`
+        # keeps gcc-ar and gcc-ranlib out; they are not compilers.
+        suffixes=('')
+        mapfile -t versioned < <(
+          find /usr/bin -maxdepth 1 -name 'gcc-[0-9]*' -printf '%f\n' \
+            | sed 's/^gcc//' | grep -E '^-[0-9]+$' | sort -u
+        )
+        [ "${#versioned[@]}" -gt 0 ] && suffixes+=("${versioned[@]}")
+
+        major() {
+          # Requires a dot, so the -14 in a binary's own name cannot be mistaken for its version.
+          "$1" --version 2>&1 | head -1 | grep -oE '[0-9]+(\.[0-9]+)+' | head -1 | cut -d. -f1
+        }
+
+        best='' best_sfx=''
+        for sfx in "${suffixes[@]}"; do
+          cc="/usr/bin/gcc$sfx" cxx="/usr/bin/g++$sfx" gcov="/usr/bin/gcov$sfx"
+          if ! { [ -x "$cc" ] && [ -x "$cxx" ] && [ -x "$gcov" ]; }; then
+            printf '  gcc%-4s incomplete trio, skipping\n' "${sfx:-(none)}"
+            continue
+          fi
+          # All three must agree: a gcov that cannot read the compiler's .gcno reports a plausible
+          # and wrong result rather than failing, so a mixed set is worse than no set.
+          v=$(major "$cc") vx=$(major "$cxx") vg=$(major "$gcov")
+          if [ -z "$v" ] || [ "$v" != "$vx" ] || [ "$v" != "$vg" ]; then
+            printf '  gcc%-4s versions disagree (gcc=%s g++=%s gcov=%s), skipping\n' \
+              "${sfx:-(none)}" "${v:-?}" "${vx:-?}" "${vg:-?}"
+            continue
+          fi
+          printf '  gcc%-4s reports %s\n' "${sfx:-(none)}" "$v"
+          if [ "$v" -ge "$MIN_VERSION" ] && { [ -z "$best" ] || [ "$v" -gt "$best" ]; }; then
+            best="$v" best_sfx="$sfx"
+          fi
+        done
+
+        if [ -z "$best" ]; then
+          printf '::error::no complete gcc/g++/gcov trio of version %s or newer in /usr/bin\n' \
+            "$MIN_VERSION"
+          exit 1
+        fi
+
+        {
+          printf 'CC=/usr/bin/gcc%s\n'   "$best_sfx"
+          printf 'CXX=/usr/bin/g++%s\n'  "$best_sfx"
+          printf 'GCOV=/usr/bin/gcov%s\n' "$best_sfx"
+        } >> "$GITHUB_ENV"
+        printf 'selected gcc %s (/usr/bin/gcc%s)\n' "$best" "$best_sfx"

--- a/.github/workflows/codecov-pr-scan.yml
+++ b/.github/workflows/codecov-pr-scan.yml
@@ -20,8 +20,8 @@ jobs:
     if: >
       github.event.workflow_run.event == 'pull_request' &&
       github.event.workflow_run.conclusion == 'success'
+    # No container: this job unpacks an artifact and uploads a report, and needs no toolchain to do it.
     runs-on: ${{ github.repository == 'libfn/functional' && 'warp-ubuntu-latest-x64-4x' || 'ubuntu-latest' }}
-    container: libfn.azurecr.io/ci-build-gcc:15-sha-08b1133
 
     steps:
     # Download the artifact outside the workspace so the subsequent checkout does not wipe it.

--- a/.github/workflows/codecov.yml
+++ b/.github/workflows/codecov.yml
@@ -12,6 +12,7 @@ on:
       - '.github/workflows/codecov-pr-scan.yml'
       - '.github/scripts/validate-pr-artifact.sh'
       - '.github/actions/collect-pr-workspace/**'
+      - '.github/actions/select-gcc/**'
       - 'include/**'
       - 'tests/**'
       - 'CMakeLists.txt'
@@ -22,20 +23,31 @@ on:
   # examples/** not included in coverage paths intentionally, see also .codecov.yml
 
 jobs:
+  # Deliberately un-containerised: coverage needs a gcc, a gcov to match it and gcovr, and the runner
+  # already carries the first two, so pulling a ~0.5 GB image over the x64 fleet's 1-2 MB/s path costs
+  # minutes to obtain what is already there. Building on stock also keeps us honest about the platform
+  # a contributor actually has, rather than only the one we curate.
   codecov:
     runs-on: ${{ github.repository == 'libfn/functional' && 'warp-ubuntu-latest-x64-4x' || 'ubuntu-latest' }}
-    container: libfn.azurecr.io/ci-build-gcc:15-sha-08b1133
-    env:
-      CC: /usr/local/bin/gcc
-      CXX: /usr/local/bin/g++
-      GCOV: /usr/local/bin/gcov
-
     steps:
     - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
       id: checkout
       with:
         # Head, not checkout's default merge commit: coverage must describe the SHA reported downstream.
         ref: ${{ github.event.pull_request.head.sha }}
+
+    - name: Select the toolchain
+      uses: ./.github/actions/select-gcc
+
+    # The distro's gcovr is too old: `--merge-lines` arrived in 8.4, and without it the aggregate
+    # keeps a record per instantiation — the very defect it is ingested to avoid (see .codecov.yml).
+    - name: Install gcovr
+      run: |
+        set -euo pipefail
+        python3 -m venv "${RUNNER_TEMP}/gcovr-venv"
+        "${RUNNER_TEMP}/gcovr-venv/bin/pip" --no-cache-dir install --quiet 'gcovr>=8.4,<9'
+        printf '%s/gcovr-venv/bin\n' "${RUNNER_TEMP}" >> "$GITHUB_PATH"
+        "${RUNNER_TEMP}/gcovr-venv/bin/gcovr" --version | head -1
 
     - name: Build coverage and package pull request workspace
       uses: ./.github/actions/collect-pr-workspace

--- a/.github/workflows/sonarcloud-pr-scan.yml
+++ b/.github/workflows/sonarcloud-pr-scan.yml
@@ -33,6 +33,8 @@ jobs:
       github.event.workflow_run.event == 'pull_request' &&
       github.event.workflow_run.conclusion == 'success' &&
       (github.repository == 'libfn/functional' || vars.SONAR_PROJECT_KEY != '')
+    # Runner and container must match sonarcloud.yml's: the compiler paths in the compile_commands.json
+    # analysed below were recorded there, and must resolve to the same toolchain here.
     runs-on: ${{ github.repository == 'libfn/functional' && 'warp-ubuntu-latest-x64-4x' || 'ubuntu-latest' }}
     container: libfn.azurecr.io/ci-build-gcc:15-sha-08b1133
     env:

--- a/.github/workflows/sonarcloud.yml
+++ b/.github/workflows/sonarcloud.yml
@@ -9,12 +9,11 @@ on:
 
 jobs:
   sonarcloud:
+    # Runner and container must match sonarcloud-pr-scan's: it analyses the compile_commands.json
+    # written here, and the compiler paths recorded in it must resolve to the same toolchain there.
     runs-on: ${{ github.repository == 'libfn/functional' && 'warp-ubuntu-latest-x64-4x' || 'ubuntu-latest' }}
     container: libfn.azurecr.io/ci-build-gcc:15-sha-08b1133
     env:
-      CC: /usr/local/bin/gcc
-      CXX: /usr/local/bin/g++
-      GCOV: /usr/local/bin/gcov
       # Gates the inline scan below (a fork without a token no-ops); see also resolve-sonar-project.
       SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
 
@@ -25,6 +24,9 @@ jobs:
         # Head, not checkout's default merge commit: coverage must describe the SHA reported downstream.
         ref: ${{ github.event.pull_request.head.sha }}
         fetch-depth: 0  # Full history for blame info
+
+    - name: Select the toolchain
+      uses: ./.github/actions/select-gcc
 
     - name: Build coverage and package pull request workspace
       uses: ./.github/actions/collect-pr-workspace


### PR DESCRIPTION
Both codecov jobs pulled `ci-build-gcc:15` (~0.5 GB) over the warp x64 fleet's 1–2 MB/s path — 4–6 min of "Initialize containers" per job, per pull request, to reach tools the runner mostly already has. A [probe of the stock runners](https://github.com/libfn/functional/actions/runs/29512469529) measured what is actually there:

| | warp-ubuntu-latest-x64-4x | ubuntu-latest |
| --- | --- | --- |
| gcc / g++ / gcov | **12, 13, 14** | **12, 13, 14** |
| cmake, ninja, python3 | present | present |
| gcovr | absent | absent |

The two runners are the same image, so upstream and the fork fallback behave alike. **`gcovr` is the only thing missing** — a `pip install`, against minutes of pull.

### Selecting a toolchain — `.github/actions/select-gcc`

Both coverage workflows now ask the same question, so it lives in one action: pick the newest complete **gcc/g++/gcov trio** in `/usr/bin` at or above `min-version` (12, the project's floor), and export `CC`/`CXX`/`GCOV`.

Selection is by the version each binary **reports**, never by its name, which is what lets one action serve both platforms:

| layout | selects |
| --- | --- |
| the image: unsuffixed gcc 15 (via `update-alternatives`) beside a diverted distro gcc-12 | **15** — `/usr/bin/gcc` |
| a stock runner: unsuffixed 13.3 beside gcc-12/13/14 | **14** — `/usr/bin/gcc-14` |

Two deliberate refusals to be clever:

- **No fallback.** No complete trio at or above 12 means the job fails. Falling back to the default `cc` would produce a plausible, wrong coverage number rather than an error.
- **The trio must agree on its version.** An unsuffixed gcc 15 paired with the distro's gcov 12 — precisely what `ci/gcc/Dockerfile`'s `dpkg-divert` guards against — is skipped, not mixed. A gcov that cannot read the compiler's `.gcno` reports silently wrong data.

### codecov

Drops `container:`, calls `select-gcc`, and installs `gcovr>=8.4,<9`. The runner already has cmake, ninja and gcc 12/13/14, so gcovr is the only install. Coverage runs on **gcc 14**.

### codecov-pr-scan

Drops `container:` outright. The job downloads an artifact, validates and untars it, and uploads `coverage.xml` — bash and tar, no toolchain. It was pulling a compiler image to run `tar`.

### sonarcloud

Keeps its container and its **gcc 15**, and merely stops hardcoding `/usr/local/bin`: the image's `update-alternatives` put the same binaries in `/usr/bin`, so `select-gcc` finds them there. That the two tools now measure different compilers is intentional — every pull request exercises two of the compilers we claim to support instead of one.

Its runner and container stay coupled to `sonarcloud-pr-scan`'s, and both files now say so: the consumer's CFamily analyzer probes the compiler paths recorded in `compile_commands.json`, so the two environments must match. That coupling is why the pull tax on those jobs wants `runs-on: arm64` (~15s pulls, per #313) rather than container removal — a separate change.

### collect-pr-workspace

Its `verify` now matches `--version` rather than `--help`, because **no versioned binary could ever have passed**: gcc and g++ echo the name they were invoked as, so `/usr/bin/gcc-14 --help` prints `Usage: gcc-14 [options] file...` and never matches the fixed `Usage: gcc [options] file...`. `gcov` does not echo its name, so exactly two of three failed — the asymmetry that identified the cause. It went unnoticed because the container supplies an unversioned `/usr/local/bin/gcc`.

This action is shared with `sonarcloud.yml`: the container's unversioned `gcc` still passes, and this pull request's own `sonarcloud` check is the proof.

### Tested before pushing

`select-gcc`, against the script extracted from the action, with fixture `/usr/bin` layouts — both real shapes and the degenerate ones:

| case | result |
| --- | --- |
| unsuffixed 15 + distro 12 (**the image**) | 15 |
| unsuffixed 13.3 + gcc-12/13/14 (**a runner**) | 14 |
| only an unsuffixed toolchain | 15 |
| only a versioned toolchain | 14 |
| unsuffixed gcc 15 but gcov is the distro's 12 | FAIL |
| ↑ same, with a clean gcc-13 present | 13 |
| unsuffixed 11 (below floor) | FAIL |
| 11 unsuffixed, 12 versioned | 12 |
| only `gcc-ar`/`gcc-nm` decoys | FAIL |
| empty `/usr/bin` | FAIL |

`verify`, 14 cases: versioned accepted, the container's unversioned still accepted (sonar), clang lane intact, `g++`-as-`CC` still rejected.

### What to watch

- **Codecov's coverage will shift**: gcc 15 → 14 moves the numbers. The delta on this pull request is a re-baseline, not a regression. SonarCloud stays on gcc 15 and should not move.
- **`select-gcc` inside the container** is the one case only fixtures cover; `sonarcloud`'s step log should show it selecting 15.
- **The venv** — `python3 -m venv` needs `python3-venv` on the runner; unverified. Ubuntu 24.04's Python is externally-managed, so a bare `pip install` would not do; `--break-system-packages` is the fallback if the venv is unavailable.
- **`sonarcloud` must stay green** — it exercises the shared `verify` change with a containerised gcc-15.

