### PR TITLE
Run the sonarcloud jobs on arm64

### DIFF
--- a/.github/workflows/sonarcloud-pr-scan.yml
+++ b/.github/workflows/sonarcloud-pr-scan.yml
@@ -33,9 +33,10 @@ jobs:
       github.event.workflow_run.event == 'pull_request' &&
       github.event.workflow_run.conclusion == 'success' &&
       (github.repository == 'libfn/functional' || vars.SONAR_PROJECT_KEY != '')
+    # arm64: the amd64 warp fleet pulls images at 1-2 MB/s; the arm64 fleet serves them in seconds
     # Runner and container must match sonarcloud.yml's: the compiler paths in the compile_commands.json
     # analysed below were recorded there, and must resolve to the same toolchain here.
-    runs-on: ${{ github.repository == 'libfn/functional' && 'warp-ubuntu-latest-x64-4x' || 'ubuntu-latest' }}
+    runs-on: ${{ github.repository == 'libfn/functional' && 'warp-ubuntu-latest-arm64-4x' || 'ubuntu-latest' }}
     container: libfn.azurecr.io/ci-build-gcc:15-sha-08b1133
     env:
       SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}

--- a/.github/workflows/sonarcloud.yml
+++ b/.github/workflows/sonarcloud.yml
@@ -9,9 +9,10 @@ on:
 
 jobs:
   sonarcloud:
+    # arm64: the amd64 warp fleet pulls images at 1-2 MB/s; the arm64 fleet serves them in seconds.
     # Runner and container must match sonarcloud-pr-scan's: it analyses the compile_commands.json
     # written here, and the compiler paths recorded in it must resolve to the same toolchain there.
-    runs-on: ${{ github.repository == 'libfn/functional' && 'warp-ubuntu-latest-x64-4x' || 'ubuntu-latest' }}
+    runs-on: ${{ github.repository == 'libfn/functional' && 'warp-ubuntu-latest-arm64-4x' || 'ubuntu-latest' }}
     container: libfn.azurecr.io/ci-build-gcc:15-sha-08b1133
     env:
       # Gates the inline scan below (a fork without a token no-ops); see also resolve-sonar-project.


### PR DESCRIPTION
The last two jobs still paying the container tax. `ci-build-gcc:15` is ~0.5 GB and the amd64 warp fleet serves it at 1–2 MB/s, so each job spends **4–6 minutes** in "Initialize containers" reaching a compiler the arm64 fleet hands over in about **15 seconds** — measured in #313, where the same move took the package tests from 10+ minutes to ~30 seconds end to end, including first-ever pulls of images never fetched on arm64 before.

Nothing else changes. The container stays, so sonar keeps **gcc 15** and its numbers should not move; `select-gcc` finds the same unsuffixed toolchain there (the images are multi-arch — `linux/amd64` + `linux/arm64`).

Both jobs move **together**, which is not optional: `sonarcloud-pr-scan` analyses the `compile_commands.json` that `sonarcloud` writes, and the compiler paths recorded in it must resolve to the same toolchain in both. Each file carries a comment saying so, directly above the line this changes.

### This is an experiment

Whether SonarCloud's tooling runs on `linux-aarch64` is the open question — the one thing that kept this from being done alongside #338. Two ways it could fail, both loud and immediate rather than silent:

- **JRE provisioning** — the scan action fetches a JRE per architecture (`JRE provisioning: os[linux], arch[x86_64]` in today's logs); it needs an aarch64 build to exist.
- **The CFamily analyzer** — shipped as a native binary; an aarch64 one has to be published.

If either is missing the job fails at that step and we revert; the coverage data itself is architecture-blind, and the library is header-only.

Worth ~8–12 minutes per pull request if it holds.
