### PR TITLE
Collapse differing choice results of and_then into the superset

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 Design history of libfn, newest first. The living documents — [README.md](README.md), [CONTRIBUTING.md](CONTRIBUTING.md), [docs/](docs/) — describe only the present state of the design; when a decision makes an earlier idea obsolete, this file is where the transition is recorded and explained.
 
+## `choice::and_then` joins differing branches into the superset choice — 18 July 2026
+
+- **Branches of the dispatch may return different choice types** ([#349](https://github.com/libfn/functional/issues/349)): the result is the grade-spliced superset — all branches' alternatives, normalized and deduplicated exactly as `choice_for` produces. Previously every applicable branch had to agree on one choice type. `and_then` is the join, the one operation licensed to cross the choice boundary, and with the superset collapse `x.transform(f) == x.and_then([](auto &&v) { return choice{f(FWD(v))}; })` holds for heterogeneous branches too. Purely additive: everything now accepted was ill-formed before, and convergent callbacks keep their exact types and behaviour. The join is its own detail fold beside `transform`'s collapse — the collapse keeps a returned choice whole (fmap nests the atom), the join splices its alternatives (bind flattens) — and each branch's result reaches the superset through the existing copack widening constructors, a narrower choice converting through its copack base. A value-returning callback remains rejected, and an inapplicable one still drops `and_then` from the overload set.
+
 ## `sum` became `copack` — 17 July 2026
 
 - **The co-product of types renamed** ([#83](https://github.com/libfn/functional/issues/83)): `fn::sum` is `fn::copack`, and the whole vocabulary follows — `copack_for`, `some_copack`, `empty_copack`, `as_copack`, the graded verbs `copack_value` and `copack_error`, and the header `fn/copack.hpp`. The old name read as an arithmetic operation; `copack` names what the type is — the co-product of types, orthogonal to `pack`, the product. A clean break with no alias: the library is pre-0.1 and has no compatibility surface to keep.

--- a/include/fn/choice.hpp
+++ b/include/fn/choice.hpp
@@ -677,10 +677,15 @@ struct choice<Ts...> : copack<Ts...> {
    * @return TODO
    */
   template <typename Fn>
-  constexpr auto and_then(Fn &&fn) & noexcept(noexcept(this->apply(FWD(fn)))) -> decltype(this->apply(FWD(fn)))
+  constexpr auto and_then(Fn &&fn) & noexcept(
+      detail::_is_nothrow_rts_applicable<
+          typename detail::_copack_apply_result<detail::_joining_superset_tag, decltype(fn), choice &>::type, Fn &&,
+          choice &>) -> typename detail::_copack_apply_result<detail::_joining_superset_tag, Fn &&, choice &>::type
+    requires typelist_applicable<Fn, choice &>
   {
-    static_assert(some_choice<decltype(this->apply(FWD(fn)))>);
-    return this->apply(FWD(fn));
+    using type = detail::_copack_apply_result<detail::_joining_superset_tag, decltype(fn), choice &>::type;
+    static_assert(some_choice<type>);
+    return detail::apply_variadic_union<type, typename _impl::data_t>(_impl::data, _impl::index, FWD(fn));
   }
 
   /**
@@ -691,10 +696,16 @@ struct choice<Ts...> : copack<Ts...> {
    * @return TODO
    */
   template <typename Fn>
-  constexpr auto and_then(Fn &&fn) const & noexcept(noexcept(this->apply(FWD(fn)))) -> decltype(this->apply(FWD(fn)))
+  constexpr auto and_then(Fn &&fn) const & noexcept(
+      detail::_is_nothrow_rts_applicable<
+          typename detail::_copack_apply_result<detail::_joining_superset_tag, decltype(fn), choice const &>::type,
+          Fn &&, choice const &>) ->
+      typename detail::_copack_apply_result<detail::_joining_superset_tag, Fn &&, choice const &>::type
+    requires typelist_applicable<Fn, choice const &>
   {
-    static_assert(some_choice<decltype(this->apply(FWD(fn)))>);
-    return this->apply(FWD(fn));
+    using type = detail::_copack_apply_result<detail::_joining_superset_tag, decltype(fn), choice const &>::type;
+    static_assert(some_choice<type>);
+    return detail::apply_variadic_union<type, typename _impl::data_t>(_impl::data, _impl::index, FWD(fn));
   }
 
   /**
@@ -705,11 +716,15 @@ struct choice<Ts...> : copack<Ts...> {
    * @return TODO
    */
   template <typename Fn>
-  constexpr auto and_then(Fn &&fn) && noexcept(noexcept(::std::move(*this).apply(FWD(fn))))
-      -> decltype(::std::move(*this).apply(FWD(fn)))
+  constexpr auto and_then(Fn &&fn) && noexcept(
+      detail::_is_nothrow_rts_applicable<
+          typename detail::_copack_apply_result<detail::_joining_superset_tag, decltype(fn), choice &&>::type, Fn &&,
+          choice &&>) -> typename detail::_copack_apply_result<detail::_joining_superset_tag, Fn &&, choice &&>::type
+    requires typelist_applicable<Fn, choice &&>
   {
-    static_assert(some_choice<decltype(::std::move(*this).apply(FWD(fn)))>);
-    return ::std::move(*this).apply(FWD(fn));
+    using type = detail::_copack_apply_result<detail::_joining_superset_tag, decltype(fn), choice &&>::type;
+    static_assert(some_choice<type>);
+    return detail::apply_variadic_union<type, typename _impl::data_t>(::std::move(_impl::data), _impl::index, FWD(fn));
   }
 
   /**
@@ -720,11 +735,16 @@ struct choice<Ts...> : copack<Ts...> {
    * @return TODO
    */
   template <typename Fn>
-  constexpr auto and_then(Fn &&fn) const && noexcept(noexcept(::std::move(*this).apply(FWD(fn))))
-      -> decltype(::std::move(*this).apply(FWD(fn)))
+  constexpr auto and_then(Fn &&fn) const && noexcept(
+      detail::_is_nothrow_rts_applicable<
+          typename detail::_copack_apply_result<detail::_joining_superset_tag, decltype(fn), choice const &&>::type,
+          Fn &&, choice const &&>) ->
+      typename detail::_copack_apply_result<detail::_joining_superset_tag, Fn &&, choice const &&>::type
+    requires typelist_applicable<Fn, choice const &&>
   {
-    static_assert(some_choice<decltype(::std::move(*this).apply(FWD(fn)))>);
-    return ::std::move(*this).apply(FWD(fn));
+    using type = detail::_copack_apply_result<detail::_joining_superset_tag, decltype(fn), choice const &&>::type;
+    static_assert(some_choice<type>);
+    return detail::apply_variadic_union<type, typename _impl::data_t>(::std::move(_impl::data), _impl::index, FWD(fn));
   }
 };
 

--- a/include/fn/copack.hpp
+++ b/include/fn/copack.hpp
@@ -130,6 +130,53 @@ template <typename Fn, typename Self, typename... Args>
 struct _copack_apply_result<_collapsing_copack_tag, Fn, Self, Args...> final
     : _typelist_collapsing_copack<Fn, Self, ::std::remove_cvref_t<Self>, Args...> {};
 
+struct _joining_superset_tag final {};
+
+// and_then's join - a sibling of the collapse above with the OPPOSITE convention for a result of
+// Self's own kind: the collapse keeps it whole (fmap nests the nominal atom), the join splices its
+// alternatives into the accumulated list (bind flattens). Only results of Self's own template kind
+// splice - the kind is deduced from Self exactly as the collapse deduces Tpl.
+namespace _joining_superset {
+template <typename... Ts> struct typelist;
+template <typename... Ts> extern typelist<Ts...> const &typelist_v;
+
+template <typename... Ts, template <typename...> typename Tpl, typename... Us>
+auto operator^(typelist<Ts...> const &, typelist<Tpl<Us...>> const &) -> typelist<Ts..., Us...> const &;
+
+template <typename... Ts> using flattened = ::std::remove_cvref_t<decltype((typelist_v<> ^ ... ^ typelist_v<Ts>))>;
+
+template <template <typename...> typename Tpl, typename T> constexpr inline bool is_kind = false;
+template <template <typename...> typename Tpl, typename... Us> constexpr inline bool is_kind<Tpl, Tpl<Us...>> = true;
+
+template <template <typename...> typename Tpl, typename T> struct superset;
+template <template <typename...> typename Tpl, typename... Ts> struct superset<Tpl, typelist<Ts...>> {
+  using type = ::fn::detail::normalized<Ts...>::template apply<Tpl>;
+};
+} // namespace _joining_superset
+
+template <template <typename...> typename Tpl, typename... Rs> struct _joining_superset_type {
+  using type = _joining_superset::superset<Tpl, _joining_superset::flattened<Rs...>>::type;
+};
+
+// Results all of Self's kind join into the normalized superset; anything else falls back to the
+// select trait, so today's diagnostics are preserved verbatim - a convergent result of another
+// kind instantiates the member, whose static_assert names the requirement, and a divergent one
+// trips select's own assert.
+template <typename Fn, typename Self, typename T, typename... Args> struct _typelist_joining_superset;
+template <typename Fn, typename Self, template <typename...> typename Tpl, typename... Ts, typename... Args>
+struct _typelist_joining_superset<Fn, Self, Tpl<Ts...>, Args...>
+    : ::std::conditional_t<
+          (...
+           && _joining_superset::is_kind<Tpl, ::std::remove_cvref_t<typename ::fn::detail::_apply_result<
+                                                  Fn, apply_const_lvalue_t<Self, Ts>, Args...>::type>>),
+          _joining_superset_type<Tpl, ::std::remove_cvref_t<typename ::fn::detail::_apply_result<
+                                          Fn, apply_const_lvalue_t<Self, Ts>, Args...>::type>...>,
+          _typelist_select_apply_result<Fn, Self, Tpl<Ts...>, Args...>> {};
+
+template <typename Fn, typename Self, typename... Args>
+struct _copack_apply_result<_joining_superset_tag, Fn, Self, Args...> final
+    : _typelist_joining_superset<Fn, Self, ::std::remove_cvref_t<Self>, Args...> {};
+
 template <typename Fn, typename Self, typename T, typename... Args> struct _typelist_type_select_invoke_result;
 template <typename Fn, typename Self, template <typename...> typename Tpl, typename... Ts, typename... Args>
 struct _typelist_type_select_invoke_result<Fn, Self, Tpl<Ts...>, Args...> {

--- a/tests/fn/choice.cpp
+++ b/tests/fn/choice.cpp
@@ -54,6 +54,9 @@ concept can_emplace = requires(S &s, Args &&...args) { s.template emplace<T>(sta
 template <typename S, typename Fn>
 concept can_transform = requires(S s, Fn fn) { FWD(s).transform(fn); };
 
+template <typename S, typename Fn>
+concept can_and_then = requires(S s, Fn fn) { FWD(s).and_then(fn); };
+
 template <typename S, typename Fn, typename... Args>
 concept can_apply_type = requires(S s, Fn fn, Args... args) { FWD(s).apply_type(FWD(fn), FWD(args)...); };
 
@@ -865,6 +868,71 @@ TEST_CASE("choice and_then", "[choice][and_then]")
                                  [](int &&) -> fn::choice<bool> { throw 0; },      //
                                  [](int const &&i) -> fn::choice<bool> { return {i == 42}; }})
                 == fn::choice{true});
+
+  SECTION("superset join")
+  {
+    struct A final {
+      bool operator==(A const &) const = default;
+    };
+    struct B final {
+      bool operator==(B const &) const = default;
+    };
+    struct U final {
+      bool operator==(U const &) const = default;
+    };
+    struct V final {
+      bool operator==(V const &) const = default;
+    };
+    struct W final {
+      bool operator==(W const &) const = default;
+    };
+    using J = fn::choice_for<A, B>;
+
+    // divergent branch choices join into the normalized superset choice
+    constexpr auto fnJoin = fn::overload{[](A) { return fn::choice<U>{U{}}; }, //
+                                         [](B) { return fn::choice_for<V, W>{V{}}; }};
+    static_assert(std::is_same_v<decltype(J{A{}}.and_then(fnJoin)), fn::choice_for<U, V, W>>);
+    CHECK(J{A{}}.and_then(fnJoin) == fn::choice_for<U, V, W>{U{}});
+    CHECK(J{B{}}.and_then(fnJoin) == fn::choice_for<U, V, W>{V{}});
+
+    // ... with overlapping alternatives deduplicated
+    constexpr auto fnOverlap = fn::overload{[](A) { return fn::choice_for<U, V>{U{}}; }, //
+                                            [](B) { return fn::choice_for<V, W>{W{}}; }};
+    static_assert(std::is_same_v<decltype(J{A{}}.and_then(fnOverlap)), fn::choice_for<U, V, W>>);
+    CHECK(J{A{}}.and_then(fnOverlap) == fn::choice_for<U, V, W>{U{}});
+    CHECK(J{B{}}.and_then(fnOverlap) == fn::choice_for<U, V, W>{W{}});
+
+    static_assert(J{A{}}.and_then(fnJoin) == fn::choice_for<U, V, W>{U{}});
+    static_assert(J{B{}}.and_then(fnOverlap) == fn::choice_for<U, V, W>{W{}});
+
+    // noexcept: the callback and the widening arms both weigh in
+    constexpr auto fnNothrow = fn::overload{[](A) noexcept { return fn::choice<U>{U{}}; }, //
+                                            [](B) noexcept { return fn::choice_for<V, W>{V{}}; }};
+    J j{A{}};
+    static_assert(noexcept(j.and_then(fnNothrow)));
+    static_assert(noexcept(std::as_const(j).and_then(fnNothrow)));
+    static_assert(noexcept(std::move(j).and_then(fnNothrow)));
+    static_assert(not noexcept(j.and_then(fnJoin))); // fnJoin's branches may throw
+    struct ThrowingMove final {
+      ThrowingMove() = default;
+      ThrowingMove(ThrowingMove &&) noexcept(false) {}
+      bool operator==(ThrowingMove const &) const = default;
+    };
+    // nothrow branches, but relocating one branch's alternative into the superset may throw
+    constexpr auto fnThrowingArm
+        = fn::overload{[](A) noexcept { return fn::choice<ThrowingMove>{std::in_place_type<ThrowingMove>}; },
+                       [](B) noexcept { return fn::choice<U>{U{}}; }};
+    static_assert(not noexcept(j.and_then(fnThrowingArm)));
+
+    // asking answers: an inapplicable callback drops and_then from the overload set; a
+    // value-returning one stays viable - its rejection is the deliberately loud static_assert
+    // on instantiation, not a constraint
+    constexpr auto fnPartial = [](A) { return fn::choice<U>{U{}}; };
+    static_assert(not can_and_then<J &, decltype(fnPartial)>);
+    static_assert(can_and_then<fn::choice<A> &, decltype(fnPartial)>);
+    constexpr auto fnValue = [](auto &&) { return 42; };
+    static_assert(can_and_then<J &, decltype(fnValue)>);
+  }
 }
 
 TEST_CASE("choice transform", "[choice][transform]")

--- a/tests/fn/choice.cpp
+++ b/tests/fn/choice.cpp
@@ -902,8 +902,13 @@ TEST_CASE("choice and_then", "[choice][and_then]")
     CHECK(J{A{}}.and_then(fnOverlap) == fn::choice_for<U, V, W>{U{}});
     CHECK(J{B{}}.and_then(fnOverlap) == fn::choice_for<U, V, W>{W{}});
 
-    static_assert(J{A{}}.and_then(fnJoin) == fn::choice_for<U, V, W>{U{}});
-    static_assert(J{B{}}.and_then(fnOverlap) == fn::choice_for<U, V, W>{W{}});
+    // constexpr twins dispatch from named sources: VS 2022's MSVC (observed through 19.44)
+    // misreads the union's empty-class member as uninitialized when the source is a prvalue
+    // materialized mid-expression - independent of the join, apply's select path trips the same way
+    constexpr J ca{A{}};
+    constexpr J cb{B{}};
+    static_assert(ca.and_then(fnJoin) == fn::choice_for<U, V, W>{U{}});
+    static_assert(std::move(cb).and_then(fnOverlap) == fn::choice_for<U, V, W>{W{}});
 
     // noexcept: the callback and the widening arms both weigh in
     constexpr auto fnNothrow = fn::overload{[](A) noexcept { return fn::choice<U>{U{}}; }, //


### PR DESCRIPTION
`choice::and_then` branches may now return *different* choice types: the result is the grade-spliced superset — every branch's alternatives, normalized and deduplicated exactly as `choice_for` produces. Previously `_typelist_select_apply_result` mandated one common result type across all applicable branches. `and_then` is the join, the one operation licensed to cross the choice boundary; with the superset collapse, the fmap-from-bind derivation `x.transform(f) == x.and_then([](auto &&v) { return choice{f(FWD(v))}; })` holds for heterogeneous branches too.

```cpp
fn::choice_for<A, B>{A{}}.and_then(fn::overload{
    [](A) { return fn::choice<U>{U{}}; },
    [](B) { return fn::choice_for<V, W>{V{}}; }});
// before: error (branches must agree); now: choice_for<U, V, W>
```

Implementation notes:

- **The join engine is a detail-layer sibling of `transform`'s collapse fold, with the opposite convention for a result of Self's own kind**: the collapse keeps it whole (fmap nests the nominal atom), the join splices its alternatives (bind flattens). It is a separate fold precisely so `transform`'s meaning cannot shift.
- **copack.hpp names no monad**: the target template is deduced from Self (`Tpl<Ts...>` pattern), the same way the collapse gate takes its `Tpl` — the fold's splice overload deduces `Tpl<Us...>` generically behind an `is_kind` gate ("all results are instances of Self's template"). The engine is thereby consumer-agnostic — the shape #350's cluster arm will reuse.
- **No new conversions**: each branch's narrower choice reaches the superset through its `copack` base and the existing `is_superset_of`-constrained widening constructors; the alternative mapping, constexpr usability, and `noexcept` pricing of that path are probe-verified and pinned in the tests.
- **Diagnostics preserved verbatim**: when the results are not all choices the trait falls back to the select machinery — a convergent non-choice result still trips `and_then`'s own `some_choice` static_assert (deliberately loud, and pinned as *viable* in the suite: a mandate, not a constraint), a divergent one still trips select's assert, and an inapplicable callback still drops `and_then` from the overload set (asking answers).
- **`noexcept`** is computed from callback applicability plus the widening arms via the existing `_is_nothrow_rts_applicable` with the superset as the result type; a throwing-move alternative in one branch's choice correctly poisons the specification (pinned, with its positive control).
- Purely additive: everything now accepted was ill-formed before; convergent callbacks keep their exact types and behaviour (pinned against the pre-change baselines).

Tests: the superset join with disjoint and overlapping (deduplicated) alternatives, runtime paths down both branches with constexpr twins, `noexcept` pins including the widening-arm fixture, and the constraint probes above.

Verified on gcc and clang across Debug/Release and both `VALIDATE_CXX23` lanes, and on MSVC (build and ctest).

Closes #349

🤖 Generated with [Claude Code](https://claude.com/claude-code)
