### PR TITLE
Remove macOS 14 support

### DIFF
--- a/.github/actionlint.yaml
+++ b/.github/actionlint.yaml
@@ -4,6 +4,5 @@ self-hosted-runner:
     - warp-ubuntu-latest-arm64-2x
     - warp-ubuntu-latest-arm64-4x
     - warp-ubuntu-latest-x64-4x
-    - warp-macos-14-arm64-6x
     - warp-macos-15-arm64-6x
     - warp-macos-26-arm64-6x

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -120,8 +120,6 @@ jobs:
           - Release
         compiler:
           - name: appleclang
-            osver: 14
-          - name: appleclang
             osver: 15
           - name: appleclang
             osver: 26

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 Design history of libfn, newest first. The living documents — [README.md](README.md), [CONTRIBUTING.md](CONTRIBUTING.md), [docs/](docs/) — describe only the present state of the design; when a decision makes an earlier idea obsolete, this file is where the transition is recorded and explained.
 
+## macOS 14 support removed — 18 July 2026
+
+- **The macOS-14 CI lane (Apple clang 15) is gone**: Apple clang 15 was the only compiler in the matrix without P0960 (parenthesized aggregate initialization, a C++20 feature) and sat below the documented Apple Clang 16.0 floor; its frontend also crashes outright on the `just` test suite. With the lane went the test-side aggregate-construction wraps it alone required — the terse in-place forms (`{unexpect, "…"}`, `{in_place, N}`) are restored throughout the verb tests and `examples/simple`.
+
 ## `choice::and_then` joins differing branches into the superset choice — 18 July 2026
 
 - **Branches of the dispatch may return different choice types** ([#349](https://github.com/libfn/functional/issues/349)): the result is the grade-spliced superset — all branches' alternatives, normalized and deduplicated exactly as `choice_for` produces. Previously every applicable branch had to agree on one choice type. `and_then` is the join, the one operation licensed to cross the choice boundary, and with the superset collapse `x.transform(f) == x.and_then([](auto &&v) { return choice{f(FWD(v))}; })` holds for heterogeneous branches too. Purely additive: everything now accepted was ill-formed before, and convergent callbacks keep their exact types and behaviour. The join is its own detail fold beside `transform`'s collapse — the collapse keeps a returned choice whole (fmap nests the atom), the join splices its alternatives (bind flattens) — and each branch's result reaches the superset through the existing copack widening constructors, a narrower choice converting through its copack base. A value-returning callback remains rejected, and an inapplicable one still drops `and_then` from the overload set.

--- a/examples/simple/main.cpp
+++ b/examples/simple/main.cpp
@@ -83,7 +83,7 @@ TEST_CASE("Minimal expected", "[expected][and_then]")
   }
   {
     // example-expected-and_then-error
-    fn::expected<double, Error> ex = ::fn::unexpected<Error>{Error{"Not good"}};
+    fn::expected<double, Error> ex = ::fn::unexpected<Error>{"Not good"};
 
     auto oops = ex
       | fn::and_then([](auto&& v) -> fn::expected<unsigned, Error> {
@@ -139,14 +139,14 @@ TEST_CASE("Demo expected", "[expected][pack][and_then][discard][transform_error]
       if (std::from_chars(str.data(), end, tmp).ptr == end) {
         return {tmp};
       }
-      return ::fn::unexpected<Error>{Error{"Failed to parse " + std::string(str)}};
+      return ::fn::unexpected<Error>{"Failed to parse " + std::string(str)};
     };
 
     // Immovable operations must be captured as lvalues, and functor will store
     // reference to them rather than make a copy
     constexpr auto fn1 = [j = ImmovableValue{-1}](int i) noexcept -> fn::expected<double, Error> {
       if (i < j.value) {
-        return ::fn::unexpected<Error>{Error{"Too small"}};
+        return ::fn::unexpected<Error>{"Too small"};
       }
       return {i + 0.5};
     };
@@ -199,12 +199,12 @@ TEST_CASE("Demo expected", "[expected][pack][and_then][discard][transform_error]
       if (std::from_chars(str.data(), end, tmp).ptr == end) {
         return {tmp};
       }
-      return ::fn::unexpected<Error>{Error{"Failed to parse " + std::string(str)}};
+      return ::fn::unexpected<Error>{"Failed to parse " + std::string(str)};
     };
 
     constexpr auto parse_twelve = [](std::string str) noexcept -> fn::expected<double, Error> {
       if (str != "12")
-        return ::fn::unexpected<Error>{Error{"Not 12"}};
+        return ::fn::unexpected<Error>{"Not 12"};
       return {12.};
     };
 
@@ -235,7 +235,7 @@ TEST_CASE("Demo expected", "[expected][pack][and_then][discard][transform_error]
       | fn::inspect_error([](Error) noexcept { CHECK(false); }) //
       | fn::discard();
 
-  fn::expected<int, Error>{::fn::unexpected<Error>{Error{"discarded"}}}             //
+  fn::expected<int, Error>{::fn::unexpected<Error>{"discarded"}}                    //
       | fn::inspect([](int) noexcept { CHECK(false); })                             //
       | fn::inspect_error([](Error e) noexcept { REQUIRE(e.what == "discarded"); }) //
       | fn::discard();

--- a/tests/fn/and_then.cpp
+++ b/tests/fn/and_then.cpp
@@ -226,7 +226,7 @@ TEST_CASE("and_then", "[and_then][expected][expected_value][pack]")
 
   constexpr auto fnValue = [](int i) -> operand_t { return {i + 1}; };
   constexpr auto wrong = [](int) -> operand_t { throw 0; };
-  constexpr auto fnFail = [](int i) -> operand_t { return ::fn::unexpected<Error>(Error{"Got " + std::to_string(i)}); };
+  constexpr auto fnFail = [](int i) -> operand_t { return ::fn::unexpected<Error>("Got " + std::to_string(i)); };
   constexpr auto fnXabs = [](int i) -> fn::expected<Xint, Error> { return {{std::abs(8 - i)}}; };
 
   static_assert(is::invocable_with_any(fnValue));
@@ -319,7 +319,7 @@ TEST_CASE("and_then", "[and_then][expected][expected_value][pack]")
 
     SECTION("error")
     {
-      operand_t a{::fn::unexpect, Error{"Not good"}};
+      operand_t a{::fn::unexpect, "Not good"};
       using T = decltype(a | and_then(wrong));
       static_assert(std::is_same_v<T, operand_t>);
       REQUIRE((a //
@@ -343,7 +343,7 @@ TEST_CASE("and_then", "[and_then][expected][expected_value][pack]")
         SECTION("fail")
         {
           constexpr auto fnFail = [](int i, double d) constexpr -> fn::expected<int, Error> {
-            return ::fn::unexpected<Error>(Error{"Got " + std::to_string(i) + " and " + std::to_string(d)});
+            return ::fn::unexpected<Error>("Got " + std::to_string(i) + " and " + std::to_string(d));
           };
           using T = decltype(a | and_then(fnFail));
           static_assert(std::is_same_v<T, fn::expected<int, Error>>);
@@ -354,7 +354,7 @@ TEST_CASE("and_then", "[and_then][expected][expected_value][pack]")
       SECTION("error")
       {
         constexpr auto wrong = [](auto...) -> operand_t { throw 0; };
-        REQUIRE((operand_t{::fn::unexpect, Error{"Not good"}} | and_then(wrong)).error().what == "Not good");
+        REQUIRE((operand_t{::fn::unexpect, "Not good"} | and_then(wrong)).error().what == "Not good");
       }
     }
   }
@@ -383,9 +383,9 @@ TEST_CASE("and_then", "[and_then][expected][expected_value][pack]")
     }
     SECTION("error")
     {
-      using T = decltype(operand_t{::fn::unexpect, Error{"Not good"}} | and_then(wrong));
+      using T = decltype(operand_t{::fn::unexpect, "Not good"} | and_then(wrong));
       static_assert(std::is_same_v<T, operand_t>);
-      REQUIRE((operand_t{::fn::unexpect, Error{"Not good"}} //
+      REQUIRE((operand_t{::fn::unexpect, "Not good"} //
                | and_then(wrong))
                   .error()
                   .what
@@ -548,7 +548,7 @@ TEST_CASE("and_then", "[and_then][expected][expected_void]")
   };
 
   constexpr auto wrong = []() -> operand_t { throw 0; };
-  auto fnFail = [&count]() -> operand_t { return ::fn::unexpected<Error>(Error{"Got " + std::to_string(++count)}); };
+  auto fnFail = [&count]() -> operand_t { return ::fn::unexpected<Error>("Got " + std::to_string(++count)); };
   auto fnXabs = [&count]() -> fn::expected<Xint, Error> { return {{++count}}; };
 
   static_assert(is::invocable_with_any(fnValue));
@@ -606,7 +606,7 @@ TEST_CASE("and_then", "[and_then][expected][expected_void]")
     }
     SECTION("error")
     {
-      operand_t a{::fn::unexpect, Error{"Not good"}};
+      operand_t a{::fn::unexpect, "Not good"};
       using T = decltype(a | and_then(wrong));
       static_assert(std::is_same_v<T, operand_t>);
       REQUIRE((a //
@@ -642,9 +642,9 @@ TEST_CASE("and_then", "[and_then][expected][expected_void]")
     }
     SECTION("error")
     {
-      using T = decltype(operand_t{::fn::unexpect, Error{"Not good"}} | and_then(wrong));
+      using T = decltype(operand_t{::fn::unexpect, "Not good"} | and_then(wrong));
       static_assert(std::is_same_v<T, operand_t>);
-      REQUIRE((operand_t{::fn::unexpect, Error{"Not good"}} //
+      REQUIRE((operand_t{::fn::unexpect, "Not good"} //
                | and_then(wrong))
                   .error()
                   .what

--- a/tests/fn/discard.cpp
+++ b/tests/fn/discard.cpp
@@ -14,23 +14,13 @@
 
 using namespace util;
 
-namespace {
-struct Error {
-  std::string what;
-};
-
-struct DerivedError : Error {};
-struct IncompatibleError {};
-
-struct Value {
-  int v;
-  constexpr bool operator==(Value const &) const = default;
-};
-} // namespace
-
 TEST_CASE("discard", "[discard][expected][expected_value]")
 {
   using namespace fn;
+
+  struct Error final {
+    std::string what;
+  };
 
   using operand_t = fn::expected<int, Error>;
   using is = monadic_static_check<discard_t, operand_t>;
@@ -96,6 +86,11 @@ TEST_CASE("discard with pack", "[discard][expected][expected_value][pack]")
 {
   using namespace fn;
 
+  struct Error final {
+    std::string what;
+    constexpr ~Error() = default; // MSVC workaround
+  };
+
   using operand_t = fn::expected<fn::pack<int, double>, Error>;
   using is = monadic_static_check<discard_t, operand_t>;
   static_assert(is::invocable_with_any());
@@ -120,6 +115,10 @@ TEST_CASE("discard with pack", "[discard][expected][expected_value][pack]")
 TEST_CASE("discard", "[discard][expected][expected_void]")
 {
   using namespace fn;
+
+  struct Error final {
+    std::string what;
+  };
 
   using operand_t = fn::expected<void, Error>;
   using is = monadic_static_check<discard_t, operand_t>;
@@ -229,6 +228,10 @@ TEST_CASE("discard", "[discard][optional]")
 TEST_CASE("discard noexcept", "[discard][noexcept]")
 {
   using namespace fn;
+
+  struct Error final {
+    std::string what;
+  };
 
   // The one verb whose unconditional noexcept is accurate by construction: discard's apply takes the
   // operand by reference, invokes no callback and returns void, so there is nothing in it that can

--- a/tests/fn/discard.cpp
+++ b/tests/fn/discard.cpp
@@ -50,7 +50,7 @@ TEST_CASE("discard", "[discard][expected][expected_value]")
 
     SECTION("error")
     {
-      operand_t a{::fn::unexpect, Error{"Not good"}};
+      operand_t a{::fn::unexpect, "Not good"};
       a | discard();
 
       REQUIRE(a.error().what == "Not good");
@@ -67,7 +67,7 @@ TEST_CASE("discard", "[discard][expected][expected_value]")
 
     SECTION("error")
     {
-      operand_t{::fn::unexpect, Error{"Not good"}} | discard();
+      operand_t{::fn::unexpect, "Not good"} | discard();
       SUCCEED();
     }
   }
@@ -110,7 +110,7 @@ TEST_CASE("discard with pack", "[discard][expected][expected_value][pack]")
 
   SECTION("error")
   {
-    operand_t b{::fn::unexpect, Error{"Pack error"}};
+    operand_t b{::fn::unexpect, "Pack error"};
     b | discard();
 
     REQUIRE(b.error().what == "Pack error");
@@ -139,7 +139,7 @@ TEST_CASE("discard", "[discard][expected][expected_void]")
 
     SECTION("error")
     {
-      operand_t a{::fn::unexpect, Error{"Not good"}};
+      operand_t a{::fn::unexpect, "Not good"};
       a | discard();
 
       REQUIRE(a.error().what == "Not good");
@@ -156,7 +156,7 @@ TEST_CASE("discard", "[discard][expected][expected_void]")
 
     SECTION("error")
     {
-      operand_t{::fn::unexpect, Error{"Not good"}} | discard();
+      operand_t{::fn::unexpect, "Not good"} | discard();
       SUCCEED();
     }
   }

--- a/tests/fn/fail.cpp
+++ b/tests/fn/fail.cpp
@@ -79,7 +79,7 @@ TEST_CASE("fail", "[fail][expected][expected_value][pack]")
     }
     SECTION("error")
     {
-      operand_t a{::fn::unexpect, Error{"Not good"}};
+      operand_t a{::fn::unexpect, "Not good"};
       using T = decltype(a | fail(wrong));
       static_assert(std::is_same_v<T, operand_t>);
       REQUIRE((a //
@@ -91,7 +91,7 @@ TEST_CASE("fail", "[fail][expected][expected_value][pack]")
     SECTION("member function")
     {
       using operand_t = fn::expected<Value, Error>;
-      operand_t a{std::in_place, Value{12}};
+      operand_t a{std::in_place, 12};
       using T = decltype(a | fail(&Value::fn));
       static_assert(std::is_same_v<T, operand_t>);
       REQUIRE((a | fail(&Value::fn)).error().what == "Was 12");
@@ -115,7 +115,7 @@ TEST_CASE("fail", "[fail][expected][expected_value][pack]")
     SECTION("error")
     {
       constexpr auto wrong = [](auto...) -> Error { throw 0; };
-      REQUIRE((operand_t{::fn::unexpect, Error{"Not good"}} | fail(wrong)).error().what == "Not good");
+      REQUIRE((operand_t{::fn::unexpect, "Not good"} | fail(wrong)).error().what == "Not good");
     }
   }
 
@@ -129,9 +129,9 @@ TEST_CASE("fail", "[fail][expected][expected_value][pack]")
     }
     SECTION("error")
     {
-      using T = decltype(operand_t{::fn::unexpect, Error{"Not good"}} | fail(wrong));
+      using T = decltype(operand_t{::fn::unexpect, "Not good"} | fail(wrong));
       static_assert(std::is_same_v<T, operand_t>);
-      REQUIRE((operand_t{::fn::unexpect, Error{"Not good"}} //
+      REQUIRE((operand_t{::fn::unexpect, "Not good"} //
                | fail(wrong))
                   .error()
                   .what
@@ -140,9 +140,9 @@ TEST_CASE("fail", "[fail][expected][expected_value][pack]")
     SECTION("member function")
     {
       using operand_t = fn::expected<Value, Error>;
-      using T = decltype(operand_t{std::in_place, Value{12}} | fail(&Value::fn));
+      using T = decltype(operand_t{std::in_place, 12} | fail(&Value::fn));
       static_assert(std::is_same_v<T, operand_t>);
-      REQUIRE((operand_t{std::in_place, Value{12}} | fail(&Value::fn)).error().what == "Was 12");
+      REQUIRE((operand_t{std::in_place, 12} | fail(&Value::fn)).error().what == "Was 12");
     }
   }
 
@@ -218,7 +218,7 @@ TEST_CASE("fail", "[fail][expected][expected_void]")
     }
     SECTION("error")
     {
-      operand_t a{::fn::unexpect, Error{"Not good"}};
+      operand_t a{::fn::unexpect, "Not good"};
       using T = decltype(a | fail(wrong));
       static_assert(std::is_same_v<T, operand_t>);
       REQUIRE((a //
@@ -239,9 +239,9 @@ TEST_CASE("fail", "[fail][expected][expected_void]")
     }
     SECTION("error")
     {
-      using T = decltype(operand_t{::fn::unexpect, Error{"Not good"}} | fail(wrong));
+      using T = decltype(operand_t{::fn::unexpect, "Not good"} | fail(wrong));
       static_assert(std::is_same_v<T, operand_t>);
-      REQUIRE((operand_t{::fn::unexpect, Error{"Not good"}} //
+      REQUIRE((operand_t{::fn::unexpect, "Not good"} //
                | fail(wrong))
                   .error()
                   .what
@@ -298,7 +298,7 @@ TEST_CASE("fail", "[fail][optional][pack]")
     SECTION("member function")
     {
       using operand_t = fn::optional<Value>;
-      operand_t a{std::in_place, Value{12}};
+      operand_t a{std::in_place, 12};
       using T = decltype(a | fail(&Value::finalize));
       static_assert(std::is_same_v<T, operand_t>);
       auto const before = Value::count;
@@ -350,10 +350,10 @@ TEST_CASE("fail", "[fail][optional][pack]")
     SECTION("member function")
     {
       using operand_t = fn::optional<Value>;
-      using T = decltype(operand_t{std::in_place, Value{12}} | fail(&Value::finalize));
+      using T = decltype(operand_t{std::in_place, 12} | fail(&Value::finalize));
       static_assert(std::is_same_v<T, operand_t>);
       auto const before = Value::count;
-      REQUIRE(not(operand_t{std::in_place, Value{12}} | fail(&Value::finalize)).has_value());
+      REQUIRE(not(operand_t{std::in_place, 12} | fail(&Value::finalize)).has_value());
       CHECK(Value::count == before + 12);
     }
   }

--- a/tests/fn/filter.cpp
+++ b/tests/fn/filter.cpp
@@ -97,7 +97,7 @@ TEST_CASE("filter", "[filter][expected][expected_value]")
 
     SECTION("error")
     {
-      operand_t a{::fn::unexpect, Error{"Not good"}};
+      operand_t a{::fn::unexpect, "Not good"};
       using T = decltype(a | filter(truePred, wrong));
       static_assert(std::is_same_v<T, operand_t>);
 
@@ -132,10 +132,10 @@ TEST_CASE("filter", "[filter][expected][expected_value]")
 
     SECTION("error")
     {
-      using T = decltype(operand_t{::fn::unexpect, Error{"Not good"}} | filter(truePred, wrong));
+      using T = decltype(operand_t{::fn::unexpect, "Not good"} | filter(truePred, wrong));
       static_assert(std::is_same_v<T, operand_t>);
 
-      REQUIRE((operand_t{::fn::unexpect, Error{"Not good"}} //
+      REQUIRE((operand_t{::fn::unexpect, "Not good"} //
                | filter(truePred, wrong))
                   .error()
                   .what
@@ -222,7 +222,7 @@ TEST_CASE("filter member function", "[filter][expected][expected_value][member_f
     {
       SECTION("predicate true")
       {
-        operand_t a{std::in_place, Value{1}};
+        operand_t a{std::in_place, 1};
         using T = decltype(a | filter(predicate, onError));
         static_assert(std::is_same_v<T, operand_t>);
 
@@ -232,7 +232,7 @@ TEST_CASE("filter member function", "[filter][expected][expected_value][member_f
 
       SECTION("predicate false")
       {
-        operand_t a{std::in_place, Value{42}};
+        operand_t a{std::in_place, 42};
         using T = decltype(a | filter(predicate, onError));
         static_assert(std::is_same_v<T, operand_t>);
 
@@ -266,13 +266,13 @@ TEST_CASE("filter member function", "[filter][expected][expected_value][member_f
 
       SECTION("error")
       {
-        REQUIRE((operand_t{::fn::unexpect, Error{"Not good"}} | filter(predPack, errPack)).error().what == "Not good");
+        REQUIRE((operand_t{::fn::unexpect, "Not good"} | filter(predPack, errPack)).error().what == "Not good");
       }
     }
 
     SECTION("error")
     {
-      operand_t a{::fn::unexpect, Error{"Not good"}};
+      operand_t a{::fn::unexpect, "Not good"};
       using T = decltype(a | filter(predicate, wrong));
       static_assert(std::is_same_v<T, operand_t>);
 
@@ -290,29 +290,29 @@ TEST_CASE("filter member function", "[filter][expected][expected_value][member_f
     {
       SECTION("predicate true")
       {
-        using T = decltype(operand_t{std::in_place, Value{1}} | filter(predicate, onError));
+        using T = decltype(operand_t{std::in_place, 1} | filter(predicate, onError));
         static_assert(std::is_same_v<T, operand_t>);
 
-        REQUIRE((operand_t{std::in_place, Value{1}} | filter(predicate, onError)).value().v == 1);
-        REQUIRE((operand_t{std::in_place, Value{1}} | filter(predicate, &Value::error_)).value().v == 1);
+        REQUIRE((operand_t{std::in_place, 1} | filter(predicate, onError)).value().v == 1);
+        REQUIRE((operand_t{std::in_place, 1} | filter(predicate, &Value::error_)).value().v == 1);
       }
 
       SECTION("predicate false")
       {
-        using T = decltype(operand_t{std::in_place, Value{42}} | filter(predicate, onError));
+        using T = decltype(operand_t{std::in_place, 42} | filter(predicate, onError));
         static_assert(std::is_same_v<T, operand_t>);
 
-        REQUIRE((operand_t{std::in_place, Value{42}} | filter(predicate, onError)).error().what == "Got 42");
-        REQUIRE((operand_t{std::in_place, Value{42}} | filter(predicate, &Value::error_)).error().what == "Got 42");
+        REQUIRE((operand_t{std::in_place, 42} | filter(predicate, onError)).error().what == "Got 42");
+        REQUIRE((operand_t{std::in_place, 42} | filter(predicate, &Value::error_)).error().what == "Got 42");
       }
     }
 
     SECTION("error")
     {
-      using T = decltype(operand_t{::fn::unexpect, Error{"Not good"}} | filter(predicate, wrong));
+      using T = decltype(operand_t{::fn::unexpect, "Not good"} | filter(predicate, wrong));
       static_assert(std::is_same_v<T, operand_t>);
 
-      REQUIRE((operand_t{::fn::unexpect, Error{"Not good"}} //
+      REQUIRE((operand_t{::fn::unexpect, "Not good"} //
                | filter(predicate, wrong))
                   .error()
                   .what
@@ -369,7 +369,7 @@ TEST_CASE("filter", "[filter][expected][expected_void]")
 
     SECTION("error")
     {
-      operand_t a{::fn::unexpect, Error{"Not good"}};
+      operand_t a{::fn::unexpect, "Not good"};
       using T = decltype(a | filter(truePred, wrong));
       static_assert(std::is_same_v<T, operand_t>);
 
@@ -404,10 +404,10 @@ TEST_CASE("filter", "[filter][expected][expected_void]")
 
     SECTION("error")
     {
-      using T = decltype(operand_t{::fn::unexpect, Error{"Not good"}} | filter(truePred, wrong));
+      using T = decltype(operand_t{::fn::unexpect, "Not good"} | filter(truePred, wrong));
       static_assert(std::is_same_v<T, operand_t>);
 
-      REQUIRE((operand_t{::fn::unexpect, Error{"Not good"}} //
+      REQUIRE((operand_t{::fn::unexpect, "Not good"} //
                | filter(truePred, wrong))
                   .error()
                   .what

--- a/tests/fn/inspect.cpp
+++ b/tests/fn/inspect.cpp
@@ -70,7 +70,7 @@ TEST_CASE("inspect expected", "[inspect][expected][expected_value][pack]")
     }
     SECTION("error")
     {
-      operand_t a{::fn::unexpect, Error{"Not good"}};
+      operand_t a{::fn::unexpect, "Not good"};
       using T = decltype(a | inspect(wrong));
       static_assert(std::is_same_v<T, operand_t &>);
       REQUIRE((a //
@@ -82,7 +82,7 @@ TEST_CASE("inspect expected", "[inspect][expected][expected_value][pack]")
     SECTION("member function")
     {
       using operand_t = fn::expected<Value, Error>;
-      operand_t a{std::in_place, Value{12}};
+      operand_t a{std::in_place, 12};
       using T = decltype(a | inspect(&Value::fn));
       static_assert(std::is_same_v<T, operand_t &>);
       auto const before = Value::count;
@@ -108,7 +108,7 @@ TEST_CASE("inspect expected", "[inspect][expected][expected_value][pack]")
     SECTION("error")
     {
       using operand_t = fn::expected<fn::pack<int, double>, Error>;
-      operand_t a{::fn::unexpect, Error{"Not good"}};
+      operand_t a{::fn::unexpect, "Not good"};
       constexpr auto wrong = [](auto...) { throw 0; };
       using T = decltype(a | inspect(wrong));
       static_assert(std::is_same_v<T, operand_t &>);
@@ -131,9 +131,9 @@ TEST_CASE("inspect expected", "[inspect][expected][expected_value][pack]")
     }
     SECTION("error")
     {
-      using T = decltype(operand_t{::fn::unexpect, Error{"Not good"}} | inspect(wrong));
+      using T = decltype(operand_t{::fn::unexpect, "Not good"} | inspect(wrong));
       static_assert(std::is_same_v<T, operand_t &&>);
-      REQUIRE((operand_t{::fn::unexpect, Error{"Not good"}} //
+      REQUIRE((operand_t{::fn::unexpect, "Not good"} //
                | inspect(wrong))
                   .error()
                   .what
@@ -142,10 +142,10 @@ TEST_CASE("inspect expected", "[inspect][expected][expected_value][pack]")
     SECTION("member function")
     {
       using operand_t = fn::expected<Value, Error>;
-      using T = decltype(operand_t{std::in_place, Value{12}} | inspect(&Value::fn));
+      using T = decltype(operand_t{std::in_place, 12} | inspect(&Value::fn));
       static_assert(std::is_same_v<T, operand_t &&>);
       auto const before = Value::count;
-      REQUIRE((operand_t{std::in_place, Value{12}} | inspect(&Value::fn)).value().value == 12);
+      REQUIRE((operand_t{std::in_place, 12} | inspect(&Value::fn)).value().value == 12);
       CHECK(Value::count == before + 12);
     }
   }
@@ -210,7 +210,7 @@ TEST_CASE("inspect void expected", "[inspect][expected][expected_void]")
     }
     SECTION("error")
     {
-      operand_t a{::fn::unexpect, Error{"Not good"}};
+      operand_t a{::fn::unexpect, "Not good"};
       using T = decltype(a | inspect(wrong));
       static_assert(std::is_same_v<T, operand_t &>);
       REQUIRE((a //
@@ -232,9 +232,9 @@ TEST_CASE("inspect void expected", "[inspect][expected][expected_void]")
     }
     SECTION("error")
     {
-      using T = decltype(operand_t{::fn::unexpect, Error{"Not good"}} | inspect(wrong));
+      using T = decltype(operand_t{::fn::unexpect, "Not good"} | inspect(wrong));
       static_assert(std::is_same_v<T, operand_t &&>);
-      REQUIRE((operand_t{::fn::unexpect, Error{"Not good"}} //
+      REQUIRE((operand_t{::fn::unexpect, "Not good"} //
                | inspect(wrong))
                   .error()
                   .what
@@ -286,7 +286,7 @@ TEST_CASE("inspect optional", "[inspect][optional][pack]")
     SECTION("member function")
     {
       using operand_t = fn::optional<Value>;
-      operand_t a{std::in_place, Value{12}};
+      operand_t a{std::in_place, 12};
       using T = decltype(a | inspect(&Value::fn));
       static_assert(std::is_same_v<T, operand_t &>);
       auto const before = Value::count;
@@ -340,10 +340,10 @@ TEST_CASE("inspect optional", "[inspect][optional][pack]")
     SECTION("member function")
     {
       using operand_t = fn::optional<Value>;
-      using T = decltype(operand_t{std::in_place, Value{12}} | inspect(&Value::fn));
+      using T = decltype(operand_t{std::in_place, 12} | inspect(&Value::fn));
       static_assert(std::is_same_v<T, operand_t &&>);
       auto const before = Value::count;
-      REQUIRE((operand_t{std::in_place, Value{12}} | inspect(&Value::fn)).value().value == 12);
+      REQUIRE((operand_t{std::in_place, 12} | inspect(&Value::fn)).value().value == 12);
       CHECK(Value::count == before + 12);
     }
   }

--- a/tests/fn/inspect_error.cpp
+++ b/tests/fn/inspect_error.cpp
@@ -62,7 +62,7 @@ TEST_CASE("inspect_error expected", "[inspect_error][expected]")
     }
     SECTION("error")
     {
-      operand_t a{::fn::unexpect, Error{"Not good"}};
+      operand_t a{::fn::unexpect, "Not good"};
       using T = decltype(a | inspect_error(fnError));
       static_assert(std::is_same_v<T, operand_t &>);
       REQUIRE((a //
@@ -74,7 +74,7 @@ TEST_CASE("inspect_error expected", "[inspect_error][expected]")
     }
     SECTION("member function")
     {
-      operand_t a{::fn::unexpect, Error{"Not good"}};
+      operand_t a{::fn::unexpect, "Not good"};
       using T = decltype(a | inspect_error(&Error::finalize));
       static_assert(std::is_same_v<T, operand_t &>);
       auto const before = Error::count;
@@ -97,9 +97,9 @@ TEST_CASE("inspect_error expected", "[inspect_error][expected]")
     }
     SECTION("error")
     {
-      using T = decltype(operand_t{::fn::unexpect, Error{"Not good"}} | inspect_error(fnError));
+      using T = decltype(operand_t{::fn::unexpect, "Not good"} | inspect_error(fnError));
       static_assert(std::is_same_v<T, operand_t &&>);
-      REQUIRE((operand_t{::fn::unexpect, Error{"Not good"}} //
+      REQUIRE((operand_t{::fn::unexpect, "Not good"} //
                | inspect_error(fnError))
                   .error()
                   .what
@@ -108,10 +108,10 @@ TEST_CASE("inspect_error expected", "[inspect_error][expected]")
     }
     SECTION("member function")
     {
-      using T = decltype(operand_t{::fn::unexpect, Error{"Not good"}} | inspect_error(&Error::finalize));
+      using T = decltype(operand_t{::fn::unexpect, "Not good"} | inspect_error(&Error::finalize));
       static_assert(std::is_same_v<T, operand_t &&>);
       auto const before = Error::count;
-      REQUIRE((operand_t{::fn::unexpect, Error{"Not good"}} //
+      REQUIRE((operand_t{::fn::unexpect, "Not good"} //
                | inspect_error(&Error::finalize))
                   .error()
                   .what

--- a/tests/fn/or_else.cpp
+++ b/tests/fn/or_else.cpp
@@ -45,9 +45,9 @@ TEST_CASE("or_else", "[or_else][expected][expected_value]")
 
   constexpr auto fnError = [](Error e) -> operand_t { return {e.what.size()}; };
   constexpr auto fnXerror
-      = [](Error e) -> fn::expected<int, Xerror> { return ::fn::unexpected<Xerror>{Xerror{"Was: " + e.what}}; };
+      = [](Error e) -> fn::expected<int, Xerror> { return ::fn::unexpected<Xerror>{"Was: " + e.what}; };
   constexpr auto wrong = [](Error) -> operand_t { throw 0; };
-  constexpr auto fnFail = [](Error v) -> operand_t { return ::fn::unexpected<Error>(Error{"Got: " + v.what}); };
+  constexpr auto fnFail = [](Error v) -> operand_t { return ::fn::unexpected<Error>("Got: " + v.what); };
 
   static_assert(is::invocable_with_any(fnError));
   static_assert(is::invocable_with_any(fnXerror));
@@ -90,7 +90,7 @@ TEST_CASE("or_else", "[or_else][expected][expected_value]")
     }
     SECTION("error")
     {
-      operand_t a{::fn::unexpect, Error{"Not good"}};
+      operand_t a{::fn::unexpect, "Not good"};
       using T = decltype(a | or_else(fnError));
       static_assert(std::is_same_v<T, operand_t>);
       REQUIRE((a | or_else(fnError)).value() == 8);
@@ -111,7 +111,7 @@ TEST_CASE("or_else", "[or_else][expected][expected_value]")
     }
     SECTION("member function")
     {
-      operand_t a{::fn::unexpect, Error{"Not good"}};
+      operand_t a{::fn::unexpect, "Not good"};
       using T = decltype(a | or_else(&Error::fn<operand_t>));
       static_assert(std::is_same_v<T, operand_t>);
       REQUIRE((a | or_else(&Error::fn<operand_t>)).value() == 8);
@@ -128,15 +128,15 @@ TEST_CASE("or_else", "[or_else][expected][expected_value]")
     }
     SECTION("error")
     {
-      using T = decltype(operand_t{::fn::unexpect, Error{"Not good"}} | or_else(fnError));
+      using T = decltype(operand_t{::fn::unexpect, "Not good"} | or_else(fnError));
       static_assert(std::is_same_v<T, operand_t>);
-      REQUIRE((operand_t{::fn::unexpect, Error{"Not good"}} | or_else(fnError)).value() == 8);
+      REQUIRE((operand_t{::fn::unexpect, "Not good"} | or_else(fnError)).value() == 8);
 
       SECTION("fail")
       {
-        using T = decltype(operand_t{::fn::unexpect, Error{"Not good"}} | or_else(fnFail));
+        using T = decltype(operand_t{::fn::unexpect, "Not good"} | or_else(fnFail));
         static_assert(std::is_same_v<T, operand_t>);
-        REQUIRE((operand_t{::fn::unexpect, Error{"Not good"}} //
+        REQUIRE((operand_t{::fn::unexpect, "Not good"} //
                  | or_else(fnFail))
                     .error()
                     .what
@@ -145,9 +145,9 @@ TEST_CASE("or_else", "[or_else][expected][expected_value]")
     }
     SECTION("member function")
     {
-      using T = decltype(operand_t{::fn::unexpect, Error{"Not good"}} | or_else(&Error::fn<operand_t>));
+      using T = decltype(operand_t{::fn::unexpect, "Not good"} | or_else(&Error::fn<operand_t>));
       static_assert(std::is_same_v<T, operand_t>);
-      REQUIRE((operand_t{::fn::unexpect, Error{"Not good"}} | or_else(&Error::fn<operand_t>)).value() == 8);
+      REQUIRE((operand_t{::fn::unexpect, "Not good"} | or_else(&Error::fn<operand_t>)).value() == 8);
     }
   }
 
@@ -307,9 +307,9 @@ TEST_CASE("or_else", "[or_else][expected][expected_void]")
     return {};
   };
   constexpr auto fnXerror
-      = [](Error e) -> fn::expected<void, Xerror> { return ::fn::unexpected<Xerror>{Xerror{"Was: " + e.what}}; };
+      = [](Error e) -> fn::expected<void, Xerror> { return ::fn::unexpected<Xerror>{"Was: " + e.what}; };
   constexpr auto wrong = [](Error) -> operand_t { throw 0; };
-  constexpr auto fnFail = [](Error v) -> operand_t { return ::fn::unexpected<Error>(Error{"Got: " + v.what}); };
+  constexpr auto fnFail = [](Error v) -> operand_t { return ::fn::unexpected<Error>("Got: " + v.what); };
 
   static_assert(is::invocable_with_any(fnError));
   static_assert(is::invocable_with_any(fnXerror));
@@ -342,7 +342,7 @@ TEST_CASE("or_else", "[or_else][expected][expected_void]")
     }
     SECTION("error")
     {
-      operand_t a{::fn::unexpect, Error{"Not good"}};
+      operand_t a{::fn::unexpect, "Not good"};
       using T = decltype(a | or_else(fnError));
       static_assert(std::is_same_v<T, operand_t>);
       (a | or_else(fnError)).value();
@@ -365,7 +365,7 @@ TEST_CASE("or_else", "[or_else][expected][expected_void]")
     }
     SECTION("member function")
     {
-      operand_t a{::fn::unexpect, Error{"Not good"}};
+      operand_t a{::fn::unexpect, "Not good"};
       using T = decltype(a | or_else(&Error::finalize<operand_t>));
       static_assert(std::is_same_v<T, operand_t>);
       auto const before = Error::count;
@@ -385,15 +385,15 @@ TEST_CASE("or_else", "[or_else][expected][expected_void]")
     }
     SECTION("error")
     {
-      using T = decltype(operand_t{::fn::unexpect, Error{"Not good"}} | or_else(fnError));
+      using T = decltype(operand_t{::fn::unexpect, "Not good"} | or_else(fnError));
       static_assert(std::is_same_v<T, operand_t>);
-      (operand_t{::fn::unexpect, Error{"Not good"}} | or_else(fnError)).value();
+      (operand_t{::fn::unexpect, "Not good"} | or_else(fnError)).value();
 
       SECTION("fail")
       {
-        using T = decltype(operand_t{::fn::unexpect, Error{"Not good"}} | or_else(fnFail));
+        using T = decltype(operand_t{::fn::unexpect, "Not good"} | or_else(fnFail));
         static_assert(std::is_same_v<T, operand_t>);
-        REQUIRE((operand_t{::fn::unexpect, Error{"Not good"}} //
+        REQUIRE((operand_t{::fn::unexpect, "Not good"} //
                  | or_else(fnFail))
                     .error()
                     .what
@@ -402,10 +402,10 @@ TEST_CASE("or_else", "[or_else][expected][expected_void]")
     }
     SECTION("member function")
     {
-      using T = decltype(operand_t{::fn::unexpect, Error{"Not good"}} | or_else(&Error::finalize<operand_t>));
+      using T = decltype(operand_t{::fn::unexpect, "Not good"} | or_else(&Error::finalize<operand_t>));
       static_assert(std::is_same_v<T, operand_t>);
       auto const before = Error::count;
-      (operand_t{::fn::unexpect, Error{"Not good"}} | or_else(&Error::finalize<operand_t>)).value();
+      (operand_t{::fn::unexpect, "Not good"} | or_else(&Error::finalize<operand_t>)).value();
       CHECK(Error::count == before + 8);
     }
   }

--- a/tests/fn/recover.cpp
+++ b/tests/fn/recover.cpp
@@ -69,14 +69,14 @@ TEST_CASE("recover", "[recover][expected][expected_value]")
     }
     SECTION("error")
     {
-      operand_t a{::fn::unexpect, Error{"Not good"}};
+      operand_t a{::fn::unexpect, "Not good"};
       using T = decltype(a | recover(fnError));
       static_assert(std::is_same_v<T, operand_t>);
       REQUIRE((a | recover(fnError)).value() == 8);
     }
     SECTION("member function")
     {
-      operand_t a{::fn::unexpect, Error{"Not good"}};
+      operand_t a{::fn::unexpect, "Not good"};
       using T = decltype(a | recover(&Error::fn));
       static_assert(std::is_same_v<T, operand_t>);
       REQUIRE((a | recover(&Error::fn)).value() == 8);
@@ -93,15 +93,15 @@ TEST_CASE("recover", "[recover][expected][expected_value]")
     }
     SECTION("error")
     {
-      using T = decltype(operand_t{::fn::unexpect, Error{"Not good"}} | recover(fnError));
+      using T = decltype(operand_t{::fn::unexpect, "Not good"} | recover(fnError));
       static_assert(std::is_same_v<T, operand_t>);
-      REQUIRE((operand_t{::fn::unexpect, Error{"Not good"}} | recover(fnError)).value() == 8);
+      REQUIRE((operand_t{::fn::unexpect, "Not good"} | recover(fnError)).value() == 8);
     }
     SECTION("member function")
     {
-      using T = decltype(operand_t{::fn::unexpect, Error{"Not good"}} | recover(&Error::fn));
+      using T = decltype(operand_t{::fn::unexpect, "Not good"} | recover(&Error::fn));
       static_assert(std::is_same_v<T, operand_t>);
-      REQUIRE((operand_t{::fn::unexpect, Error{"Not good"}} | recover(&Error::fn)).value() == 8);
+      REQUIRE((operand_t{::fn::unexpect, "Not good"} | recover(&Error::fn)).value() == 8);
     }
   }
 
@@ -186,7 +186,7 @@ TEST_CASE("recover", "[recover][expected][expected_void]")
     }
     SECTION("error")
     {
-      operand_t a{::fn::unexpect, Error{"Not good"}};
+      operand_t a{::fn::unexpect, "Not good"};
       using T = decltype(a | recover(fnError));
       static_assert(std::is_same_v<T, operand_t>);
       (a | recover(fnError)).value();
@@ -205,9 +205,9 @@ TEST_CASE("recover", "[recover][expected][expected_void]")
     }
     SECTION("error")
     {
-      using T = decltype(operand_t{::fn::unexpect, Error{"Not good"}} | recover(fnError));
+      using T = decltype(operand_t{::fn::unexpect, "Not good"} | recover(fnError));
       static_assert(std::is_same_v<T, operand_t>);
-      (operand_t{::fn::unexpect, Error{"Not good"}} | recover(fnError)).value();
+      (operand_t{::fn::unexpect, "Not good"} | recover(fnError)).value();
       REQUIRE(count == 1);
     }
   }

--- a/tests/fn/transform.cpp
+++ b/tests/fn/transform.cpp
@@ -71,7 +71,7 @@ TEST_CASE("transform", "[transform][expected][expected_value][pack]")
     }
     SECTION("error")
     {
-      operand_t a{::fn::unexpect, Error{"Not good"}};
+      operand_t a{::fn::unexpect, "Not good"};
       using T = decltype(a | transform(wrong));
       static_assert(std::is_same_v<T, operand_t>);
       REQUIRE((a //
@@ -102,7 +102,7 @@ TEST_CASE("transform", "[transform][expected][expected_value][pack]")
     SECTION("error")
     {
       constexpr auto wrong = [](auto...) -> int { throw 0; };
-      REQUIRE((operand_t{::fn::unexpect, Error{"Not good"}} | transform(wrong)).error().what == "Not good");
+      REQUIRE((operand_t{::fn::unexpect, "Not good"} | transform(wrong)).error().what == "Not good");
     }
   }
 
@@ -123,9 +123,9 @@ TEST_CASE("transform", "[transform][expected][expected_value][pack]")
     }
     SECTION("error")
     {
-      using T = decltype(operand_t{::fn::unexpect, Error{"Not good"}} | transform(wrong));
+      using T = decltype(operand_t{::fn::unexpect, "Not good"} | transform(wrong));
       static_assert(std::is_same_v<T, operand_t>);
-      REQUIRE((operand_t{::fn::unexpect, Error{"Not good"}} //
+      REQUIRE((operand_t{::fn::unexpect, "Not good"} //
                | transform(wrong))
                   .error()
                   .what
@@ -287,7 +287,7 @@ TEST_CASE("transform", "[transform][expected][expected_void]")
     }
     SECTION("error")
     {
-      operand_t a{::fn::unexpect, Error{"Not good"}};
+      operand_t a{::fn::unexpect, "Not good"};
       using T = decltype(a | transform(wrong));
       static_assert(std::is_same_v<T, operand_t>);
       REQUIRE((a //
@@ -316,9 +316,9 @@ TEST_CASE("transform", "[transform][expected][expected_void]")
     }
     SECTION("error")
     {
-      using T = decltype(operand_t{::fn::unexpect, Error{"Not good"}} | transform(wrong));
+      using T = decltype(operand_t{::fn::unexpect, "Not good"} | transform(wrong));
       static_assert(std::is_same_v<T, operand_t>);
-      REQUIRE((operand_t{::fn::unexpect, Error{"Not good"}} //
+      REQUIRE((operand_t{::fn::unexpect, "Not good"} //
                | transform(wrong))
                   .error()
                   .what

--- a/tests/fn/transform_error.cpp
+++ b/tests/fn/transform_error.cpp
@@ -67,7 +67,7 @@ TEST_CASE("transform_error", "[transform_error][expected]")
     }
     SECTION("error")
     {
-      operand_t a{::fn::unexpect, Error{"Not good"}};
+      operand_t a{::fn::unexpect, "Not good"};
       using T = decltype(a | transform_error(fnError));
       static_assert(std::is_same_v<T, operand_t>);
       REQUIRE((a //
@@ -102,9 +102,9 @@ TEST_CASE("transform_error", "[transform_error][expected]")
     }
     SECTION("error")
     {
-      using T = decltype(operand_t{::fn::unexpect, Error{"Not good"}} | transform_error(fnError));
+      using T = decltype(operand_t{::fn::unexpect, "Not good"} | transform_error(fnError));
       static_assert(std::is_same_v<T, operand_t>);
-      REQUIRE((operand_t{::fn::unexpect, Error{"Not good"}} //
+      REQUIRE((operand_t{::fn::unexpect, "Not good"} //
                | transform_error(fnError))
                   .error()
                   .what
@@ -112,16 +112,16 @@ TEST_CASE("transform_error", "[transform_error][expected]")
 
       SECTION("change type")
       {
-        using T = decltype(operand_t{::fn::unexpect, Error{"Not good"}} | transform_error(fnXerror));
+        using T = decltype(operand_t{::fn::unexpect, "Not good"} | transform_error(fnXerror));
         static_assert(std::is_same_v<T, fn::expected<int, Xerror>>);
-        REQUIRE((operand_t{::fn::unexpect, Error{"Not good"}} | transform_error(fnXerror)).error().value == 8);
+        REQUIRE((operand_t{::fn::unexpect, "Not good"} | transform_error(fnXerror)).error().value == 8);
       }
 
       SECTION("member function")
       {
-        using T = decltype(operand_t{::fn::unexpect, Error{"Not good"}} | transform_error(&Error::fn));
+        using T = decltype(operand_t{::fn::unexpect, "Not good"} | transform_error(&Error::fn));
         static_assert(std::is_same_v<T, fn::expected<int, Xerror>>);
-        REQUIRE((operand_t{::fn::unexpect, Error{"Not good"}} | transform_error(&Error::fn)).error().value == 8);
+        REQUIRE((operand_t{::fn::unexpect, "Not good"} | transform_error(&Error::fn)).error().value == 8);
       }
     }
   }

--- a/tests/fn/value_or.cpp
+++ b/tests/fn/value_or.cpp
@@ -41,7 +41,7 @@ TEST_CASE("value_or", "[value_or][expected][expected_value]")
     }
     SECTION("error")
     {
-      operand_t a{::fn::unexpect, Error{"Not good"}};
+      operand_t a{::fn::unexpect, "Not good"};
       using T = decltype(a | value_or(3));
       static_assert(std::is_same_v<T, operand_t>);
       REQUIRE((a | value_or(3)).value() == 3);
@@ -58,9 +58,9 @@ TEST_CASE("value_or", "[value_or][expected][expected_value]")
     }
     SECTION("error")
     {
-      using T = decltype(operand_t{::fn::unexpect, Error{"Not good"}} | value_or(3));
+      using T = decltype(operand_t{::fn::unexpect, "Not good"} | value_or(3));
       static_assert(std::is_same_v<T, operand_t>);
-      REQUIRE((operand_t{::fn::unexpect, Error{"Not good"}} | value_or(3)).value() == 3);
+      REQUIRE((operand_t{::fn::unexpect, "Not good"} | value_or(3)).value() == 3);
     }
   }
 
@@ -76,13 +76,13 @@ TEST_CASE("value_or", "[value_or][expected][expected_value]")
       }
       SECTION("error")
       {
-        operand_t a{::fn::unexpect, Error{"Not good"}};
+        operand_t a{::fn::unexpect, "Not good"};
         REQUIRE((std::move(a) | value_or(3, 5)).value().v == 3 * 5);
       }
     }
     SECTION("move ctor")
     {
-      operand_t a{::fn::unexpect, Error{"Not good"}};
+      operand_t a{::fn::unexpect, "Not good"};
       REQUIRE((std::move(a) | value_or(helper_move_only{3, 7})).value().v == 21 * from_rval * from_rval);
     }
   }


### PR DESCRIPTION
Drops the macOS-14 CI lane (Apple clang 15) and everything that existed only to serve it.

- Apple clang 15 sits below the documented Apple Clang 16.0 floor, is the only compiler in the matrix without P0960 (parenthesized aggregate initialization), and its frontend segfaults outright on the `just` test suite introduced by #354.
- The `appleclang / osver: 14` matrix entry and the `warp-macos-14-arm64-6x` actionlint label are removed.
- The 119 test-side aggregate-construction wraps that lane alone required are undone — the terse in-place forms (`{unexpect, "…"}`, `{in_place, N}`) return throughout the verb tests and `examples/simple`. Deliberately untouched: the `include/` brace-init convention (a permanent header rule), `tests/util/helper_types.hpp`'s constraint shape (it guards clang 16, still the floor), and `tests/fn/utility.cpp`'s noexcept witnesses (better coverage regardless of the lane).
