### PR TITLE
Answer instead of asserting in the and_then functor's cluster probe

### DIFF
--- a/include/fn/and_then.hpp
+++ b/include/fn/and_then.hpp
@@ -19,13 +19,14 @@ namespace fn {
 
 namespace detail {
 // The engine's result over a bound payload, computed assert-free: a copack payload goes through
-// the join trait - all-choice branch results answer the superset choice, others the select
-// convergence - so asking about a divergent-choice callback answers instead of tripping select's
-// convergence assert; a single value goes through _apply_result as always.
+// the cluster trait - all-choice branch results answer the superset choice, convergent ones the
+// select trait's answer, and every other set none at all - so asking about any divergent callback
+// answers instead of tripping select's convergence assert; a single value goes through
+// _apply_result as always.
 template <typename Fn, typename... V> struct _and_then_result : _apply_result<Fn, V...> {};
 template <typename Fn, typename V>
   requires _some_copack<::std::remove_cvref_t<V>>
-struct _and_then_result<Fn, V> : _typelist_joining_superset<::fn::choice, Fn, V, ::std::remove_cvref_t<V>> {};
+struct _and_then_result<Fn, V> : _typelist_joining_cluster<::fn::choice, Fn, V, ::std::remove_cvref_t<V>> {};
 } // namespace detail
 
 /**
@@ -153,14 +154,15 @@ struct and_then_t::apply final {
   // ride delegation, and the verb layer is the licensed cross-carrier place. Dropping the input's
   // channels forgets nothing: they are uninhabited, which is what admits the input here at all.
   template <some_monadic_type V, typename Fn>
-  [[nodiscard]] constexpr auto operator()(V &&v, Fn &&fn) const                //
-      noexcept(noexcept(detail::_join_apply<choice>(FWD(v).value(), FWD(fn)))) //
+  [[nodiscard]] constexpr auto operator()(V &&v, Fn &&fn) const //
+      noexcept(noexcept(detail::_tagged_join_apply<detail::_joining_cluster_tag<choice>>(FWD(v).value(),
+                                                                                         FWD(fn)))) //
       -> some_identity auto
     requires applicable_and_then_across<Fn &&, V &&>
              && (not ::std::is_void_v<typename ::std::remove_cvref_t<V>::value_type>)
              && some_copack<::std::remove_cvref_t<decltype(::std::declval<V>().value())>>
   {
-    return detail::_join_apply<choice>(FWD(v).value(), FWD(fn));
+    return detail::_tagged_join_apply<detail::_joining_cluster_tag<choice>>(FWD(v).value(), FWD(fn));
   }
 
   template <some_monadic_type V, typename Fn>

--- a/include/fn/copack.hpp
+++ b/include/fn/copack.hpp
@@ -1315,11 +1315,13 @@ template <typename Cp>
 
 namespace detail {
 // The graded joins for expected's binds over a copack side, when the exhaustive branches return
-// DIFFERENT expected types. Convergent sets and any non-expected result fall back to the select
-// trait, preserving today's behaviour and diagnostics verbatim; only a heterogeneous all-expected
-// set engages the join, and an invalid one - mixed void and non-void values, or a plain fixed side
-// some branch does not retain - leaves no `type`, so asking answers instead of erroring. Tpl is
-// the caller's own two-parameter carrier, keeping this header free of the expected dependency.
+// DIFFERENT expected types. Sets convergent in the exact result type fall back to the select
+// trait, preserving today's behaviour and diagnostics verbatim - exact, not stripped, because
+// select compares exact types and a set convergent only after removing cv/ref would reach its
+// assert; such a set engages the join like any heterogeneous all-expected one. An invalid set -
+// a non-expected result, mixed void and non-void values, or a plain fixed side some branch does
+// not retain - leaves no `type`, so asking answers instead of erroring. Tpl is the caller's own
+// two-parameter carrier, keeping this header free of the expected dependency.
 template <template <typename...> typename Tpl, typename E> struct _joining_expected_tag final {};
 template <template <typename...> typename Tpl, typename T> struct _joining_recovery_tag final {};
 template <template <typename...> typename Tpl> struct _joining_optional_tag final {};
@@ -1435,8 +1437,8 @@ struct _typelist_joining_expected<Tpl, E, Fn, Self, Tpl2<Ts...>, Args...>
     : ::std::conditional_t<
           (sizeof...(Ts) == 0), _no_join,
           ::std::conditional_t<
-              _joining_expected::all_same<::std::remove_cvref_t<
-                  typename ::fn::detail::_apply_result<Fn, apply_const_lvalue_t<Self, Ts>, Args...>::type>...>,
+              _joining_expected::all_same<
+                  typename ::fn::detail::_apply_result<Fn, apply_const_lvalue_t<Self, Ts>, Args...>::type...>,
               _typelist_select_apply_result<Fn, Self, Tpl2<Ts...>, Args...>,
               ::std::conditional_t<
                   (...
@@ -1455,8 +1457,8 @@ struct _typelist_joining_recovery<Tpl, T, Fn, Self, Tpl2<Ts...>, Args...>
     : ::std::conditional_t<
           (sizeof...(Ts) == 0), _no_join,
           ::std::conditional_t<
-              _joining_expected::all_same<::std::remove_cvref_t<
-                  typename ::fn::detail::_apply_result<Fn, apply_const_lvalue_t<Self, Ts>, Args...>::type>...>,
+              _joining_expected::all_same<
+                  typename ::fn::detail::_apply_result<Fn, apply_const_lvalue_t<Self, Ts>, Args...>::type...>,
               _typelist_select_apply_result<Fn, Self, Tpl2<Ts...>, Args...>,
               ::std::conditional_t<
                   (...
@@ -1483,8 +1485,8 @@ struct _typelist_joining_optional<Tpl, Fn, Self, Tpl2<Ts...>, Args...>
     : ::std::conditional_t<
           (sizeof...(Ts) == 0), _no_join,
           ::std::conditional_t<
-              _joining_expected::all_same<::std::remove_cvref_t<
-                  typename ::fn::detail::_apply_result<Fn, apply_const_lvalue_t<Self, Ts>, Args...>::type>...>,
+              _joining_expected::all_same<
+                  typename ::fn::detail::_apply_result<Fn, apply_const_lvalue_t<Self, Ts>, Args...>::type...>,
               _typelist_select_apply_result<Fn, Self, Tpl2<Ts...>, Args...>,
               ::std::conditional_t<
                   (...
@@ -1500,9 +1502,11 @@ struct _copack_apply_result<_joining_optional_tag<Tpl>, Fn, Self, Args...>
 
 // The cluster bind's join - the verb layer's licensed cross-carrier dispatch over a bare copack
 // payload. The same superset join as the choice members', under the asking rule of the joining
-// traits here: convergent sets keep the select trait's answer verbatim, an all-Tpl set joins into
-// the normalized superset, every other set leaves no `type` - the members' fall-back to select
-// would assert where a probing concept must get an answer.
+// traits here: an all-Tpl set joins into the normalized superset, a set convergent in the exact
+// result type keeps the select trait's answer verbatim, every other set leaves no `type` - the
+// members' fall-back to select would assert where a probing concept must get an answer. The
+// convergence tier must be exact, not stripped: select compares exact result types, so a set
+// convergent only after removing cv/ref would reach its assert.
 template <template <typename...> typename Tpl> struct _joining_cluster_tag final {};
 
 template <template <typename...> typename Tpl, typename Fn, typename Self, typename T, typename... Args>
@@ -1513,16 +1517,14 @@ struct _typelist_joining_cluster<Tpl, Fn, Self, Tpl2<Ts...>, Args...>
     : ::std::conditional_t<
           (sizeof...(Ts) == 0), _no_join,
           ::std::conditional_t<
-              _joining_expected::all_same<::std::remove_cvref_t<
-                  typename ::fn::detail::_apply_result<Fn, apply_const_lvalue_t<Self, Ts>, Args...>::type>...>,
-              _typelist_select_apply_result<Fn, Self, Tpl2<Ts...>, Args...>,
-              ::std::conditional_t<
-                  (...
-                   && _joining_superset::is_kind<Tpl, ::std::remove_cvref_t<typename ::fn::detail::_apply_result<
-                                                          Fn, apply_const_lvalue_t<Self, Ts>, Args...>::type>>),
-                  _joining_superset_type<Tpl, ::std::remove_cvref_t<typename ::fn::detail::_apply_result<
-                                                  Fn, apply_const_lvalue_t<Self, Ts>, Args...>::type>...>,
-                  _no_join>>> {};
+              (...
+               && _joining_superset::is_kind<Tpl, ::std::remove_cvref_t<typename ::fn::detail::_apply_result<
+                                                      Fn, apply_const_lvalue_t<Self, Ts>, Args...>::type>>),
+              _joining_superset_type<Tpl, ::std::remove_cvref_t<typename ::fn::detail::_apply_result<
+                                              Fn, apply_const_lvalue_t<Self, Ts>, Args...>::type>...>,
+              ::std::conditional_t<_joining_expected::all_same<typename ::fn::detail::_apply_result<
+                                       Fn, apply_const_lvalue_t<Self, Ts>, Args...>::type...>,
+                                   _typelist_select_apply_result<Fn, Self, Tpl2<Ts...>, Args...>, _no_join>>> {};
 
 template <template <typename...> typename Tpl, typename Fn, typename Self, typename... Args>
 struct _copack_apply_result<_joining_cluster_tag<Tpl>, Fn, Self, Args...>

--- a/include/fn/copack.hpp
+++ b/include/fn/copack.hpp
@@ -180,20 +180,6 @@ template <template <typename...> typename Tpl, typename Fn, typename Self, typen
 struct _copack_apply_result<_joining_superset_tag<Tpl>, Fn, Self, Args...> final
     : _typelist_joining_superset<Tpl, Fn, Self, ::std::remove_cvref_t<Self>, Args...> {};
 
-// The engine entry for join-mode dispatch over a bare copack, for the verb layer's cluster bind -
-// the licensed cross-carrier place; a copack's members stay select and collapse.
-template <template <typename...> typename Tpl, typename Cp, typename Fn>
-  requires _some_copack<::std::remove_cvref_t<Cp>>
-[[nodiscard]] constexpr auto _join_apply(Cp &&cp, Fn &&fn) //
-    noexcept(_is_nothrow_rts_applicable<typename _copack_apply_result<_joining_superset_tag<Tpl>, Fn &&, Cp &&>::type,
-                                        Fn &&, Cp &&>) ->
-    typename _copack_apply_result<_joining_superset_tag<Tpl>, Fn &&, Cp &&>::type
-{
-  using type = _copack_apply_result<_joining_superset_tag<Tpl>, Fn &&, Cp &&>::type;
-  using data_t = ::std::remove_cvref_t<Cp>::data_t;
-  return apply_variadic_union<type, data_t>(FWD(cp).data, cp.index, FWD(fn));
-}
-
 template <typename Fn, typename Self, typename T, typename... Args> struct _typelist_type_select_invoke_result;
 template <typename Fn, typename Self, template <typename...> typename Tpl, typename... Ts, typename... Args>
 struct _typelist_type_select_invoke_result<Fn, Self, Tpl<Ts...>, Args...> {
@@ -1512,8 +1498,38 @@ template <template <typename...> typename Tpl, typename Fn, typename Self, typen
 struct _copack_apply_result<_joining_optional_tag<Tpl>, Fn, Self, Args...>
     : _typelist_joining_optional<Tpl, Fn, Self, ::std::remove_cvref_t<Self>, Args...> {};
 
-// Tag-generic sibling of _join_apply above, for expected's graded binds: dispatch over the copack
-// side with the join's announced result, each branch converting into it
+// The cluster bind's join - the verb layer's licensed cross-carrier dispatch over a bare copack
+// payload. The same superset join as the choice members', under the asking rule of the joining
+// traits here: convergent sets keep the select trait's answer verbatim, an all-Tpl set joins into
+// the normalized superset, every other set leaves no `type` - the members' fall-back to select
+// would assert where a probing concept must get an answer.
+template <template <typename...> typename Tpl> struct _joining_cluster_tag final {};
+
+template <template <typename...> typename Tpl, typename Fn, typename Self, typename T, typename... Args>
+struct _typelist_joining_cluster;
+template <template <typename...> typename Tpl, typename Fn, typename Self, template <typename...> typename Tpl2,
+          typename... Ts, typename... Args>
+struct _typelist_joining_cluster<Tpl, Fn, Self, Tpl2<Ts...>, Args...>
+    : ::std::conditional_t<
+          (sizeof...(Ts) == 0), _no_join,
+          ::std::conditional_t<
+              _joining_expected::all_same<::std::remove_cvref_t<
+                  typename ::fn::detail::_apply_result<Fn, apply_const_lvalue_t<Self, Ts>, Args...>::type>...>,
+              _typelist_select_apply_result<Fn, Self, Tpl2<Ts...>, Args...>,
+              ::std::conditional_t<
+                  (...
+                   && _joining_superset::is_kind<Tpl, ::std::remove_cvref_t<typename ::fn::detail::_apply_result<
+                                                          Fn, apply_const_lvalue_t<Self, Ts>, Args...>::type>>),
+                  _joining_superset_type<Tpl, ::std::remove_cvref_t<typename ::fn::detail::_apply_result<
+                                                  Fn, apply_const_lvalue_t<Self, Ts>, Args...>::type>...>,
+                  _no_join>>> {};
+
+template <template <typename...> typename Tpl, typename Fn, typename Self, typename... Args>
+struct _copack_apply_result<_joining_cluster_tag<Tpl>, Fn, Self, Args...>
+    : _typelist_joining_cluster<Tpl, Fn, Self, ::std::remove_cvref_t<Self>, Args...> {};
+
+// The tag-generic engine entry for join-mode dispatch over a copack side: each branch converts
+// into the tag's announced result. Serves expected's graded binds and the verb layer's cluster arm
 template <typename Tag, typename Cp, typename Fn>
   requires _some_copack<::std::remove_cvref_t<Cp>>
 [[nodiscard]] constexpr auto _tagged_join_apply(Cp &&cp, Fn &&fn) //

--- a/tests/fn/and_then.cpp
+++ b/tests/fn/and_then.cpp
@@ -1200,6 +1200,20 @@ TEST_CASE("and_then joins heterogeneous expected branches", "[and_then][expected
     auto r = In{fn::copack_for<A, B>{A{}}}.and_then(fnConv);
     static_assert(std::is_same_v<decltype(r), fn::expected<X, fn::copack_for<E0, E1>>>);
     CHECK(r.value() == X{});
+
+    // branches convergent only after stripping cv/ref engage the join instead: the hetero tier
+    // already owns reference-returning branches, so a more-alike set must not assert
+    // (no constexpr twin - the reference-returning branch needs static storage, barred in
+    // constant evaluation until C++23)
+    constexpr auto fnRefConv = fn::overload{[](A) -> fn::expected<X, fn::copack<E1>> & {
+                                              static fn::expected<X, fn::copack<E1>> e{X{}};
+                                              return e;
+                                            },
+                                            [](B) { return fn::expected<X, fn::copack<E1>>{X{}}; }};
+    auto rr = In{fn::copack_for<A, B>{A{}}}.and_then(fnRefConv);
+    static_assert(std::is_same_v<decltype(rr), fn::expected<X, fn::copack_for<E0, E1>>>);
+    CHECK(rr.value() == X{});
+    CHECK((In{fn::copack_for<A, B>{B{}}} | fn::and_then(fnRefConv)).value() == X{}); // the pipe agrees
   }
 
   SECTION("all-void branches join to void; mixed void and non-void answers")
@@ -1268,6 +1282,14 @@ TEST_CASE("and_then joins heterogeneous expected branches", "[and_then][expected
     static_assert(not canM(InB{fn::copack_for<A, B>{A{}}}, fnRaw));
     static_assert(not canP(InB{fn::copack_for<A, B>{A{}}}, fnRaw));
     static_assert(canP(InB{fn::copack_for<A, B>{A{}}}, fnJoin)); // converse
+    // ... nor on branches convergent only after stripping cv/ref - select compares exact types
+    constexpr auto fnRef = fn::overload{[](A) -> X & {
+                                          static X x{};
+                                          return x;
+                                        },
+                                        [](B) { return X{}; }};
+    static_assert(not fn::applicable_and_then_across<decltype(fnRef), InB>);
+    static_assert(not canP(InB{fn::copack_for<A, B>{A{}}}, fnRef));
     SUCCEED();
   }
 }
@@ -1316,6 +1338,18 @@ TEST_CASE("and_then joins heterogeneous optional branches", "[and_then][optional
     auto r = In{fn::copack_for<A, B>{A{}}}.and_then(fnConv);
     static_assert(std::is_same_v<decltype(r), fn::optional<X>>);
     CHECK(r.value() == X{});
+
+    // branches convergent only after stripping cv/ref engage the join to the common type
+    // (no constexpr twin - the reference-returning branch needs static storage, barred in
+    // constant evaluation until C++23)
+    constexpr auto fnRefConv = fn::overload{[](A) -> fn::optional<X> & {
+                                              static fn::optional<X> o{X{}};
+                                              return o;
+                                            },
+                                            [](B) { return fn::optional<X>{X{}}; }};
+    auto rr = In{fn::copack_for<A, B>{A{}}}.and_then(fnRefConv);
+    static_assert(std::is_same_v<decltype(rr), fn::optional<X>>);
+    CHECK(rr.value() == X{});
   }
 
   SECTION("constraints and noexcept")

--- a/tests/fn/and_then.cpp
+++ b/tests/fn/and_then.cpp
@@ -1101,6 +1101,8 @@ TEST_CASE("and_then across the identity cluster", "[and_then][just][choice][expe
     static_assert(not fn::applicable_and_then_across<decltype(fnValue), fn::just<int> &>);
     // an endo callback is the member's business, not the cluster's
     static_assert(not fn::applicable_and_then_across<decltype(fnJust), fn::just<int> &>);
+    // an uninhabited copack payload has no branches to join - the probe answers, not asserts
+    static_assert(not fn::applicable_and_then_across<decltype(fnJust), fn::expected<fn::copack<>, E0> &>);
     SUCCEED();
   }
 }
@@ -1129,9 +1131,11 @@ TEST_CASE("and_then joins heterogeneous expected branches", "[and_then][expected
     bool operator==(E2 const &) const = default;
   };
   using In = fn::expected<fn::copack_for<A, B>, fn::copack<E0>>;
+  using InB = fn::expected<fn::copack_for<A, B>, fn::copack<>>;
   constexpr auto fnJoin = fn::overload{[](A) { return fn::expected<X, fn::copack<E1>>{X{}}; },
                                        [](B) { return fn::expected<Y, fn::copack<E2>>{Y{}}; }};
   constexpr auto canM = [](auto &&v, auto &&fn) { return requires { FWD(v).and_then(FWD(fn)); }; };
+  constexpr auto canP = [](auto &&v, auto &&fn) { return requires { FWD(v) | fn::and_then(FWD(fn)); }; };
 
   SECTION("values join, errors union with self's grade")
   {
@@ -1176,10 +1180,17 @@ TEST_CASE("and_then joins heterogeneous expected branches", "[and_then][expected
 
   SECTION("a copack<> grade acquires the branch errors")
   {
-    using InB = fn::expected<fn::copack_for<A, B>, fn::copack<>>;
     auto r = InB{fn::copack_for<A, B>{A{}}}.and_then(fnJoin);
     static_assert(std::is_same_v<decltype(r), fn::expected<fn::copack_for<X, Y>, fn::copack_for<E1, E2>>>);
     CHECK(r.value() == fn::copack_for<X, Y>{X{}});
+
+    // the piped spelling agrees - an identity input must not divert the join into the cluster
+    auto p = InB{fn::copack_for<A, B>{B{}}} | fn::and_then(fnJoin);
+    static_assert(std::is_same_v<decltype(p), fn::expected<fn::copack_for<X, Y>, fn::copack_for<E1, E2>>>);
+    CHECK(p.value() == fn::copack_for<X, Y>{Y{}});
+    // named source: VS 2022 misreads a mid-expression prvalue's empty-class union member
+    constexpr InB cb{fn::copack_for<A, B>{A{}}};
+    static_assert((cb | fn::and_then(fnJoin)).value() == fn::copack_for<X, Y>{X{}});
   }
 
   SECTION("convergent branches keep their exact type and the widening behaviour")
@@ -1246,6 +1257,18 @@ TEST_CASE("and_then joins heterogeneous expected branches", "[and_then][expected
     static_assert(fn::applicable_and_then<decltype(fnMix), InL>);
     static_assert(fn::applicable_and_then<decltype(fnLift), InL>);
     static_assert(not fn::applicable_and_then<decltype(fnBad), InL>);
+  }
+
+  SECTION("the functor answers over an identity input")
+  {
+    // the cluster arm's probe must not claim the member's join, nor assert on what neither owns
+    static_assert(not fn::applicable_and_then_across<decltype(fnJoin), InB>);
+    constexpr auto fnRaw = fn::overload{[](A) { return 1; }, [](B) { return 2L; }};
+    static_assert(not fn::applicable_and_then_across<decltype(fnRaw), InB>);
+    static_assert(not canM(InB{fn::copack_for<A, B>{A{}}}, fnRaw));
+    static_assert(not canP(InB{fn::copack_for<A, B>{A{}}}, fnRaw));
+    static_assert(canP(InB{fn::copack_for<A, B>{A{}}}, fnJoin)); // converse
+    SUCCEED();
   }
 }
 

--- a/tests/fn/or_else.cpp
+++ b/tests/fn/or_else.cpp
@@ -605,6 +605,18 @@ TEST_CASE("or_else joins heterogeneous expected branches", "[or_else][expected][
     using InP = fn::expected<X, fn::copack_for<E1, E2>>;
     static_assert(not canO(InP{X{}}, fnR));
     static_assert(not fn::applicable_or_else<decltype(fnR), InP>);
+
+    // recovery branches convergent only after stripping cv/ref engage the join
+    // (no constexpr twin - the reference-returning branch needs static storage, barred in
+    // constant evaluation until C++23)
+    constexpr auto fnRef = fn::overload{[](E1) -> fn::expected<X, fn::copack<E0>> & {
+                                          static fn::expected<X, fn::copack<E0>> e{X{}};
+                                          return e;
+                                        },
+                                        [](E2) { return fn::expected<X, fn::copack<E0>>{X{}}; }};
+    auto rr = In{fn::unexpect, fn::copack_for<E1, E2>{E1{}}}.or_else(fnRef);
+    static_assert(std::is_same_v<decltype(rr), fn::expected<fn::copack<X>, fn::copack<E0>>>);
+    CHECK(rr.value() == fn::copack<X>{X{}});
   }
 
   SECTION("convergent values with hetero branch errors union; member and piped spellings agree")


### PR DESCRIPTION
The `and_then` functor evaluated the identity cluster arm's probe over every identity `expected`, and that probe — the choice-superset trait — falls back to the asserting select trait, so the shapes #356 made member-legal (and shapes the member cleanly rejects) hard-errored in the piped spelling. Demonstration and mechanics in #357.

The cluster probe now goes through `_typelist_joining_cluster`, the same superset join under the joining traits' asking rule: a convergent set keeps the select trait's answer verbatim, an all-choice set joins into the normalized superset, every other set leaves no `type` — an unsatisfied constraint. `choice::and_then`'s members keep the asserting trait and with it today's diagnostics. The cluster arm's runtime is keyed to the same tag through `_tagged_join_apply`, so probe and engine cannot diverge; the now-unused `_join_apply` is removed.

Tests pin the piped spelling equal to the member over an identity input, clean rejection of raw heterogeneous branches in both spellings, and the cluster concept answering — not asserting — for member-legal, raw, and uninhabited payloads.

Resolves #357

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0198ikYYxtCqwNG54SS1b249
