### PR TITLE
Make just<void> construction implicit and rename fn::identity to fn::conjoin

### DIFF
--- a/include/CMakeLists.txt
+++ b/include/CMakeLists.txt
@@ -210,6 +210,8 @@ if("cxx_std_26" IN_LIST CMAKE_CXX_COMPILE_FEATURES)
     append_compilation_options("${target}" WARNINGS)
     add_dependencies("sentinels" "${target}")
     set_property(TARGET "${target}" PROPERTY CXX_STANDARD "${mode}")
+    # Some tooling is unable to deal with -std=c++26, so do not put this target in compile_commands.json
+    set_property(TARGET "${target}" PROPERTY EXPORT_COMPILE_COMMANDS OFF)
 
     unset(target)
     unset(mode)

--- a/include/fn/just.hpp
+++ b/include/fn/just.hpp
@@ -516,8 +516,9 @@ private:
 template <> struct just<void> {
   using value_type = void;
 
-  constexpr explicit just() = default;
+  constexpr just() = default;
   constexpr explicit just(::std::in_place_type_t<void>) noexcept {}
+  constexpr explicit just(::std::in_place_t) noexcept {}
 
   [[nodiscard]] constexpr bool operator==(just const &) const noexcept = default;
 
@@ -659,6 +660,7 @@ template <typename T, typename U>
 template <typename T> just(T) -> just<T>;
 template <typename T> explicit just(::std::in_place_type_t<T>, auto &&...) -> just<T>;
 just() -> just<void>;
+explicit just(::std::in_place_t) -> just<void>;
 
 } // namespace LIBFN_VERSION
 } // namespace fn

--- a/include/fn/pack.hpp
+++ b/include/fn/pack.hpp
@@ -399,9 +399,9 @@ template <template <typename> typename Tpl>
 }
 
 /**
- * @brief Identity, which is basically lift for operator & above
+ * @brief The n-ary fold of `operator &` above; a single argument is forwarded unchanged
  */
-constexpr inline struct identity_t {
+constexpr inline struct conjoin_t {
   /**
    * @brief TODO
    *
@@ -442,7 +442,7 @@ constexpr inline struct identity_t {
   {
     return (FWD(arg) & ... & FWD(args));
   }
-} identity;
+} conjoin;
 
 } // namespace LIBFN_VERSION
 } // namespace fn

--- a/test_package/src/main.cpp
+++ b/test_package/src/main.cpp
@@ -4,6 +4,7 @@
 #include <fn/utility.hpp>
 
 #include <cstdio>
+#include <numeric>
 
 static constexpr char const *src[] = {")", R"(#include <fn/and_then.hpp>
 #include <fn/choice.hpp>
@@ -11,38 +12,41 @@ static constexpr char const *src[] = {")", R"(#include <fn/and_then.hpp>
 #include <fn/utility.hpp>
 
 #include <cstdio>
+#include <numeric>
 
 static constexpr char const *src[] = {"%c", R"(%s%c",
                                       ""};
 
 int main()
 {
-  fn::choice_for<fn::pack<>, char, fn::pack<char, char const *>> quine = fn::pack<>{};
-  for (char const *s : src) {
-    quine = quine
-            | fn::and_then(fn::overload{//
-                                        [s]() -> decltype(quine) { return *s; },
-                                        [s](char c) -> decltype(quine) { return fn::pack<char, char const *>{c, s}; },
-                                        [](char c, char const *s) -> decltype(quine) {
-                                          std::printf(s, c, s, c);
-                                          return fn::pack<>{};
-                                        }});
-  }
+  using quine_t = fn::choice_for<fn::pack<>, fn::pack<char>, fn::pack<char, char const *>>;
+  std::accumulate(std::begin(src), std::end(src), quine_t{fn::as_pack()}, //
+                  [](quine_t &&acc, char const *s) -> quine_t {
+                    return acc
+                           | fn::and_then(
+                               fn::overload{[s]() -> quine_t { return fn::pack<char>{*s}; },
+                                            [s](char c) -> quine_t { return fn::pack<char, char const *>{c, s}; },
+                                            [](char c, char const *fmt) -> quine_t {
+                                              std::printf(fmt, c, fmt, c);
+                                              return fn::as_pack();
+                                            }});
+                  });
 }
 )",
                                       ""};
 
 int main()
 {
-  fn::choice_for<fn::pack<>, char, fn::pack<char, char const *>> quine = fn::pack<>{};
-  for (char const *s : src) {
-    quine = quine
-            | fn::and_then(fn::overload{//
-                                        [s]() -> decltype(quine) { return *s; },
-                                        [s](char c) -> decltype(quine) { return fn::pack<char, char const *>{c, s}; },
-                                        [](char c, char const *s) -> decltype(quine) {
-                                          std::printf(s, c, s, c);
-                                          return fn::pack<>{};
-                                        }});
-  }
+  using quine_t = fn::choice_for<fn::pack<>, fn::pack<char>, fn::pack<char, char const *>>;
+  std::accumulate(std::begin(src), std::end(src), quine_t{fn::as_pack()}, //
+                  [](quine_t &&acc, char const *s) -> quine_t {
+                    return acc
+                           | fn::and_then(
+                               fn::overload{[s]() -> quine_t { return fn::pack<char>{*s}; },
+                                            [s](char c) -> quine_t { return fn::pack<char, char const *>{c, s}; },
+                                            [](char c, char const *fmt) -> quine_t {
+                                              std::printf(fmt, c, fmt, c);
+                                              return fn::as_pack();
+                                            }});
+                  });
 }

--- a/test_package/src/main.cpp
+++ b/test_package/src/main.cpp
@@ -20,17 +20,17 @@ static constexpr char const *src[] = {"%c", R"(%s%c",
 int main()
 {
   using quine_t = fn::choice_for<fn::pack<>, fn::pack<char>, fn::pack<char, char const *>>;
-  std::accumulate(std::begin(src), std::end(src), quine_t{fn::as_pack()}, //
-                  [](quine_t &&acc, char const *s) -> quine_t {
-                    return acc
-                           | fn::and_then(
-                               fn::overload{[s]() -> quine_t { return fn::pack<char>{*s}; },
-                                            [s](char c) -> quine_t { return fn::pack<char, char const *>{c, s}; },
-                                            [](char c, char const *fmt) -> quine_t {
-                                              std::printf(fmt, c, fmt, c);
-                                              return fn::as_pack();
-                                            }});
-                  });
+  [[maybe_unused]] auto _ = std::accumulate(
+      std::begin(src), std::end(src), quine_t{fn::as_pack()}, //
+      [](quine_t &&acc, char const *s) -> quine_t {
+        return acc
+               | fn::and_then(fn::overload{[s]() -> quine_t { return fn::pack<char>{*s}; },
+                                           [s](char c) -> quine_t { return fn::pack<char, char const *>{c, s}; },
+                                           [](char c, char const *fmt) -> quine_t {
+                                             std::printf(fmt, c, fmt, c);
+                                             return fn::as_pack();
+                                           }});
+      });
 }
 )",
                                       ""};
@@ -38,15 +38,15 @@ int main()
 int main()
 {
   using quine_t = fn::choice_for<fn::pack<>, fn::pack<char>, fn::pack<char, char const *>>;
-  std::accumulate(std::begin(src), std::end(src), quine_t{fn::as_pack()}, //
-                  [](quine_t &&acc, char const *s) -> quine_t {
-                    return acc
-                           | fn::and_then(
-                               fn::overload{[s]() -> quine_t { return fn::pack<char>{*s}; },
-                                            [s](char c) -> quine_t { return fn::pack<char, char const *>{c, s}; },
-                                            [](char c, char const *fmt) -> quine_t {
-                                              std::printf(fmt, c, fmt, c);
-                                              return fn::as_pack();
-                                            }});
-                  });
+  [[maybe_unused]] auto _ = std::accumulate(
+      std::begin(src), std::end(src), quine_t{fn::as_pack()}, //
+      [](quine_t &&acc, char const *s) -> quine_t {
+        return acc
+               | fn::and_then(fn::overload{[s]() -> quine_t { return fn::pack<char>{*s}; },
+                                           [s](char c) -> quine_t { return fn::pack<char, char const *>{c, s}; },
+                                           [](char c, char const *fmt) -> quine_t {
+                                             std::printf(fmt, c, fmt, c);
+                                             return fn::as_pack();
+                                           }});
+      });
 }

--- a/tests/fn/just.cpp
+++ b/tests/fn/just.cpp
@@ -46,6 +46,8 @@ template <typename S, typename Fn, typename... Args>
 concept can_apply = requires(S s, Fn fn, Args... args) { FWD(s).apply(fn, FWD(args)...); };
 template <typename S, typename Fn, typename... Args>
 concept can_apply_type = requires(S s, Fn fn, Args... args) { FWD(s).apply_type(fn, FWD(args)...); };
+template <typename T>
+concept implicitly_default_constructible = requires(void (&sink)(T)) { sink({}); };
 
 } // namespace
 
@@ -59,6 +61,7 @@ TEST_CASE("just", "[just]")
     static_assert(std::is_same_v<decltype(fn::just(std::in_place_type<std::string>, "foo")), fn::just<std::string>>);
     static_assert(std::is_same_v<decltype(fn::just{}), fn::just<void>>);
     static_assert(std::is_same_v<decltype(fn::just(std::in_place_type<void>)), fn::just<void>>);
+    static_assert(std::is_same_v<decltype(fn::just{std::in_place}), fn::just<void>>);
 
     T a{13};
     CHECK(a.value() == 13);
@@ -280,6 +283,15 @@ TEST_CASE("just of void", "[just]")
   static_assert(std::is_trivially_copyable_v<V>);
   static_assert(std::is_trivially_default_constructible_v<V>);
   static_assert(std::is_same_v<V::value_type, void>);
+
+  // implicit default construction, there being nothing to convert from; the in-place tags stay
+  // explicit, following expected<void, E>
+  static_assert(implicitly_default_constructible<V>);
+  static_assert(std::is_constructible_v<V, std::in_place_t>);
+  static_assert(not std::is_convertible_v<std::in_place_t, V>);
+  static_assert(std::is_constructible_v<V, std::in_place_type_t<void>>);
+  static_assert(not std::is_convertible_v<std::in_place_type_t<void>, V>);
+  static_assert(V{std::in_place} == V{std::in_place_type<void>});
 
   constexpr V v{};
   v.value();

--- a/tests/fn/pack.cpp
+++ b/tests/fn/pack.cpp
@@ -903,8 +903,8 @@ TEST_CASE("operator &", "[pack][copack][operator_and]")
   static_assert(r1.apply([](auto &&...args) -> double { return (1 * ... * static_cast<double>(args)); })
                 == 12. * 3 * 2.5 * 0.5 * 1 * 1.5 * 12);
 
-  constexpr auto r2 = fn::identity(12, 3, 2.5, fn::pack{0.5, true},
-                                   fn::copack_for<bool, int, fn::pack<double, int>>(fn::pack{1.5, 12}));
+  constexpr auto r2 = fn::conjoin(12, 3, 2.5, fn::pack{0.5, true},
+                                  fn::copack_for<bool, int, fn::pack<double, int>>(fn::pack{1.5, 12}));
   static_assert(std::is_same_v<                                     //
                 decltype(r2),                                       //
                 fn::copack_for<                                     //


### PR DESCRIPTION
Three related refinements to the public surface:

**`just<void>` construction** — the default constructor becomes implicit: there is nothing to convert from, the primary `just<T>`'s default constructor was never explicit, and `std::expected<void, E>`'s default constructor is implicit too ([expected.void.cons]). A `std::in_place_t` constructor is added (the standard's own spelling for the void specialization), kept `explicit` along with the `in_place_type_t<void>` form — tags are shared protocol vocabulary and never convert implicitly, exactly the standard's split. A CTAD guide deduces `fn::just{std::in_place}` as `just<void>`, closing the gap where guide `just(T) -> just<T>` would have deduced `just<std::in_place_t>`. New test pins cover the implicit default construction, both explicit-tag pairs, and the deduction.

**The package quine** — rewritten as a `std::accumulate` fold: seed plus step function, each arm returning the next state, with the three states being the prefixes of the gathered data (`pack<>`, `pack<char>`, `pack<char, char const *>`). Verified self-reproducing byte-for-byte on gcc and clang in C++20 and in the `LIBFN_CXX26` mode, and a clang-format fixed point under the repository style.

**`fn::identity` renamed `fn::conjoin`** — the old name collided with `std::identity` and, worse, with the library's own identity-cluster vocabulary (`some_identity`, where "identity" names a concept). `conjoin` names what the utility is: the n-ary fold of `operator&`, a single argument forwarded unchanged — and the conjunction reading predicts the behaviour, since conjunction distributing over disjunction is exactly why copack arguments yield a copack-of-packs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0198ikYYxtCqwNG54SS1b249
