### PR TITLE
Short-circuit the join over an uninhabited value side

### DIFF
--- a/include/fn/pack.hpp
+++ b/include/fn/pack.hpp
@@ -346,37 +346,66 @@ namespace detail {
 // the accessor spelled as a type rather than as a call which would drag its own throw in.
 template <typename Monad> using _value_of_t = decltype(::std::declval<Monad>().value());
 
+// A product with an uninhabited factor is itself uninhabited, and copack<> has no value fold - the
+// join over such a side must not name the fold, in the declared type, the noexcept specification
+// or the body, and always resolves through `efn`.
 template <typename Lh, typename Rh>
-using _joined_t = decltype(::fn::detail::_fold_detail::fold<typename ::std::remove_cvref_t<Lh>::value_type,
-                                                            typename ::std::remove_cvref_t<Rh>::value_type>(
-    ::std::declval<_value_of_t<Lh>>(), ::std::declval<_value_of_t<Rh>>()));
+constexpr inline bool _uninhabited_join = empty_copack<typename ::std::remove_cvref_t<Lh>::value_type>
+                                          || empty_copack<typename ::std::remove_cvref_t<Rh>::value_type>;
+
+template <bool Uninhabited, typename Lh, typename Rh> struct _joined {
+  using type = copack<>;
+};
+template <typename Lh, typename Rh> struct _joined<false, Lh, Rh> {
+  using type = decltype(::fn::detail::_fold_detail::fold<typename ::std::remove_cvref_t<Lh>::value_type,
+                                                         typename ::std::remove_cvref_t<Rh>::value_type>(
+      ::std::declval<_value_of_t<Lh>>(), ::std::declval<_value_of_t<Rh>>()));
+};
+template <typename Lh, typename Rh> using _joined_t = typename _joined<_uninhabited_join<Lh, Rh>, Lh, Rh>::type;
 
 // `_join` invokes `efn` as an lvalue - a named parameter - so the `Efn &` questions ask about the
 // call the body performs; the reference collapses to it whatever category the callable arrived in.
+template <bool Uninhabited, template <typename> typename Tpl, typename Lh, typename Rh, typename Efn>
+struct _nothrow_join_arm {
+  static constexpr bool value = ::std::is_nothrow_invocable_v<Efn &, Lh> && ::std::is_nothrow_invocable_v<Efn &, Rh>
+                                && _nothrow_initializable<Tpl<copack<>>, ::std::invoke_result_t<Efn &, Lh>>
+                                && _nothrow_initializable<Tpl<copack<>>, ::std::invoke_result_t<Efn &, Rh>>;
+};
 template <template <typename> typename Tpl, typename Lh, typename Rh, typename Efn>
-constexpr inline bool _nothrow_join
-    = noexcept(::fn::detail::_fold_detail::fold<typename ::std::remove_cvref_t<Lh>::value_type,
-                                                typename ::std::remove_cvref_t<Rh>::value_type>(
-          ::std::declval<_value_of_t<Lh>>(), ::std::declval<_value_of_t<Rh>>()))
-      && _nothrow_initializable<Tpl<_joined_t<Lh, Rh>>, ::std::in_place_t, _joined_t<Lh, Rh>>
-      && ::std::is_nothrow_invocable_v<Efn &, Lh> && ::std::is_nothrow_invocable_v<Efn &, Rh>
-      && _nothrow_initializable<Tpl<_joined_t<Lh, Rh>>, ::std::invoke_result_t<Efn &, Lh>>
-      && _nothrow_initializable<Tpl<_joined_t<Lh, Rh>>, ::std::invoke_result_t<Efn &, Rh>>;
+struct _nothrow_join_arm<false, Tpl, Lh, Rh, Efn> {
+  static constexpr bool value
+      = noexcept(::fn::detail::_fold_detail::fold<typename ::std::remove_cvref_t<Lh>::value_type,
+                                                  typename ::std::remove_cvref_t<Rh>::value_type>(
+            ::std::declval<_value_of_t<Lh>>(), ::std::declval<_value_of_t<Rh>>()))
+        && _nothrow_initializable<Tpl<_joined_t<Lh, Rh>>, ::std::in_place_t, _joined_t<Lh, Rh>>
+        && ::std::is_nothrow_invocable_v<Efn &, Lh> && ::std::is_nothrow_invocable_v<Efn &, Rh>
+        && _nothrow_initializable<Tpl<_joined_t<Lh, Rh>>, ::std::invoke_result_t<Efn &, Lh>>
+        && _nothrow_initializable<Tpl<_joined_t<Lh, Rh>>, ::std::invoke_result_t<Efn &, Rh>>;
+};
+template <template <typename> typename Tpl, typename Lh, typename Rh, typename Efn>
+constexpr inline bool _nothrow_join = _nothrow_join_arm<_uninhabited_join<Lh, Rh>, Tpl, Lh, Rh, Efn>::value;
 
 template <template <typename> typename Tpl>
 [[nodiscard]] constexpr auto _join(auto &&lh, auto &&rh, auto &&efn) //
     noexcept(_nothrow_join<Tpl, decltype(lh), decltype(rh), decltype(efn)>)
         -> Tpl<_joined_t<decltype(lh), decltype(rh)>>
 {
-  using Lh = ::std::remove_cvref_t<decltype(lh)>::value_type;
-  using Rh = ::std::remove_cvref_t<decltype(rh)>::value_type;
   using type = Tpl<_joined_t<decltype(lh), decltype(rh)>>;
-  if (lh.has_value() && rh.has_value())
-    return type{::std::in_place, ::fn::detail::_fold_detail::fold<Lh, Rh>(FWD(lh).value(), FWD(rh).value())};
-  else if (not lh.has_value())
-    return type{efn(FWD(lh))};
-  else
-    return type{efn(FWD(rh))};
+  if constexpr (_uninhabited_join<decltype(lh), decltype(rh)>) {
+    if (not lh.has_value())
+      return type{efn(FWD(lh))};
+    else
+      return type{efn(FWD(rh))};
+  } else {
+    using Lh = ::std::remove_cvref_t<decltype(lh)>::value_type;
+    using Rh = ::std::remove_cvref_t<decltype(rh)>::value_type;
+    if (lh.has_value() && rh.has_value())
+      return type{::std::in_place, ::fn::detail::_fold_detail::fold<Lh, Rh>(FWD(lh).value(), FWD(rh).value())};
+    else if (not lh.has_value())
+      return type{efn(FWD(lh))};
+    else
+      return type{efn(FWD(rh))};
+  }
 }
 
 } // namespace detail

--- a/test_package/src/main.cpp
+++ b/test_package/src/main.cpp
@@ -20,17 +20,18 @@ static constexpr char const *src[] = {"%c", R"(%s%c",
 int main()
 {
   using quine_t = fn::choice_for<fn::pack<>, fn::pack<char>, fn::pack<char, char const *>>;
-  [[maybe_unused]] auto _ = std::accumulate(
-      std::begin(src), std::end(src), quine_t{fn::as_pack()}, //
-      [](quine_t &&acc, char const *s) -> quine_t {
-        return acc
-               | fn::and_then(fn::overload{[s]() -> quine_t { return fn::pack<char>{*s}; },
-                                           [s](char c) -> quine_t { return fn::pack<char, char const *>{c, s}; },
-                                           [](char c, char const *fmt) -> quine_t {
-                                             std::printf(fmt, c, fmt, c);
-                                             return fn::as_pack();
-                                           }});
-      });
+  return std::accumulate(
+             std::begin(src), std::end(src), quine_t{fn::as_pack()}, //
+             [](quine_t &&acc, char const *s) -> quine_t {
+               return acc
+                      | fn::and_then(fn::overload{[s]() -> quine_t { return fn::pack<char>{*s}; },
+                                                  [s](char c) -> quine_t { return fn::pack<char, char const *>{c, s}; },
+                                                  [](char c, char const *fmt) -> quine_t {
+                                                    std::printf(fmt, c, fmt, c);
+                                                    return fn::as_pack();
+                                                  }});
+             })
+      .apply([](auto &&...args) -> int { return sizeof...(args); });
 }
 )",
                                       ""};
@@ -38,15 +39,16 @@ int main()
 int main()
 {
   using quine_t = fn::choice_for<fn::pack<>, fn::pack<char>, fn::pack<char, char const *>>;
-  [[maybe_unused]] auto _ = std::accumulate(
-      std::begin(src), std::end(src), quine_t{fn::as_pack()}, //
-      [](quine_t &&acc, char const *s) -> quine_t {
-        return acc
-               | fn::and_then(fn::overload{[s]() -> quine_t { return fn::pack<char>{*s}; },
-                                           [s](char c) -> quine_t { return fn::pack<char, char const *>{c, s}; },
-                                           [](char c, char const *fmt) -> quine_t {
-                                             std::printf(fmt, c, fmt, c);
-                                             return fn::as_pack();
-                                           }});
-      });
+  return std::accumulate(
+             std::begin(src), std::end(src), quine_t{fn::as_pack()}, //
+             [](quine_t &&acc, char const *s) -> quine_t {
+               return acc
+                      | fn::and_then(fn::overload{[s]() -> quine_t { return fn::pack<char>{*s}; },
+                                                  [s](char c) -> quine_t { return fn::pack<char, char const *>{c, s}; },
+                                                  [](char c, char const *fmt) -> quine_t {
+                                                    std::printf(fmt, c, fmt, c);
+                                                    return fn::as_pack();
+                                                  }});
+             })
+      .apply([](auto &&...args) -> int { return sizeof...(args); });
 }

--- a/test_package/src/main.cpp
+++ b/test_package/src/main.cpp
@@ -31,7 +31,7 @@ int main()
                                                     return fn::as_pack();
                                                   }});
              })
-      .apply([](auto &&...args) -> int { return sizeof...(args); });
+      .apply([]([[maybe_unused]] auto &&...args) -> int { return sizeof...(args); });
 }
 )",
                                       ""};
@@ -50,5 +50,5 @@ int main()
                                                     return fn::as_pack();
                                                   }});
              })
-      .apply([](auto &&...args) -> int { return sizeof...(args); });
+      .apply([]([[maybe_unused]] auto &&...args) -> int { return sizeof...(args); });
 }

--- a/tests/fn/expected.cpp
+++ b/tests/fn/expected.cpp
@@ -2462,6 +2462,65 @@ TEST_CASE("expected pack support", "[expected][pack][and_then][transform][operat
       }
     }
 
+    SECTION("uninhabited value grade copack<>")
+    {
+      // An always-erroring expected<copack<>, E> composes too: a value product with an uninhabited
+      // factor is itself uninhabited, so the join always resolves into the error channel.
+      // Previously a hard error - the join named copack<>'s value fold in its declared type.
+      using Dead = fn::expected<fn::copack<>, Error>;
+
+      SECTION("same error type, either order")
+      {
+        using Rh = fn::expected<int, Error>;
+        static_assert(
+            std::same_as<decltype(std::declval<Dead>() & std::declval<Rh>()), fn::expected<fn::copack<>, Error>>);
+        static_assert(
+            std::same_as<decltype(std::declval<Rh>() & std::declval<Dead>()), fn::expected<fn::copack<>, Error>>);
+        static_assert(
+            std::same_as<decltype(std::declval<Dead>() & std::declval<Dead>()), fn::expected<fn::copack<>, Error>>);
+
+        static_assert((Dead{::fn::unexpect, FileNotFound} & Rh{5}).error() == FileNotFound);
+        static_assert((Dead{::fn::unexpect, FileNotFound} & Rh{::fn::unexpect, Unknown}).error() == FileNotFound);
+        static_assert((Rh{5} & Dead{::fn::unexpect, Unknown}).error() == Unknown);
+        static_assert((Rh{::fn::unexpect, FileNotFound} & Dead{::fn::unexpect, Unknown}).error() == FileNotFound);
+
+        CHECK((Dead{::fn::unexpect, FileNotFound} & Rh{5}).error() == FileNotFound);
+        CHECK((Dead{::fn::unexpect, FileNotFound} & Rh{::fn::unexpect, Unknown}).error() == FileNotFound);
+        CHECK((Rh{5} & Dead{::fn::unexpect, Unknown}).error() == Unknown);
+        CHECK((Rh{::fn::unexpect, FileNotFound} & Dead{::fn::unexpect, Unknown}).error() == FileNotFound);
+      }
+
+      SECTION("graded error join, either order")
+      {
+        using Rh = fn::expected<int, fn::copack<Error>>;
+        static_assert(std::same_as<decltype(std::declval<Dead>() & std::declval<Rh>()),
+                                   fn::expected<fn::copack<>, fn::copack<Error>>>);
+        static_assert(std::same_as<decltype(std::declval<Rh>() & std::declval<Dead>()),
+                                   fn::expected<fn::copack<>, fn::copack<Error>>>);
+
+        static_assert((Dead{::fn::unexpect, FileNotFound} & Rh{5}).error() == fn::copack{FileNotFound});
+        static_assert((Rh{::fn::unexpect, fn::copack{Unknown}} & Dead{::fn::unexpect, FileNotFound}).error()
+                      == fn::copack{Unknown});
+
+        CHECK((Dead{::fn::unexpect, FileNotFound} & Rh{5}).error() == fn::copack{FileNotFound});
+        CHECK((Rh{::fn::unexpect, fn::copack{Unknown}} & Dead{::fn::unexpect, FileNotFound}).error()
+              == fn::copack{Unknown});
+      }
+
+      SECTION("noexcept")
+      {
+        // nothing to relocate on the dead value side; the error side weighs as usual
+        using Rh = fn::expected<int, Error>;
+        static_assert(noexcept(std::declval<Dead &>() & std::declval<Rh &>()));
+        static_assert(noexcept(std::declval<Rh &>() & std::declval<Dead &>()));
+        using Th = fn::expected<fn::copack<>, MoveNothrow>;
+        using Rt = fn::expected<int, MoveNothrow>;
+        static_assert(not noexcept(std::declval<Th &>() & std::declval<Rt &>())); // copies the error
+        static_assert(noexcept(std::declval<Th &&>() & std::declval<Rt &&>()));   // moves it
+        SUCCEED();
+      }
+    }
+
     SECTION("noexcept")
     {
       // the join relocates both operands' values and errors into the result, so it promises only

--- a/tests/fn/optional.cpp
+++ b/tests/fn/optional.cpp
@@ -569,6 +569,29 @@ TEST_CASE("optional pack support", "[optional][pack][and_then][transform][operat
       }
     }
 
+    SECTION("uninhabited value grade copack<>")
+    {
+      // An always-empty optional<copack<>> composes: a value product with an uninhabited factor is
+      // itself uninhabited, so the join is always empty. Previously a hard error - the join named
+      // copack<>'s value fold in its declared type.
+      using Dead = fn::optional<fn::copack<>>;
+      using Rh = fn::optional<int>;
+      static_assert(std::same_as<decltype(std::declval<Dead>() & std::declval<Rh>()), Dead>);
+      static_assert(std::same_as<decltype(std::declval<Rh>() & std::declval<Dead>()), Dead>);
+      static_assert(std::same_as<decltype(std::declval<Dead>() & std::declval<Dead>()), Dead>);
+      static_assert(noexcept(std::declval<Dead &>() & std::declval<Rh &>()));
+
+      static_assert(not(Dead{} & Rh{12}).has_value());
+      static_assert(not(Rh{12} & Dead{}).has_value());
+      static_assert(not(Rh{std::nullopt} & Dead{}).has_value());
+      static_assert(not(Dead{} & Dead{}).has_value());
+
+      CHECK(not(Dead{} & Rh{12}).has_value());
+      CHECK(not(Rh{12} & Dead{}).has_value());
+      CHECK(not(Rh{std::nullopt} & Dead{}).has_value());
+      CHECK(not(Dead{} & Dead{}).has_value());
+    }
+
     SECTION("copack on left side only")
     {
       using Lh = fn::optional<fn::copack<double, int>>;


### PR DESCRIPTION
Fixes #367.

`operator&`'s constraints admit operands whose value side is the uninhabited `copack<>` — `expected<copack<>, E>`, `optional<copack<>>` — but the join then named `copack<>`'s value fold in its declared return type, a hard error outside the immediate context: even a `requires` probe was a hard error rather than an answer. This was the one monadic operation missed by the #344/#346 empty-sum sweep, whose contract has every monadic operation over an uninhabited `copack<>` side compile and short-circuit.

The fix selects lazily at the three sites that named the fold: the joined value type dispatches through a bool-specialized helper (a product with an uninhabited factor is itself uninhabited, so the dead side's joined type is `copack<>` and the fold is never named), the `noexcept` specification splits into a dead arm that weighs only the error path, and the body `if constexpr`s down to the two error-channel branches. The observable semantics: the conjunction over such an operand always resolves into the error channel, leftmost failure first, `noexcept` exactly when relocating the errors is. Nothing outside `pack.hpp`'s join machinery changed — `optional` and both general `expected` overloads heal transitively, and the void-specialized overloads were verified already sound (their all-valued branches are formable but unreachable, the same shape as their #271 error-side guards).

New test sections ("uninhabited value grade copack<>") in `tests/fn/expected.cpp` — same-error and graded error joins in both orders, values pinned at compile time and runtime, the noexcept conditionality pair — and in `tests/fn/optional.cpp` — always-empty results in both orders. Identity-cluster (`just`/`choice`) admission remains out of scope here; that is #368.

The second commit has the package quine consume its fold's result instead of suppressing it: `main` returns the final state's arity through `apply`, which is `0` exactly when the three-phase cycle completes — the exit status becomes its own correctness check, and the `[[maybe_unused]]` placeholder goes away.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0198ikYYxtCqwNG54SS1b249
