### PR TITLE
Add the disjunction and admit the identity cluster in both operators

### DIFF
--- a/include/fn/choice.hpp
+++ b/include/fn/choice.hpp
@@ -9,6 +9,7 @@
 #include <fn/copack.hpp>
 #include <fn/detail/meta.hpp>
 #include <fn/fwd.hpp>
+#include <fn/just.hpp>
 #include <fn/pack.hpp>
 #include <libfn_version.hpp>
 
@@ -809,6 +810,127 @@ template <typename Lh, typename Rh>
     noexcept(::std::is_nothrow_constructible_v<::std::remove_cvref_t<Lh>, Lh>) -> ::std::remove_cvref_t<Lh>
 {
   return ::std::remove_cvref_t<Lh>{FWD(lh)};
+}
+
+namespace detail {
+template <typename T>
+concept _identity_expected = _some_expected<T> && empty_copack<typename ::std::remove_cvref_t<T>::error_type>;
+template <typename T>
+concept _cluster_operand = _some_just<T> || _some_choice<T> || _identity_expected<T>;
+template <typename T>
+concept _some_carrier = _some_expected<T> || _some_optional<T> || _some_just<T> || _some_choice<T>;
+
+// How a side enters the total disjunction's result: not at all (dead), as the unit pack<>, or as
+// its value - the three-way split keeps the dead and void conjuncts from naming an accessor.
+template <typename T>
+constexpr inline int _inject_kind
+    = ::std::is_void_v<typename ::std::remove_cvref_t<T>::value_type> ? 1 : (::fn::detail::_dead_value<T> ? 0 : 2);
+template <int Kind, typename Type, typename Side> struct _nothrow_total_inject {
+  static constexpr bool value = true;
+};
+template <typename Type, typename Side> struct _nothrow_total_inject<1, Type, Side> {
+  static constexpr bool value = ::std::is_nothrow_constructible_v<Type, pack<>>;
+};
+template <typename Type, typename Side> struct _nothrow_total_inject<2, Type, Side> {
+  static constexpr bool value = ::std::is_nothrow_constructible_v<Type, decltype(::std::declval<Side>().value())>;
+};
+
+// Type stays a template parameter so both branches are dependent: a non-dependent discarded
+// statement would still be checked against choices without a pack<> alternative.
+template <typename Type, typename Side>
+[[nodiscard]] constexpr auto _total_inject(Side &&side) //
+    noexcept(_nothrow_total_inject<_inject_kind<Side>, Type, Side>::value) -> Type
+{
+  if constexpr (::std::is_void_v<typename ::std::remove_cvref_t<Side>::value_type>)
+    return Type{pack<>{}};
+  else
+    return Type{FWD(side).value()};
+}
+} // namespace detail
+
+// The total disjunction: a cluster operand - just, choice, or the identity expected - puts an
+// uninhabited factor into the error product, so the result never fails and collapses into the
+// cluster: just when the value sum stays one bare type, choice when the union is genuine. The
+// leftmost engaged operand wins; a cluster operand is always engaged.
+template <typename Lh, typename Rh>
+  requires(detail::_cluster_operand<Lh> || detail::_cluster_operand<Rh>) //
+          && detail::_some_carrier<Lh> && detail::_some_carrier<Rh>
+          && (not ::std::is_void_v<typename ::std::remove_cvref_t<Lh>::value_type>)
+          && ::std::is_same_v<typename ::std::remove_cvref_t<Lh>::value_type,
+                              typename ::std::remove_cvref_t<Rh>::value_type>
+          && (not some_copack<typename ::std::remove_cvref_t<Lh>::value_type>)
+[[nodiscard]] constexpr auto operator|(Lh &&lh, Rh &&rh) //
+    noexcept(detail::_nothrow_total_inject<detail::_inject_kind<Lh>,
+                                           ::fn::just<typename ::std::remove_cvref_t<Lh>::value_type>, Lh>::value
+             && detail::_nothrow_total_inject<detail::_inject_kind<Rh>,
+                                              ::fn::just<typename ::std::remove_cvref_t<Lh>::value_type>, Rh>::value)
+{
+  using type = ::fn::just<typename ::std::remove_cvref_t<Lh>::value_type>;
+  if constexpr (detail::_cluster_operand<Lh>) {
+    return type{FWD(lh).value()};
+  } else {
+    if (lh.has_value())
+      return type{FWD(lh).value()};
+    return type{FWD(rh).value()};
+  }
+}
+
+template <typename Lh, typename Rh>
+  requires(detail::_cluster_operand<Lh> || detail::_cluster_operand<Rh>) //
+          && detail::_some_carrier<Lh> && detail::_some_carrier<Rh>
+          && ::std::is_same_v<typename ::std::remove_cvref_t<Lh>::value_type,
+                              typename ::std::remove_cvref_t<Rh>::value_type>
+          && some_copack<typename ::std::remove_cvref_t<Lh>::value_type>
+[[nodiscard]] constexpr auto operator|(Lh &&lh, Rh &&rh) //
+    noexcept(detail::_nothrow_total_inject<
+                 detail::_inject_kind<Lh>,
+                 typename detail::_rechoice<typename ::std::remove_cvref_t<Lh>::value_type>::type, Lh>::value
+             && detail::_nothrow_total_inject<
+                 detail::_inject_kind<Rh>,
+                 typename detail::_rechoice<typename ::std::remove_cvref_t<Lh>::value_type>::type, Rh>::value)
+{
+  using type = typename detail::_rechoice<typename ::std::remove_cvref_t<Lh>::value_type>::type;
+  if constexpr (detail::_cluster_operand<Lh>) {
+    return type{FWD(lh).value()};
+  } else {
+    if (lh.has_value())
+      return type{FWD(lh).value()};
+    return type{FWD(rh).value()};
+  }
+}
+
+template <typename Lh, typename Rh>
+  requires(detail::_cluster_operand<Lh> || detail::_cluster_operand<Rh>) //
+          && detail::_some_carrier<Lh> && detail::_some_carrier<Rh>
+          && ::std::is_void_v<typename ::std::remove_cvref_t<Lh>::value_type>
+          && ::std::is_void_v<typename ::std::remove_cvref_t<Rh>::value_type>
+[[nodiscard]] constexpr auto operator|(Lh &&, Rh &&) noexcept -> ::fn::just<void>
+{
+  return ::fn::just<void>{};
+}
+
+template <typename Lh, typename Rh>
+  requires(detail::_cluster_operand<Lh> || detail::_cluster_operand<Rh>) //
+          && detail::_some_carrier<Lh> && detail::_some_carrier<Rh>
+          && (not ::std::is_same_v<typename ::std::remove_cvref_t<Lh>::value_type,
+                                   typename ::std::remove_cvref_t<Rh>::value_type>)
+[[nodiscard]] constexpr auto operator|(Lh &&lh, Rh &&rh) //
+    noexcept(
+        detail::_nothrow_total_inject<detail::_inject_kind<Lh>,
+                                      typename detail::_rechoice<::fn::detail::_disjoined_t<Lh, Rh>>::type, Lh>::value
+        && detail::_nothrow_total_inject<
+            detail::_inject_kind<Rh>, typename detail::_rechoice<::fn::detail::_disjoined_t<Lh, Rh>>::type, Rh>::value)
+{
+  using type = typename detail::_rechoice<::fn::detail::_disjoined_t<Lh, Rh>>::type;
+  if constexpr (detail::_cluster_operand<Lh>) {
+    return detail::_total_inject<type>(FWD(lh));
+  } else {
+    if constexpr (not ::fn::detail::_dead_value<Lh>) {
+      if (lh.has_value())
+        return detail::_total_inject<type>(FWD(lh));
+    }
+    return detail::_total_inject<type>(FWD(rh));
+  }
 }
 
 template <typename T> explicit choice(::std::in_place_type_t<T>, auto &&...) -> choice<T>;

--- a/include/fn/choice.hpp
+++ b/include/fn/choice.hpp
@@ -8,6 +8,8 @@
 
 #include <fn/copack.hpp>
 #include <fn/detail/meta.hpp>
+#include <fn/fwd.hpp>
+#include <fn/pack.hpp>
 #include <libfn_version.hpp>
 
 #include <type_traits>
@@ -757,6 +759,58 @@ struct choice<Ts...> : copack<Ts...> {
 };
 
 // CTAD for single-element choice
+namespace detail {
+template <typename T> struct _rechoice;
+template <typename... Ts> struct _rechoice<copack<Ts...>> {
+  using type = choice<Ts...>;
+};
+template <typename Lh, typename Rh>
+using _choice_fold_t = decltype(_fold_detail::fold<typename ::std::remove_cvref_t<Lh>::value_type,
+                                                   typename ::std::remove_cvref_t<Rh>::value_type>(
+    ::std::declval<Lh>().value(), ::std::declval<Rh>().value()));
+template <typename Lh, typename Rh>
+constexpr inline bool _nothrow_choice_fold
+    = noexcept(_fold_detail::fold<typename ::std::remove_cvref_t<Lh>::value_type,
+                                  typename ::std::remove_cvref_t<Rh>::value_type>(::std::declval<Lh>().value(),
+                                                                                  ::std::declval<Rh>().value()))
+      && ::std::is_nothrow_constructible_v<typename _rechoice<_choice_fold_t<Lh, Rh>>::type, _choice_fold_t<Lh, Rh>>;
+} // namespace detail
+
+// The conjunction inside the cluster, choice on either side: the copack distributes through the
+// value product, so the fold answers a copack of packs and the result stays a choice. just<void>
+// is the product's unit and elides.
+template <typename Lh, typename Rh>
+  requires(detail::_some_choice<Lh> || detail::_some_choice<Rh>) && (detail::_some_just<Lh> || detail::_some_choice<Lh>)
+          && (detail::_some_just<Rh> || detail::_some_choice<Rh>)
+          && (not ::std::is_void_v<typename ::std::remove_cvref_t<Lh>::value_type>)
+          && (not ::std::is_void_v<typename ::std::remove_cvref_t<Rh>::value_type>)
+[[nodiscard]] constexpr auto operator&(Lh &&lh, Rh &&rh) //
+    noexcept(detail::_nothrow_choice_fold<Lh, Rh>)
+{
+  using VL = ::std::remove_cvref_t<Lh>::value_type;
+  using VR = ::std::remove_cvref_t<Rh>::value_type;
+  using type = typename detail::_rechoice<detail::_choice_fold_t<Lh, Rh>>::type;
+  return type{::fn::detail::_fold_detail::fold<VL, VR>(FWD(lh).value(), FWD(rh).value())};
+}
+
+template <typename Lh, typename Rh>
+  requires detail::_some_just<Lh> && ::std::is_void_v<typename ::std::remove_cvref_t<Lh>::value_type>
+           && detail::_some_choice<Rh>
+[[nodiscard]] constexpr auto operator&(Lh &&, Rh &&rh) //
+    noexcept(::std::is_nothrow_constructible_v<::std::remove_cvref_t<Rh>, Rh>) -> ::std::remove_cvref_t<Rh>
+{
+  return ::std::remove_cvref_t<Rh>{FWD(rh)};
+}
+
+template <typename Lh, typename Rh>
+  requires detail::_some_choice<Lh> && detail::_some_just<Rh>
+           && ::std::is_void_v<typename ::std::remove_cvref_t<Rh>::value_type>
+[[nodiscard]] constexpr auto operator&(Lh &&lh, Rh &&) //
+    noexcept(::std::is_nothrow_constructible_v<::std::remove_cvref_t<Lh>, Lh>) -> ::std::remove_cvref_t<Lh>
+{
+  return ::std::remove_cvref_t<Lh>{FWD(lh)};
+}
+
 template <typename T> explicit choice(::std::in_place_type_t<T>, auto &&...) -> choice<T>;
 template <typename T> explicit choice(T) -> choice<T>;
 

--- a/include/fn/expected.hpp
+++ b/include/fn/expected.hpp
@@ -2229,6 +2229,149 @@ template <some_expected Lh, typename Rh>
   return ::std::remove_cvref_t<Lh>{FWD(lh)};
 }
 
+namespace detail {
+// The disjunction's error channel: the product of both operands' errors - the same fold as the
+// conjunction's value product, on the other channel, distributing graded errors the same way.
+template <typename Lh, typename Rh>
+using _error_product_t = decltype(::fn::detail::_fold_detail::fold<typename ::std::remove_cvref_t<Lh>::error_type,
+                                                                   typename ::std::remove_cvref_t<Rh>::error_type>(
+    ::std::declval<Lh>().error(), ::std::declval<Rh>().error()));
+
+template <typename Type, typename Lh, typename Rh>
+constexpr inline bool _nothrow_disj_error
+    = noexcept(::fn::detail::_fold_detail::fold<typename ::std::remove_cvref_t<Lh>::error_type,
+                                                typename ::std::remove_cvref_t<Rh>::error_type>(
+          ::std::declval<Lh>().error(), ::std::declval<Rh>().error()))
+      && _nothrow_initializable<Type, ::fn::unexpect_t, _error_product_t<Lh, Rh>>;
+
+} // namespace detail
+
+// The disjunction: the value channel is the sum of the value types - a same-type pair stays bare,
+// as the conjunction's same-error sum does - and the error channel is the product of both errors,
+// present only when every operand failed, all evidence kept positionally. The leftmost engaged
+// operand wins and injects by type; void enters a genuine sum as pack<>.
+template <typename Lh, typename Rh>
+  requires some_expected<Lh> && some_expected<Rh> && (not some_expected_void<Lh>) && (not some_expected_void<Rh>)
+           && (not empty_copack<typename ::std::remove_cvref_t<Lh>::error_type>)
+           && (not empty_copack<typename ::std::remove_cvref_t<Rh>::error_type>)
+           && ::std::is_same_v<typename ::std::remove_cvref_t<Lh>::value_type,
+                               typename ::std::remove_cvref_t<Rh>::value_type>
+[[nodiscard]] constexpr auto operator|(Lh &&lh, Rh &&rh) //
+    noexcept(::fn::detail::_nothrow_disj_inject<
+                 ::fn::detail::_dead_value<Lh>,
+                 expected<typename ::std::remove_cvref_t<Lh>::value_type, detail::_error_product_t<Lh, Rh>>, Lh>::value
+             && detail::_nothrow_disj_error<
+                 expected<typename ::std::remove_cvref_t<Lh>::value_type, detail::_error_product_t<Lh, Rh>>, Lh, Rh>)
+{
+  using value_type = ::std::remove_cvref_t<Lh>::value_type;
+  using type = expected<value_type, detail::_error_product_t<Lh, Rh>>;
+  using El = ::std::remove_cvref_t<Lh>::error_type;
+  using Er = ::std::remove_cvref_t<Rh>::error_type;
+  if constexpr (not ::fn::detail::_dead_value<Lh>) {
+    if (lh.has_value())
+      return type{::std::in_place, FWD(lh).value()};
+    if (rh.has_value())
+      return type{::std::in_place, FWD(rh).value()};
+  }
+  return type{::fn::unexpect, ::fn::detail::_fold_detail::fold<El, Er>(FWD(lh).error(), FWD(rh).error())};
+}
+
+template <some_expected_void Lh, some_expected_void Rh>
+  requires(not empty_copack<typename ::std::remove_cvref_t<Lh>::error_type>)
+          && (not empty_copack<typename ::std::remove_cvref_t<Rh>::error_type>)
+[[nodiscard]] constexpr auto operator|(Lh &&lh, Rh &&rh) //
+    noexcept(detail::_nothrow_disj_error<expected<void, detail::_error_product_t<Lh, Rh>>, Lh, Rh>)
+{
+  using type = expected<void, detail::_error_product_t<Lh, Rh>>;
+  using El = ::std::remove_cvref_t<Lh>::error_type;
+  using Er = ::std::remove_cvref_t<Rh>::error_type;
+  if (lh.has_value() || rh.has_value())
+    return type{};
+  return type{::fn::unexpect, ::fn::detail::_fold_detail::fold<El, Er>(FWD(lh).error(), FWD(rh).error())};
+}
+
+template <typename Lh, typename Rh>
+  requires some_expected<Lh> && some_expected<Rh> && (not some_expected_void<Lh>) && (not some_expected_void<Rh>)
+           && (not empty_copack<typename ::std::remove_cvref_t<Lh>::error_type>)
+           && (not empty_copack<typename ::std::remove_cvref_t<Rh>::error_type>)
+           && (not ::std::is_same_v<typename ::std::remove_cvref_t<Lh>::value_type,
+                                    typename ::std::remove_cvref_t<Rh>::value_type>)
+[[nodiscard]] constexpr auto operator|(Lh &&lh, Rh &&rh) //
+    noexcept(::fn::detail::_nothrow_disj_inject<
+                 ::fn::detail::_dead_value<Lh>,
+                 expected<::fn::detail::_disjoined_t<Lh, Rh>, detail::_error_product_t<Lh, Rh>>, Lh>::value
+             && ::fn::detail::_nothrow_disj_inject<
+                 ::fn::detail::_dead_value<Rh>,
+                 expected<::fn::detail::_disjoined_t<Lh, Rh>, detail::_error_product_t<Lh, Rh>>, Rh>::value
+             && detail::_nothrow_disj_error<
+                 expected<::fn::detail::_disjoined_t<Lh, Rh>, detail::_error_product_t<Lh, Rh>>, Lh, Rh>)
+{
+  using type = expected<::fn::detail::_disjoined_t<Lh, Rh>, detail::_error_product_t<Lh, Rh>>;
+  using El = ::std::remove_cvref_t<Lh>::error_type;
+  using Er = ::std::remove_cvref_t<Rh>::error_type;
+  if constexpr (not ::fn::detail::_dead_value<Lh>) {
+    if (lh.has_value())
+      return type{::std::in_place, FWD(lh).value()};
+  }
+  if constexpr (not ::fn::detail::_dead_value<Rh>) {
+    if (rh.has_value())
+      return type{::std::in_place, FWD(rh).value()};
+  }
+  return type{::fn::unexpect, ::fn::detail::_fold_detail::fold<El, Er>(FWD(lh).error(), FWD(rh).error())};
+}
+
+template <some_expected_void Lh, typename Rh>
+  requires some_expected<Rh> && (not some_expected_void<Rh>)
+           && (not empty_copack<typename ::std::remove_cvref_t<Lh>::error_type>)
+           && (not empty_copack<typename ::std::remove_cvref_t<Rh>::error_type>)
+[[nodiscard]] constexpr auto operator|(Lh &&lh, Rh &&rh) //
+    noexcept(
+        ::fn::detail::_nothrow_initializable<
+            expected<::fn::detail::_disjoined_t<Lh, Rh>, detail::_error_product_t<Lh, Rh>>, ::std::in_place_t, pack<>>
+        && ::fn::detail::_nothrow_disj_inject<
+            ::fn::detail::_dead_value<Rh>,
+            expected<::fn::detail::_disjoined_t<Lh, Rh>, detail::_error_product_t<Lh, Rh>>, Rh>::value
+        && detail::_nothrow_disj_error<expected<::fn::detail::_disjoined_t<Lh, Rh>, detail::_error_product_t<Lh, Rh>>,
+                                       Lh, Rh>)
+{
+  using type = expected<::fn::detail::_disjoined_t<Lh, Rh>, detail::_error_product_t<Lh, Rh>>;
+  using El = ::std::remove_cvref_t<Lh>::error_type;
+  using Er = ::std::remove_cvref_t<Rh>::error_type;
+  if (lh.has_value())
+    return type{::std::in_place, pack<>{}};
+  if constexpr (not ::fn::detail::_dead_value<Rh>) {
+    if (rh.has_value())
+      return type{::std::in_place, FWD(rh).value()};
+  }
+  return type{::fn::unexpect, ::fn::detail::_fold_detail::fold<El, Er>(FWD(lh).error(), FWD(rh).error())};
+}
+
+template <typename Lh, some_expected_void Rh>
+  requires some_expected<Lh> && (not some_expected_void<Lh>)
+           && (not empty_copack<typename ::std::remove_cvref_t<Lh>::error_type>)
+           && (not empty_copack<typename ::std::remove_cvref_t<Rh>::error_type>)
+[[nodiscard]] constexpr auto operator|(Lh &&lh, Rh &&rh) //
+    noexcept(
+        ::fn::detail::_nothrow_disj_inject<
+            ::fn::detail::_dead_value<Lh>,
+            expected<::fn::detail::_disjoined_t<Lh, Rh>, detail::_error_product_t<Lh, Rh>>, Lh>::value
+        && ::fn::detail::_nothrow_initializable<
+            expected<::fn::detail::_disjoined_t<Lh, Rh>, detail::_error_product_t<Lh, Rh>>, ::std::in_place_t, pack<>>
+        && detail::_nothrow_disj_error<expected<::fn::detail::_disjoined_t<Lh, Rh>, detail::_error_product_t<Lh, Rh>>,
+                                       Lh, Rh>)
+{
+  using type = expected<::fn::detail::_disjoined_t<Lh, Rh>, detail::_error_product_t<Lh, Rh>>;
+  using El = ::std::remove_cvref_t<Lh>::error_type;
+  using Er = ::std::remove_cvref_t<Rh>::error_type;
+  if constexpr (not ::fn::detail::_dead_value<Lh>) {
+    if (lh.has_value())
+      return type{::std::in_place, FWD(lh).value()};
+  }
+  if (rh.has_value())
+    return type{::std::in_place, pack<>{}};
+  return type{::fn::unexpect, ::fn::detail::_fold_detail::fold<El, Er>(FWD(lh).error(), FWD(rh).error())};
+}
+
 } // namespace LIBFN_VERSION
 } // namespace fn
 

--- a/include/fn/expected.hpp
+++ b/include/fn/expected.hpp
@@ -2113,6 +2113,122 @@ template <typename Lh, typename Rh>
       FWD(lh), FWD(rh), detail::_expected_efn<new_error_type>{});
 }
 
+namespace detail {
+// The cluster conjunction's specification: the cluster operand always contributes its value, so
+// only the expected operand's channels weigh - its error relocating unchanged into the result.
+template <bool Uninhabited, typename Type, typename Lh, typename Rh, typename Err> struct _nothrow_amp_cluster {
+  static constexpr bool value = _nothrow_initializable<Type, ::fn::unexpect_t, Err>;
+};
+template <typename Type, typename Lh, typename Rh, typename Err> struct _nothrow_amp_cluster<false, Type, Lh, Rh, Err> {
+  static constexpr bool value
+      = noexcept(::fn::detail::_fold_detail::fold<typename ::std::remove_cvref_t<Lh>::value_type,
+                                                  typename ::std::remove_cvref_t<Rh>::value_type>(
+            ::std::declval<::fn::detail::_value_of_t<Lh>>(), ::std::declval<::fn::detail::_value_of_t<Rh>>()))
+        && _nothrow_initializable<Type, ::std::in_place_t, ::fn::detail::_joined_t<Lh, Rh>>
+        && _nothrow_initializable<Type, ::fn::unexpect_t, Err>;
+};
+} // namespace detail
+
+// The identity cluster in the conjunction: a just or choice operand always contributes its value
+// to the product and adds no term to the error sum - the expected operand's error passes through
+// unchanged, plain or graded, and its state alone decides. just<void> is the product's unit and
+// elides.
+template <typename Lh, some_expected Rh>
+  requires(::fn::detail::_some_just<Lh> || ::fn::detail::_some_choice<Lh>)
+          && (not ::std::is_void_v<typename ::std::remove_cvref_t<Lh>::value_type>) && (not some_expected_void<Rh>)
+[[nodiscard]] constexpr auto operator&(Lh &&lh, Rh &&rh) //
+    noexcept(detail::_nothrow_amp_cluster<
+             ::fn::detail::_uninhabited_join<Lh, Rh>,
+             expected<::fn::detail::_joined_t<Lh, Rh>, typename ::std::remove_cvref_t<Rh>::error_type>, Lh, Rh,
+             decltype(FWD(rh).error())>::value)
+{
+  using type = expected<::fn::detail::_joined_t<Lh, Rh>, typename ::std::remove_cvref_t<Rh>::error_type>;
+  if constexpr (::fn::detail::_uninhabited_join<Lh, Rh>) {
+    return type{::fn::unexpect, FWD(rh).error()};
+  } else {
+    using VL = ::std::remove_cvref_t<Lh>::value_type;
+    using VR = ::std::remove_cvref_t<Rh>::value_type;
+    if (rh.has_value())
+      return type{::std::in_place, ::fn::detail::_fold_detail::fold<VL, VR>(FWD(lh).value(), FWD(rh).value())};
+    return type{::fn::unexpect, FWD(rh).error()};
+  }
+}
+
+template <some_expected Lh, typename Rh>
+  requires(::fn::detail::_some_just<Rh> || ::fn::detail::_some_choice<Rh>)
+          && (not ::std::is_void_v<typename ::std::remove_cvref_t<Rh>::value_type>) && (not some_expected_void<Lh>)
+[[nodiscard]] constexpr auto operator&(Lh &&lh, Rh &&rh) //
+    noexcept(detail::_nothrow_amp_cluster<
+             ::fn::detail::_uninhabited_join<Lh, Rh>,
+             expected<::fn::detail::_joined_t<Lh, Rh>, typename ::std::remove_cvref_t<Lh>::error_type>, Lh, Rh,
+             decltype(FWD(lh).error())>::value)
+{
+  using type = expected<::fn::detail::_joined_t<Lh, Rh>, typename ::std::remove_cvref_t<Lh>::error_type>;
+  if constexpr (::fn::detail::_uninhabited_join<Lh, Rh>) {
+    return type{::fn::unexpect, FWD(lh).error()};
+  } else {
+    using VL = ::std::remove_cvref_t<Lh>::value_type;
+    using VR = ::std::remove_cvref_t<Rh>::value_type;
+    if (lh.has_value())
+      return type{::std::in_place, ::fn::detail::_fold_detail::fold<VL, VR>(FWD(lh).value(), FWD(rh).value())};
+    return type{::fn::unexpect, FWD(lh).error()};
+  }
+}
+
+template <typename Lh, some_expected_void Rh>
+  requires(::fn::detail::_some_just<Lh> || ::fn::detail::_some_choice<Lh>)
+          && (not ::std::is_void_v<typename ::std::remove_cvref_t<Lh>::value_type>)
+[[nodiscard]] constexpr auto operator&(Lh &&lh, Rh &&rh) //
+    noexcept(
+        ::fn::detail::_nothrow_initializable<
+            expected<typename ::std::remove_cvref_t<Lh>::value_type, typename ::std::remove_cvref_t<Rh>::error_type>,
+            ::std::in_place_t, decltype(FWD(lh).value())>
+        && ::fn::detail::_nothrow_initializable<
+            expected<typename ::std::remove_cvref_t<Lh>::value_type, typename ::std::remove_cvref_t<Rh>::error_type>,
+            ::fn::unexpect_t, decltype(FWD(rh).error())>)
+        -> expected<typename ::std::remove_cvref_t<Lh>::value_type, typename ::std::remove_cvref_t<Rh>::error_type>
+{
+  using type = expected<typename ::std::remove_cvref_t<Lh>::value_type, typename ::std::remove_cvref_t<Rh>::error_type>;
+  if (rh.has_value())
+    return type{::std::in_place, FWD(lh).value()};
+  return type{::fn::unexpect, FWD(rh).error()};
+}
+
+template <some_expected_void Lh, typename Rh>
+  requires(::fn::detail::_some_just<Rh> || ::fn::detail::_some_choice<Rh>)
+          && (not ::std::is_void_v<typename ::std::remove_cvref_t<Rh>::value_type>)
+[[nodiscard]] constexpr auto operator&(Lh &&lh, Rh &&rh) //
+    noexcept(
+        ::fn::detail::_nothrow_initializable<
+            expected<typename ::std::remove_cvref_t<Rh>::value_type, typename ::std::remove_cvref_t<Lh>::error_type>,
+            ::std::in_place_t, decltype(FWD(rh).value())>
+        && ::fn::detail::_nothrow_initializable<
+            expected<typename ::std::remove_cvref_t<Rh>::value_type, typename ::std::remove_cvref_t<Lh>::error_type>,
+            ::fn::unexpect_t, decltype(FWD(lh).error())>)
+        -> expected<typename ::std::remove_cvref_t<Rh>::value_type, typename ::std::remove_cvref_t<Lh>::error_type>
+{
+  using type = expected<typename ::std::remove_cvref_t<Rh>::value_type, typename ::std::remove_cvref_t<Lh>::error_type>;
+  if (lh.has_value())
+    return type{::std::in_place, FWD(rh).value()};
+  return type{::fn::unexpect, FWD(lh).error()};
+}
+
+template <typename Lh, some_expected Rh>
+  requires ::fn::detail::_some_just<Lh> && ::std::is_void_v<typename ::std::remove_cvref_t<Lh>::value_type>
+[[nodiscard]] constexpr auto operator&(Lh &&, Rh &&rh) //
+    noexcept(::fn::detail::_nothrow_initializable<::std::remove_cvref_t<Rh>, Rh>) -> ::std::remove_cvref_t<Rh>
+{
+  return ::std::remove_cvref_t<Rh>{FWD(rh)};
+}
+
+template <some_expected Lh, typename Rh>
+  requires ::fn::detail::_some_just<Rh> && ::std::is_void_v<typename ::std::remove_cvref_t<Rh>::value_type>
+[[nodiscard]] constexpr auto operator&(Lh &&lh, Rh &&) //
+    noexcept(::fn::detail::_nothrow_initializable<::std::remove_cvref_t<Lh>, Lh>) -> ::std::remove_cvref_t<Lh>
+{
+  return ::std::remove_cvref_t<Lh>{FWD(lh)};
+}
+
 } // namespace LIBFN_VERSION
 } // namespace fn
 

--- a/include/fn/just.hpp
+++ b/include/fn/just.hpp
@@ -12,6 +12,7 @@
 #include <fn/detail/functional.hpp>
 #include <fn/detail/fwd.hpp>
 #include <fn/detail/variadic_union.hpp>
+#include <fn/pack.hpp>
 
 #include <memory>
 #include <type_traits>
@@ -657,6 +658,51 @@ template <typename T, typename U>
 }
 
 // CTAD for just, including the deduced spelling of the void carrier: just{}
+namespace detail {
+template <typename Lh, typename Rh>
+using _just_fold_t = decltype(_fold_detail::fold<typename ::std::remove_cvref_t<Lh>::value_type,
+                                                 typename ::std::remove_cvref_t<Rh>::value_type>(
+    ::std::declval<Lh>().value(), ::std::declval<Rh>().value()));
+template <typename Lh, typename Rh>
+constexpr inline bool _nothrow_just_fold
+    = noexcept(_fold_detail::fold<typename ::std::remove_cvref_t<Lh>::value_type,
+                                  typename ::std::remove_cvref_t<Rh>::value_type>(::std::declval<Lh>().value(),
+                                                                                  ::std::declval<Rh>().value()))
+      && ::std::is_nothrow_constructible_v<just<_just_fold_t<Lh, Rh>>, _just_fold_t<Lh, Rh>>;
+} // namespace detail
+
+// The conjunction inside the cluster: just & just folds the payloads and stays just, and
+// just<void> is the product's unit - it elides, whatever the other operand.
+template <typename Lh, typename Rh>
+  requires detail::_some_just<Lh> && detail::_some_just<Rh>
+           && (not ::std::is_void_v<typename ::std::remove_cvref_t<Lh>::value_type>)
+           && (not ::std::is_void_v<typename ::std::remove_cvref_t<Rh>::value_type>)
+[[nodiscard]] constexpr auto operator&(Lh &&lh, Rh &&rh) //
+    noexcept(detail::_nothrow_just_fold<Lh, Rh>)
+{
+  using VL = ::std::remove_cvref_t<Lh>::value_type;
+  using VR = ::std::remove_cvref_t<Rh>::value_type;
+  return just<detail::_just_fold_t<Lh, Rh>>{::fn::detail::_fold_detail::fold<VL, VR>(FWD(lh).value(), FWD(rh).value())};
+}
+
+template <typename Lh, typename Rh>
+  requires detail::_some_just<Lh> && ::std::is_void_v<typename ::std::remove_cvref_t<Lh>::value_type>
+           && detail::_some_just<Rh>
+[[nodiscard]] constexpr auto operator&(Lh &&, Rh &&rh) //
+    noexcept(::std::is_nothrow_constructible_v<::std::remove_cvref_t<Rh>, Rh>) -> ::std::remove_cvref_t<Rh>
+{
+  return ::std::remove_cvref_t<Rh>{FWD(rh)};
+}
+
+template <typename Lh, typename Rh>
+  requires detail::_some_just<Lh> && (not ::std::is_void_v<typename ::std::remove_cvref_t<Lh>::value_type>)
+           && detail::_some_just<Rh> && ::std::is_void_v<typename ::std::remove_cvref_t<Rh>::value_type>
+[[nodiscard]] constexpr auto operator&(Lh &&lh, Rh &&) //
+    noexcept(::std::is_nothrow_constructible_v<::std::remove_cvref_t<Lh>, Lh>) -> ::std::remove_cvref_t<Lh>
+{
+  return ::std::remove_cvref_t<Lh>{FWD(lh)};
+}
+
 template <typename T> just(T) -> just<T>;
 template <typename T> explicit just(::std::in_place_type_t<T>, auto &&...) -> just<T>;
 just() -> just<void>;

--- a/include/fn/optional.hpp
+++ b/include/fn/optional.hpp
@@ -1429,6 +1429,42 @@ template <some_optional Lh, typename Rh>
   return ::std::remove_cvref_t<Lh>{FWD(lh)};
 }
 
+// The disjunction: the value channel is the sum of the value types - a same-type pair stays bare -
+// and the unit errors vanish in the product, so the result is empty exactly when both operands
+// are. The leftmost engaged operand wins and injects by type.
+template <some_optional Lh, some_optional Rh>
+  requires ::std::is_same_v<typename ::std::remove_cvref_t<Lh>::value_type,
+                            typename ::std::remove_cvref_t<Rh>::value_type>
+[[nodiscard]] constexpr auto operator|(Lh &&lh, Rh &&rh) //
+    noexcept(::fn::detail::_nothrow_initializable<::std::remove_cvref_t<Lh>, Lh>
+             && ::fn::detail::_nothrow_initializable<::std::remove_cvref_t<Lh>, Rh>) -> ::std::remove_cvref_t<Lh>
+{
+  if (lh.has_value())
+    return ::std::remove_cvref_t<Lh>{FWD(lh)};
+  return ::std::remove_cvref_t<Lh>{FWD(rh)};
+}
+
+template <some_optional Lh, some_optional Rh>
+  requires(not ::std::is_same_v<typename ::std::remove_cvref_t<Lh>::value_type,
+                                typename ::std::remove_cvref_t<Rh>::value_type>)
+[[nodiscard]] constexpr auto operator|(Lh &&lh, Rh &&rh) //
+    noexcept(::fn::detail::_nothrow_disj_inject<::fn::detail::_dead_value<Lh>,
+                                                optional<::fn::detail::_disjoined_t<Lh, Rh>>, Lh>::value
+             && ::fn::detail::_nothrow_disj_inject<::fn::detail::_dead_value<Rh>,
+                                                   optional<::fn::detail::_disjoined_t<Lh, Rh>>, Rh>::value)
+{
+  using type = optional<::fn::detail::_disjoined_t<Lh, Rh>>;
+  if constexpr (not ::fn::detail::_dead_value<Lh>) {
+    if (lh.has_value())
+      return type{::std::in_place, FWD(lh).value()};
+  }
+  if constexpr (not ::fn::detail::_dead_value<Rh>) {
+    if (rh.has_value())
+      return type{::std::in_place, FWD(rh).value()};
+  }
+  return type{::std::nullopt};
+}
+
 } // namespace LIBFN_VERSION
 } // namespace fn
 

--- a/include/fn/optional.hpp
+++ b/include/fn/optional.hpp
@@ -12,6 +12,7 @@
 
 #include <fn/copack.hpp>
 #include <fn/detail/functional.hpp>
+#include <fn/fwd.hpp>
 #include <fn/pack.hpp>
 
 #include <compare>
@@ -1314,6 +1315,118 @@ template <some_optional Lh, some_optional Rh>
     noexcept(noexcept(::fn::detail::_join<fn::optional>(FWD(lh), FWD(rh), detail::_optional_efn{})))
 {
   return ::fn::detail::_join<fn::optional>(FWD(lh), FWD(rh), detail::_optional_efn{});
+}
+
+// The identity cluster in the conjunction: a just or choice operand always contributes its value
+// to the product and adds no term to the error sum, so the optional operand's state decides alone.
+// just<void> is the product's unit and elides.
+template <typename Lh, some_optional Rh>
+  requires(::fn::detail::_some_just<Lh> || ::fn::detail::_some_choice<Lh>)
+          && (not ::std::is_void_v<typename ::std::remove_cvref_t<Lh>::value_type>)
+[[nodiscard]] constexpr auto operator&(Lh &&lh, Rh &&rh) //
+    noexcept(::fn::detail::_nothrow_join<fn::optional, Lh, Rh, detail::_optional_efn>)
+{
+  using type = optional<::fn::detail::_joined_t<Lh, Rh>>;
+  if constexpr (::fn::detail::_uninhabited_join<Lh, Rh>) {
+    return type{::std::nullopt};
+  } else {
+    using VL = ::std::remove_cvref_t<Lh>::value_type;
+    using VR = ::std::remove_cvref_t<Rh>::value_type;
+    if (rh.has_value())
+      return type{::std::in_place, ::fn::detail::_fold_detail::fold<VL, VR>(FWD(lh).value(), FWD(rh).value())};
+    return type{::std::nullopt};
+  }
+}
+
+template <some_optional Lh, typename Rh>
+  requires(::fn::detail::_some_just<Rh> || ::fn::detail::_some_choice<Rh>)
+          && (not ::std::is_void_v<typename ::std::remove_cvref_t<Rh>::value_type>)
+[[nodiscard]] constexpr auto operator&(Lh &&lh, Rh &&rh) //
+    noexcept(::fn::detail::_nothrow_join<fn::optional, Lh, Rh, detail::_optional_efn>)
+{
+  using type = optional<::fn::detail::_joined_t<Lh, Rh>>;
+  if constexpr (::fn::detail::_uninhabited_join<Lh, Rh>) {
+    return type{::std::nullopt};
+  } else {
+    using VL = ::std::remove_cvref_t<Lh>::value_type;
+    using VR = ::std::remove_cvref_t<Rh>::value_type;
+    if (lh.has_value())
+      return type{::std::in_place, ::fn::detail::_fold_detail::fold<VL, VR>(FWD(lh).value(), FWD(rh).value())};
+    return type{::std::nullopt};
+  }
+}
+
+template <typename Lh, some_optional Rh>
+  requires ::fn::detail::_some_just<Lh> && ::std::is_void_v<typename ::std::remove_cvref_t<Lh>::value_type>
+[[nodiscard]] constexpr auto operator&(Lh &&, Rh &&rh) //
+    noexcept(::fn::detail::_nothrow_initializable<::std::remove_cvref_t<Rh>, Rh>) -> ::std::remove_cvref_t<Rh>
+{
+  return ::std::remove_cvref_t<Rh>{FWD(rh)};
+}
+
+template <some_optional Lh, typename Rh>
+  requires ::fn::detail::_some_just<Rh> && ::std::is_void_v<typename ::std::remove_cvref_t<Rh>::value_type>
+[[nodiscard]] constexpr auto operator&(Lh &&lh, Rh &&) //
+    noexcept(::fn::detail::_nothrow_initializable<::std::remove_cvref_t<Lh>, Lh>) -> ::std::remove_cvref_t<Lh>
+{
+  return ::std::remove_cvref_t<Lh>{FWD(lh)};
+}
+
+// The identity expected is the cluster's third member: its uninhabited error contributes nothing
+// to the sum, so against optional it composes exactly as just does - and expected<void, copack<>>
+// elides as the product's unit.
+template <typename Lh, some_optional Rh>
+  requires ::fn::detail::_some_expected<Lh> && empty_copack<typename ::std::remove_cvref_t<Lh>::error_type>
+           && (not ::std::is_void_v<typename ::std::remove_cvref_t<Lh>::value_type>)
+[[nodiscard]] constexpr auto operator&(Lh &&lh, Rh &&rh) //
+    noexcept(::fn::detail::_nothrow_join<fn::optional, Lh, Rh, detail::_optional_efn>)
+{
+  using type = optional<::fn::detail::_joined_t<Lh, Rh>>;
+  if constexpr (::fn::detail::_uninhabited_join<Lh, Rh>) {
+    return type{::std::nullopt};
+  } else {
+    using VL = ::std::remove_cvref_t<Lh>::value_type;
+    using VR = ::std::remove_cvref_t<Rh>::value_type;
+    if (rh.has_value())
+      return type{::std::in_place, ::fn::detail::_fold_detail::fold<VL, VR>(FWD(lh).value(), FWD(rh).value())};
+    return type{::std::nullopt};
+  }
+}
+
+template <some_optional Lh, typename Rh>
+  requires ::fn::detail::_some_expected<Rh> && empty_copack<typename ::std::remove_cvref_t<Rh>::error_type>
+           && (not ::std::is_void_v<typename ::std::remove_cvref_t<Rh>::value_type>)
+[[nodiscard]] constexpr auto operator&(Lh &&lh, Rh &&rh) //
+    noexcept(::fn::detail::_nothrow_join<fn::optional, Lh, Rh, detail::_optional_efn>)
+{
+  using type = optional<::fn::detail::_joined_t<Lh, Rh>>;
+  if constexpr (::fn::detail::_uninhabited_join<Lh, Rh>) {
+    return type{::std::nullopt};
+  } else {
+    using VL = ::std::remove_cvref_t<Lh>::value_type;
+    using VR = ::std::remove_cvref_t<Rh>::value_type;
+    if (lh.has_value())
+      return type{::std::in_place, ::fn::detail::_fold_detail::fold<VL, VR>(FWD(lh).value(), FWD(rh).value())};
+    return type{::std::nullopt};
+  }
+}
+
+template <typename Lh, some_optional Rh>
+  requires ::fn::detail::_some_expected<Lh> && empty_copack<typename ::std::remove_cvref_t<Lh>::error_type>
+           && ::std::is_void_v<typename ::std::remove_cvref_t<Lh>::value_type>
+[[nodiscard]] constexpr auto operator&(Lh &&, Rh &&rh) //
+    noexcept(::fn::detail::_nothrow_initializable<::std::remove_cvref_t<Rh>, Rh>) -> ::std::remove_cvref_t<Rh>
+{
+  return ::std::remove_cvref_t<Rh>{FWD(rh)};
+}
+
+template <some_optional Lh, typename Rh>
+  requires ::fn::detail::_some_expected<Rh> && empty_copack<typename ::std::remove_cvref_t<Rh>::error_type>
+           && ::std::is_void_v<typename ::std::remove_cvref_t<Rh>::value_type>
+[[nodiscard]] constexpr auto operator&(Lh &&lh, Rh &&) //
+    noexcept(::fn::detail::_nothrow_initializable<::std::remove_cvref_t<Lh>, Lh>) -> ::std::remove_cvref_t<Lh>
+{
+  return ::std::remove_cvref_t<Lh>{FWD(lh)};
 }
 
 } // namespace LIBFN_VERSION

--- a/include/fn/pack.hpp
+++ b/include/fn/pack.hpp
@@ -385,6 +385,25 @@ struct _nothrow_join_arm<false, Tpl, Lh, Rh, Efn> {
 template <template <typename> typename Tpl, typename Lh, typename Rh, typename Efn>
 constexpr inline bool _nothrow_join = _nothrow_join_arm<_uninhabited_join<Lh, Rh>, Tpl, Lh, Rh, Efn>::value;
 
+// The disjunction's value channel: the sum of the two value types, with void spelled pack<> -
+// both are the unit, and a copack cannot hold void.
+template <typename V> using _sum_element_t = ::std::conditional_t<::std::is_void_v<V>, pack<>, V>;
+template <typename Lh, typename Rh>
+using _disjoined_t = copack_for<_sum_element_t<typename ::std::remove_cvref_t<Lh>::value_type>,
+                                _sum_element_t<typename ::std::remove_cvref_t<Rh>::value_type>>;
+
+template <typename T> constexpr inline bool _dead_value = empty_copack<typename ::std::remove_cvref_t<T>::value_type>;
+
+// A dead side (uninhabited value) never relocates into the result - its inject arm is if
+// constexpr'd out of the body, and weighs nothing here.
+template <bool Dead, typename Type, typename Side> struct _nothrow_disj_inject {
+  static constexpr bool value = true;
+};
+template <typename Type, typename Side> struct _nothrow_disj_inject<false, Type, Side> {
+  static constexpr bool value
+      = _nothrow_initializable<Type, ::std::in_place_t, decltype(::std::declval<Side>().value())>;
+};
+
 template <template <typename> typename Tpl>
 [[nodiscard]] constexpr auto _join(auto &&lh, auto &&rh, auto &&efn) //
     noexcept(_nothrow_join<Tpl, decltype(lh), decltype(rh), decltype(efn)>)
@@ -472,6 +491,22 @@ constexpr inline struct conjoin_t {
     return (FWD(arg) & ... & FWD(args));
   }
 } conjoin;
+
+/**
+ * @brief The n-ary fold of the disjunction `operator |` over the monadic carriers; a single
+ *        argument is forwarded unchanged
+ */
+constexpr inline struct disjoin_t {
+  template <typename Arg> [[nodiscard]] constexpr auto operator()(Arg &&arg) const -> decltype(arg) { return FWD(arg); }
+
+  template <typename Arg, typename... Args>
+    requires(sizeof...(Args) > 0) && requires(Arg &&a, Args &&...as) { (FWD(a) | ... | FWD(as)); }
+  [[nodiscard]] constexpr auto operator()(Arg &&arg, Args &&...args) const //
+      noexcept(noexcept((FWD(arg) | ... | FWD(args))))
+  {
+    return (FWD(arg) | ... | FWD(args));
+  }
+} disjoin;
 
 } // namespace LIBFN_VERSION
 } // namespace fn

--- a/tests/fn/and_then.cpp
+++ b/tests/fn/and_then.cpp
@@ -1153,6 +1153,11 @@ TEST_CASE("and_then joins heterogeneous expected branches", "[and_then][expected
     CHECK(r.value() == fn::copack_for<X, Y>{Y{}});
     auto e = In{fn::unexpect, fn::copack<E0>{E0{}}}.and_then(fnJoin);
     CHECK(e.error() == fn::copack_for<E0, E1, E2>{E0{}});
+    // the error path in every remaining value category
+    In el{fn::unexpect, fn::copack<E0>{E0{}}};
+    CHECK(el.and_then(fnJoin).error() == fn::copack_for<E0, E1, E2>{E0{}});
+    CHECK(std::as_const(el).and_then(fnJoin).error() == fn::copack_for<E0, E1, E2>{E0{}});
+    CHECK(std::move(std::as_const(el)).and_then(fnJoin).error() == fn::copack_for<E0, E1, E2>{E0{}});
     // named source: VS 2022 misreads a mid-expression prvalue's empty-class union member
     constexpr In ca{fn::copack_for<A, B>{A{}}};
     static_assert(ca.and_then(fnJoin).value() == fn::copack_for<X, Y>{X{}});

--- a/tests/fn/choice.cpp
+++ b/tests/fn/choice.cpp
@@ -4,6 +4,7 @@
 // or copy at https://opensource.org/licenses/ISC
 
 #include <fn/choice.hpp>
+#include <fn/just.hpp>
 
 #include <fn/utility.hpp>
 
@@ -636,6 +637,35 @@ TEST_CASE("choice non-monadic functionality", "[choice]")
             [](int &&) -> std::false_type { return {}; }, [](int const &&) -> std::true_type { return {}; }}));
       }
     }
+  }
+
+  SECTION("operator &")
+  {
+    // The conjunction inside the cluster: the copack distributes through the value product and the
+    // result stays a choice; just<void> is the product's unit and elides
+    using C = fn::choice_for<int, bool>;
+    static_assert(std::is_same_v<decltype(std::declval<fn::just<int>>() & std::declval<C>()),
+                                 fn::choice_for<fn::pack<int, int>, fn::pack<int, bool>>>);
+    static_assert(std::is_same_v<decltype(std::declval<C>() & std::declval<fn::just<int>>()),
+                                 fn::choice_for<fn::pack<int, int>, fn::pack<bool, int>>>);
+    static_assert(std::is_same_v<
+                  decltype(std::declval<C>() & std::declval<C>()),
+                  fn::choice_for<fn::pack<int, int>, fn::pack<int, bool>, fn::pack<bool, int>, fn::pack<bool, bool>>>);
+    static_assert(std::is_same_v<decltype(std::declval<fn::just<void>>() & std::declval<C>()), C>);
+    static_assert(std::is_same_v<decltype(std::declval<C>() & std::declval<fn::just<void>>()), C>);
+
+    constexpr auto count = []([[maybe_unused]] auto &&...args) { return static_cast<int>(sizeof...(args)); };
+    constexpr auto probe = fn::overload{[](int a, bool b) { return a == 1 && b; }, [](auto &&...) { return false; }};
+    static_assert((fn::just<int>{1} & C{true}).apply(probe));
+    static_assert((fn::just<int>{1} & C{true}).apply(count) == 2);
+    static_assert((C{2} & fn::just<int>{1}).apply(count) == 2);
+    static_assert((C{true} & C{2}).apply(count) == 2);
+    static_assert((fn::just<void>{} & C{5}).apply(count) == 1);
+    CHECK((fn::just<int>{1} & C{true}).apply(probe));
+    CHECK((fn::just<void>{} & C{5}).apply(count) == 1);
+
+    static_assert(noexcept(C{2} & C{true}));
+    SUCCEED();
   }
 }
 

--- a/tests/fn/choice.cpp
+++ b/tests/fn/choice.cpp
@@ -701,9 +701,11 @@ TEST_CASE("choice disjunction", "[choice][just][operator_or]")
     static_assert((J{1} | J{2}) == 1); // left catch: the leftmost total operand absorbs
     static_assert((fn::expected<bool, int>{::fn::unexpect, 3} | J{9}).apply(first) == 9);
     static_assert((fn::optional<bool>{} | J{9}).apply(first) == 9);
+    static_assert((fn::expected<bool, int>{true} | J{9}).apply(first) == -1); // engaged fallible left side
     CHECK((C{7} | fn::just<double>{0.5}).apply(first) == 7);
     CHECK((J{1} | J{2}) == 1);
     CHECK((fn::expected<bool, int>{::fn::unexpect, 3} | J{9}).apply(first) == 9);
+    CHECK((fn::expected<bool, int>{true} | J{9}).apply(first) == -1);
 
     static_assert(noexcept(std::declval<C>() | std::declval<C>()));
     static_assert(noexcept(std::declval<J>() | std::declval<J>()));

--- a/tests/fn/choice.cpp
+++ b/tests/fn/choice.cpp
@@ -4,7 +4,9 @@
 // or copy at https://opensource.org/licenses/ISC
 
 #include <fn/choice.hpp>
+#include <fn/expected.hpp>
 #include <fn/just.hpp>
+#include <fn/optional.hpp>
 
 #include <fn/utility.hpp>
 
@@ -666,6 +668,57 @@ TEST_CASE("choice non-monadic functionality", "[choice]")
 
     static_assert(noexcept(C{2} & C{true}));
     SUCCEED();
+  }
+}
+
+TEST_CASE("choice disjunction", "[choice][just][operator_or]")
+{
+  using C = fn::choice_for<int, bool>;
+  using J = fn::just<int>;
+  using JV = fn::just<void>;
+
+  SECTION("a cluster operand makes the disjunction total")
+  {
+    // the error product gains an uninhabited factor, so the result never fails and collapses into
+    // the cluster: just when the value sum stays one bare type, choice when the union is genuine
+    static_assert(std::is_same_v<decltype(std::declval<C>() | std::declval<C>()), C>);
+    static_assert(std::is_same_v<decltype(std::declval<C>() | std::declval<fn::just<double>>()),
+                                 fn::choice_for<int, bool, double>>);
+    static_assert(std::is_same_v<decltype(std::declval<J>() | std::declval<C>()), C>);
+    static_assert(std::is_same_v<decltype(std::declval<J>() | std::declval<J>()), J>);
+    static_assert(std::is_same_v<decltype(std::declval<fn::expected<bool, int>>() | std::declval<J>()),
+                                 fn::choice_for<bool, int>>);
+    static_assert(std::is_same_v<decltype(std::declval<fn::expected<int, int>>() | std::declval<J>()), J>);
+    static_assert(
+        std::is_same_v<decltype(std::declval<fn::optional<bool>>() | std::declval<J>()), fn::choice_for<bool, int>>);
+    // the identity expected is a cluster member
+    static_assert(std::is_same_v<decltype(std::declval<fn::expected<int, fn::copack<>>>()
+                                          | std::declval<fn::expected<bool, int>>()),
+                                 fn::choice_for<int, bool>>);
+
+    constexpr auto first = fn::overload{[](int i) { return i; }, [](auto &&) { return -1; }};
+    static_assert((C{7} | fn::just<double>{0.5}).apply(first) == 7);
+    static_assert((J{1} | J{2}) == 1); // left catch: the leftmost total operand absorbs
+    static_assert((fn::expected<bool, int>{::fn::unexpect, 3} | J{9}).apply(first) == 9);
+    static_assert((fn::optional<bool>{} | J{9}).apply(first) == 9);
+    CHECK((C{7} | fn::just<double>{0.5}).apply(first) == 7);
+    CHECK((J{1} | J{2}) == 1);
+    CHECK((fn::expected<bool, int>{::fn::unexpect, 3} | J{9}).apply(first) == 9);
+
+    static_assert(noexcept(std::declval<C>() | std::declval<C>()));
+    static_assert(noexcept(std::declval<J>() | std::declval<J>()));
+  }
+
+  SECTION("the unit's round trip")
+  {
+    // void enters a genuine sum as pack<>, and the all-unit pair collapses back to the family's
+    // unit carrier - so both groupings of the mixed chain agree
+    static_assert(std::is_same_v<decltype(std::declval<JV>() | std::declval<J>()), fn::choice_for<fn::pack<>, int>>);
+    static_assert(std::is_same_v<decltype(std::declval<JV>() | std::declval<JV>()), fn::just<void>>);
+    static_assert(std::is_same_v<decltype((std::declval<JV>() | std::declval<JV>()) | std::declval<J>()),
+                                 decltype(std::declval<JV>() | (std::declval<JV>() | std::declval<J>()))>);
+    static_assert((JV{} | J{7}).apply([]([[maybe_unused]] auto &&...args) { return sizeof...(args); }) == 0);
+    CHECK((JV{} | J{7}).apply([]([[maybe_unused]] auto &&...args) { return sizeof...(args); }) == 0);
   }
 }
 

--- a/tests/fn/expected.cpp
+++ b/tests/fn/expected.cpp
@@ -3,7 +3,9 @@
 // Distributed under the ISC License. See accompanying file LICENSE.md
 // or copy at https://opensource.org/licenses/ISC
 
+#include <fn/choice.hpp>
 #include <fn/expected.hpp>
+#include <fn/just.hpp>
 #include <fn/utility.hpp>
 
 #include <catch2/catch_all.hpp>
@@ -2517,6 +2519,52 @@ TEST_CASE("expected pack support", "[expected][pack][and_then][transform][operat
         using Rt = fn::expected<int, MoveNothrow>;
         static_assert(not noexcept(std::declval<Th &>() & std::declval<Rt &>())); // copies the error
         static_assert(noexcept(std::declval<Th &&>() & std::declval<Rt &&>()));   // moves it
+        SUCCEED();
+      }
+    }
+
+    SECTION("identity cluster operands")
+    {
+      // A just or choice operand always contributes its value to the product and adds no term to
+      // the error sum: the expected operand's error passes through unchanged, plain or graded, and
+      // its state alone decides. just<void> is the product's unit and elides.
+      using E = fn::expected<int, fn::copack<Error>>;
+      using J = fn::just<int>;
+
+      static_assert(std::same_as<decltype(std::declval<J>() & std::declval<E>()),
+                                 fn::expected<fn::pack<int, int>, fn::copack<Error>>>);
+      static_assert(std::same_as<decltype(std::declval<E>() & std::declval<J>()),
+                                 fn::expected<fn::pack<int, int>, fn::copack<Error>>>);
+      static_assert(std::same_as<decltype(std::declval<J>() & std::declval<fn::expected<int, Error>>()),
+                                 fn::expected<fn::pack<int, int>, Error>>);
+      static_assert(std::same_as<decltype(std::declval<fn::just<void>>() & std::declval<E>()), E>);
+      static_assert(std::same_as<decltype(std::declval<E>() & std::declval<fn::just<void>>()), E>);
+      static_assert(std::same_as<decltype(std::declval<J>() & std::declval<fn::expected<void, fn::copack<Error>>>()),
+                                 fn::expected<int, fn::copack<Error>>>);
+      static_assert(
+          std::same_as<decltype(std::declval<fn::choice_for<int, bool>>() & std::declval<E>()),
+                       fn::expected<fn::copack_for<fn::pack<int, int>, fn::pack<bool, int>>, fn::copack<Error>>>);
+
+      static_assert((J{1} & E{2}).value().apply([](int a, int b) { return a == 1 && b == 2; }));
+      static_assert((E{2} & J{1}).value().apply([](int a, int b) { return a == 2 && b == 1; }));
+      static_assert((J{1} & E{::fn::unexpect, fn::copack{FileNotFound}}).error() == fn::copack{FileNotFound});
+      static_assert((fn::just<void>{} & E{5}).value() == 5);
+      static_assert((J{7} & fn::expected<void, fn::copack<Error>>{}).value() == 7);
+      CHECK((J{1} & E{2}).value().apply([](int a, int b) { return a == 1 && b == 2; }));
+      CHECK((J{1} & E{::fn::unexpect, fn::copack{FileNotFound}}).error() == fn::copack{FileNotFound});
+
+      // x0: an uninhabited value side absorbs the product, the cluster operand notwithstanding
+      using Dead = fn::expected<fn::copack<>, Error>;
+      static_assert(std::same_as<decltype(std::declval<J>() & std::declval<Dead>()), Dead>);
+      static_assert((J{1} & Dead{::fn::unexpect, Unknown}).error() == Unknown);
+      CHECK((J{1} & Dead{::fn::unexpect, Unknown}).error() == Unknown);
+
+      SECTION("noexcept")
+      {
+        static_assert(noexcept(std::declval<J &>() & std::declval<E &>()));
+        using Th = fn::expected<MoveNothrow, Error>;
+        static_assert(not noexcept(std::declval<J &>() & std::declval<Th &>())); // copies the value
+        static_assert(noexcept(std::declval<J &&>() & std::declval<Th &&>()));   // moves it
         SUCCEED();
       }
     }

--- a/tests/fn/expected.cpp
+++ b/tests/fn/expected.cpp
@@ -6,6 +6,7 @@
 #include <fn/choice.hpp>
 #include <fn/expected.hpp>
 #include <fn/just.hpp>
+#include <fn/optional.hpp>
 #include <fn/utility.hpp>
 
 #include <catch2/catch_all.hpp>
@@ -2625,6 +2626,111 @@ TEST_CASE("expected pack support", "[expected][pack][and_then][transform][operat
       SUCCEED();
     }
   }
+}
+
+TEST_CASE("expected disjunction", "[expected][operator_or][graded][copack]")
+{
+  enum OtherError : int { Oops };
+  using EA = fn::expected<int, Error>;
+  using EB = fn::expected<bool, OtherError>;
+
+  SECTION("value sum, error product")
+  {
+    static_assert(std::same_as<decltype(std::declval<EA>() | std::declval<EB>()),
+                               fn::expected<fn::copack_for<int, bool>, fn::pack<Error, OtherError>>>);
+    // the same value type collapses, as the conjunction's same-error sum does; the error product
+    // never dedupes - the pack is tuple-like, and position says where a failure happened
+    static_assert(std::same_as<decltype(std::declval<EA>() | std::declval<fn::expected<int, OtherError>>()),
+                               fn::expected<int, fn::pack<Error, OtherError>>>);
+    static_assert(std::same_as<decltype(std::declval<EA>() | std::declval<EA>()), //
+                               fn::expected<int, fn::pack<Error, Error>>>);
+    // graded errors distribute through the product - the same fold as the conjunction's values
+    static_assert(std::same_as<decltype(std::declval<fn::expected<int, fn::copack_for<Error, OtherError>>>()
+                                        | std::declval<fn::expected<bool, fn::copack<Error>>>()),
+                               fn::expected<fn::copack_for<int, bool>,
+                                            fn::copack_for<fn::pack<Error, Error>, fn::pack<OtherError, Error>>>>);
+    // void enters a genuine sum as pack<>; the all-void pair collapses to void
+    static_assert(std::same_as<decltype(std::declval<fn::expected<void, Error>>() | std::declval<EB>()),
+                               fn::expected<fn::copack_for<fn::pack<>, bool>, fn::pack<Error, OtherError>>>);
+    static_assert(std::same_as<decltype(std::declval<fn::expected<void, Error>>()
+                                        | std::declval<fn::expected<void, OtherError>>()),
+                               fn::expected<void, fn::pack<Error, OtherError>>>);
+    SUCCEED();
+  }
+
+  SECTION("leftmost engaged wins; both-fail folds the errors")
+  {
+    static_assert((EA{1} | EB{true}) == fn::copack{1});
+    static_assert((EA{::fn::unexpect, FileNotFound} | EB{true}) == fn::copack{true});
+    static_assert(
+        (EA{::fn::unexpect, FileNotFound} | EB{::fn::unexpect, Oops}).error().apply([](Error a, OtherError b) {
+          return a == FileNotFound && b == Oops;
+        }));
+    CHECK(bool((EA{1} | EB{true}) == fn::copack{1})); // bool(): Catch2 decomposition re-enters the == constraint
+    CHECK(bool((EA{::fn::unexpect, FileNotFound} | EB{true})
+               == fn::copack{true})); // bool(): Catch2 decomposition re-enters the == constraint
+    CHECK((EA{::fn::unexpect, FileNotFound} | EB{::fn::unexpect, Oops}).error().apply([](Error a, OtherError b) {
+      return a == FileNotFound && b == Oops;
+    }));
+  }
+
+  SECTION("the always-failing carrier is the value channel's identity element")
+  {
+    using Dead = fn::expected<fn::copack<>, Error>;
+    static_assert(std::same_as<decltype(std::declval<Dead>() | std::declval<fn::expected<int, OtherError>>()),
+                               fn::expected<fn::copack<int>, fn::pack<Error, OtherError>>>);
+    static_assert((Dead{::fn::unexpect, FileNotFound} | fn::expected<int, OtherError>{5}) == fn::copack{5});
+    CHECK(bool((Dead{::fn::unexpect, FileNotFound} | fn::expected<int, OtherError>{5})
+               == fn::copack{5})); // bool(): Catch2 decomposition re-enters the == constraint
+  }
+
+  SECTION("associativity: the error product folds flat")
+  {
+    using EC = fn::expected<double, Error>;
+    static_assert(std::same_as<decltype((std::declval<EA>() | std::declval<EB>()) | std::declval<EC>()),
+                               decltype(std::declval<EA>() | (std::declval<EB>() | std::declval<EC>()))>);
+    static_assert(((EA{::fn::unexpect, FileNotFound} | EB{::fn::unexpect, Oops}) | EC{::fn::unexpect, Unknown})
+                      .error()
+                      .apply([](Error a, OtherError b, Error c) { //
+                        return a == FileNotFound && b == Oops && c == Unknown;
+                      }));
+    SUCCEED();
+  }
+
+  SECTION("constraints and noexcept")
+  {
+    // the disjunction stays same-kind plus cluster: the expected/optional mix is refused
+    constexpr auto can_disj = [](auto &&lh, auto &&rh) { return requires { FWD(lh) | FWD(rh); }; };
+    static_assert(can_disj(EA{1}, EB{true}));
+    static_assert(not can_disj(EA{1}, fn::optional<int>{}));
+
+    static_assert(noexcept(std::declval<EA>() | std::declval<EB>()));
+    static_assert(not noexcept(std::declval<fn::expected<MoveNothrow, Error> &>() | std::declval<EA &>()));
+    SUCCEED();
+  }
+}
+
+TEST_CASE("disjoin", "[disjoin][expected][just]")
+{
+  using EA = fn::expected<int, Error>;
+  using EB = fn::expected<bool, int>;
+
+  static_assert(std::same_as<decltype(fn::disjoin(std::declval<EA>(), std::declval<EB>())),
+                             decltype(std::declval<EA>() | std::declval<EB>())>);
+  static_assert(fn::disjoin(EA{1}) == EA{1}); // unary forwards unchanged
+  static_assert(fn::disjoin(EA{::fn::unexpect, FileNotFound}, EB{true}) == fn::copack{true});
+  static_assert(
+      fn::disjoin(fn::just<void>{}, fn::just<void>{}, fn::just<int>{7}).apply([]([[maybe_unused]] auto &&...args) {
+        return sizeof...(args);
+      })
+      == 0); // left catch through the whole chain
+  CHECK(bool(fn::disjoin(EA{::fn::unexpect, FileNotFound}, EB{true})
+             == fn::copack{true})); // bool(): Catch2 decomposition re-enters the == constraint
+
+  // a non-viable fold answers instead of erroring
+  constexpr auto can = [](auto &&...args) { return requires { fn::disjoin(FWD(args)...); }; };
+  static_assert(can(EA{1}, EB{true}));
+  static_assert(not can(EA{1}, 42));
 }
 
 TEST_CASE("expected copack support and_then", "[expected][copack][and_then]")

--- a/tests/fn/expected.cpp
+++ b/tests/fn/expected.cpp
@@ -3933,6 +3933,7 @@ TEST_CASE("expected apply_type", "[expected][apply_type]")
     CHECK(v.apply_type(varms) == 1);
     CHECK(ve.apply_type(varms) == -7);
     CHECK(v.apply_type_r<long>(varms) == 1L);
+    CHECK(ve.apply_type_r<long>(varms) == -7L);
     static_assert(not can_apply_type<expected<void, int> &, decltype(fn::overload{[](unexpect_t, int) {}}) const &>);
     static_assert(not can_apply_type<expected<void, int> &, decltype(fn::overload{[](in_place_t) {}}) const &>);
 

--- a/tests/fn/just.cpp
+++ b/tests/fn/just.cpp
@@ -273,6 +273,29 @@ TEST_CASE("just", "[just]")
     CHECK(T{3} == 3);
     SUCCEED();
   }
+
+  SECTION("operator &")
+  {
+    // just & just folds the payloads and stays just; just<void> is the product's unit and elides
+    static_assert(std::is_same_v<decltype(T{1} & T{2}), fn::just<fn::pack<int, int>>>);
+    static_assert(std::is_same_v<decltype(T{1} & fn::just<void>{}), T>);
+    static_assert(std::is_same_v<decltype(fn::just<void>{} & T{2}), T>);
+    static_assert(std::is_same_v<decltype(fn::just<void>{} & fn::just<void>{}), fn::just<void>>);
+
+    static_assert((T{1} & T{2}).value().apply([](int a, int b) { return a == 1 && b == 2; }));
+    static_assert((fn::just<void>{} & T{7}).value() == 7);
+    static_assert((T{7} & fn::just<void>{}).value() == 7);
+    CHECK((T{1} & T{2}).value().apply([](int a, int b) { return a == 1 && b == 2; }));
+    CHECK((fn::just<void>{} & T{7}).value() == 7);
+
+    static_assert(noexcept(T{1} & T{2}));
+    struct throwing_copy {
+      throwing_copy() = default;
+      // defined, not just declared: the instantiated fold references it
+      throwing_copy(throwing_copy const &) noexcept(false) {}
+    };
+    static_assert(not noexcept(std::declval<fn::just<throwing_copy> &>() & std::declval<T &>())); // copies
+  }
 }
 
 TEST_CASE("just of void", "[just]")

--- a/tests/fn/optional.cpp
+++ b/tests/fn/optional.cpp
@@ -772,6 +772,35 @@ TEST_CASE("optional pack support", "[optional][pack][and_then][transform][operat
   }
 }
 
+TEST_CASE("optional disjunction", "[optional][operator_or][copack]")
+{
+  using O = fn::optional<int>;
+  using OB = fn::optional<bool>;
+  using OI = fn::optional<fn::copack<>>;
+
+  // the value channel is the sum - a same-type pair stays bare - and the unit errors vanish in
+  // the product, so the result is empty exactly when both operands are
+  static_assert(
+      std::same_as<decltype(std::declval<O>() | std::declval<OB>()), fn::optional<fn::copack_for<int, bool>>>);
+  static_assert(std::same_as<decltype(std::declval<O>() | std::declval<O>()), O>); // same value type collapses
+  // the empty copack adds nothing to the union, but keeps the result graded
+  static_assert(std::same_as<decltype(std::declval<OI>() | std::declval<O>()), fn::optional<fn::copack<int>>>);
+  static_assert(std::same_as<decltype(std::declval<O>() | std::declval<OI>()), fn::optional<fn::copack<int>>>);
+
+  static_assert((O{1} | OB{}) == fn::copack{1});
+  static_assert((O{} | OB{true}) == fn::copack{true});
+  static_assert(not(O{} | OB{}).has_value());
+  static_assert((O{1} | O{2}).value() == 1); // leftmost, and bare
+  static_assert(not(OI{} | O{}).has_value());
+  CHECK(bool((O{1} | OB{}) == fn::copack{1}));       // bool(): Catch2 decomposition re-enters the == constraint
+  CHECK(bool((O{} | OB{true}) == fn::copack{true})); // bool(): Catch2 decomposition re-enters the == constraint
+  CHECK(not(O{} | OB{}).has_value());
+  CHECK((O{1} | O{2}).value() == 1);
+
+  static_assert(noexcept(std::declval<O>() | std::declval<OB>()));
+  static_assert(not noexcept(std::declval<fn::optional<MoveNothrow> &>() | std::declval<O &>())); // copies the value
+}
+
 TEST_CASE("optional and_then copack", "[optional][copack][and_then]")
 {
   using S = fn::optional<fn::copack_for<Xint, int>>;

--- a/tests/fn/optional.cpp
+++ b/tests/fn/optional.cpp
@@ -3,6 +3,9 @@
 // Distributed under the ISC License. See accompanying file LICENSE.md
 // or copy at https://opensource.org/licenses/ISC
 
+#include <fn/choice.hpp>
+#include <fn/expected.hpp>
+#include <fn/just.hpp>
 #include <fn/optional.hpp>
 #include <fn/utility.hpp>
 
@@ -590,6 +593,48 @@ TEST_CASE("optional pack support", "[optional][pack][and_then][transform][operat
       CHECK(not(Rh{12} & Dead{}).has_value());
       CHECK(not(Rh{std::nullopt} & Dead{}).has_value());
       CHECK(not(Dead{} & Dead{}).has_value());
+    }
+
+    SECTION("identity cluster operands")
+    {
+      // A cluster operand always contributes its value to the product and adds no term to the
+      // error sum, so the optional operand's state decides alone. just<void> and the void identity
+      // expected are the product's unit and elide; the identity expected is the cluster's third
+      // member and composes exactly as just does.
+      using O = fn::optional<int>;
+      using J = fn::just<int>;
+      using EIv = fn::expected<int, fn::copack<>>;
+      using EVI = fn::expected<void, fn::copack<>>;
+
+      static_assert(std::same_as<decltype(std::declval<J>() & std::declval<O>()), fn::optional<fn::pack<int, int>>>);
+      static_assert(std::same_as<decltype(std::declval<O>() & std::declval<J>()), fn::optional<fn::pack<int, int>>>);
+      static_assert(std::same_as<decltype(std::declval<fn::just<void>>() & std::declval<O>()), O>);
+      static_assert(std::same_as<decltype(std::declval<O>() & std::declval<fn::just<void>>()), O>);
+      static_assert(std::same_as<decltype(std::declval<EIv>() & std::declval<O>()), fn::optional<fn::pack<int, int>>>);
+      static_assert(std::same_as<decltype(std::declval<O>() & std::declval<EIv>()), fn::optional<fn::pack<int, int>>>);
+      static_assert(std::same_as<decltype(std::declval<EVI>() & std::declval<O>()), O>);
+      static_assert(std::same_as<decltype(std::declval<O>() & std::declval<EVI>()), O>);
+      static_assert(std::same_as<decltype(std::declval<fn::choice_for<int, bool>>() & std::declval<O>()),
+                                 fn::optional<fn::copack_for<fn::pack<int, int>, fn::pack<bool, int>>>>);
+
+      static_assert((J{1} & O{2}).value().apply([](int a, int b) { return a == 1 && b == 2; }));
+      static_assert(not(J{1} & O{}).has_value());
+      static_assert((EIv{7} & O{2}).value().apply([](int a, int b) { return a == 7 && b == 2; }));
+      static_assert((O{2} & EVI{}).value() == 2);
+      static_assert((fn::just<void>{} & O{5}).value() == 5);
+      CHECK((J{1} & O{2}).value().apply([](int a, int b) { return a == 1 && b == 2; }));
+      CHECK(not(J{1} & O{}).has_value());
+
+      // 0 x 1 = 0: the void identity elides, passing the always-empty optional through unchanged
+      using DeadO = fn::optional<fn::copack<>>;
+      static_assert(std::same_as<decltype(std::declval<DeadO>() & std::declval<EVI>()), DeadO>);
+      static_assert(std::same_as<decltype(std::declval<J>() & std::declval<DeadO>()), DeadO>);
+      static_assert(not(DeadO{} & EVI{}).has_value());
+      static_assert(not(J{1} & DeadO{}).has_value());
+      CHECK(not(DeadO{} & EVI{}).has_value());
+
+      static_assert(noexcept(std::declval<J &>() & std::declval<O &>()));
+      static_assert(not noexcept(std::declval<fn::just<MoveNothrow> &>() & std::declval<O &>())); // copies the value
     }
 
     SECTION("copack on left side only")

--- a/tests/fn/optional.cpp
+++ b/tests/fn/optional.cpp
@@ -796,6 +796,7 @@ TEST_CASE("optional disjunction", "[optional][operator_or][copack]")
   CHECK(bool((O{} | OB{true}) == fn::copack{true})); // bool(): Catch2 decomposition re-enters the == constraint
   CHECK(not(O{} | OB{}).has_value());
   CHECK((O{1} | O{2}).value() == 1);
+  CHECK((O{} | O{2}).value() == 2); // the right side returned whole
 
   static_assert(noexcept(std::declval<O>() | std::declval<OB>()));
   static_assert(not noexcept(std::declval<fn::optional<MoveNothrow> &>() | std::declval<O &>())); // copies the value

--- a/tests/fn/or_else.cpp
+++ b/tests/fn/or_else.cpp
@@ -599,6 +599,11 @@ TEST_CASE("or_else joins heterogeneous expected branches", "[or_else][expected][
     CHECK(r.value() == fn::copack_for<X, Y>{Y{}});
     auto v = In{fn::copack<X>{X{}}}.or_else(fnR);
     CHECK(v.value() == fn::copack_for<X, Y>{X{}});
+    // the value path in every remaining value category
+    In vl{fn::copack<X>{X{}}};
+    CHECK(vl.or_else(fnR).value() == fn::copack_for<X, Y>{X{}});
+    CHECK(std::as_const(vl).or_else(fnR).value() == fn::copack_for<X, Y>{X{}});
+    CHECK(std::move(std::as_const(vl)).or_else(fnR).value() == fn::copack_for<X, Y>{X{}});
     // named source: VS 2022 misreads a mid-expression prvalue's empty-class union member
     constexpr In cv{fn::copack<X>{X{}}};
     static_assert(cv.or_else(fnR).value() == fn::copack_for<X, Y>{X{}});


### PR DESCRIPTION
Fixes #368, in two commits — the conjunction's cluster admission, then the disjunction itself.

**Admit the identity cluster in the conjunction.** A `just`, `choice`, or identity-`expected` operand always contributes its value to the product and adds no term to the error sum, so the fallible operand's channels decide alone: its error type passes through unchanged, plain or graded. `just<void>` and `expected<void, copack<>>` are the product's unit and elide; an uninhabited value side (`expected<copack<>, E>`, `optional<copack<>>`) absorbs the product — multiplication by zero, which is why it must stay uninhabited. Cluster & cluster stays in the cluster: identity over a pack is spelled `just`, over a copack `choice`. Seventeen overloads, placed with their result kinds, reusing #367's join machinery for the dead-side guards.

**Add the disjunction and its disjoin fold.** `operator|` is the De Morgan dual of `&` — the channels swap: the value channel is the *sum* of the value types, the error channel the *product* of both errors, riding the same fold (which is what distributes graded errors correctly). The leftmost engaged operand wins and injects by type; both-failed folds both errors, positionally — the product never dedupes, because the pack is tuple-like and position says where a failure happened, while the sum may collapse a same-type pair because type-indexed identity makes the arms indistinguishable anyway. Void enters a genuine sum as `pack<>` (both are 1, and a `copack` cannot hold `void` - we might revisit this in the future); the all-unit case collapses back to the family's unit carrier, so `just<void> | just<void>` is `just<void>` and both groupings of `(JV|JV)|J` agree. A cluster operand puts an uninhabited factor into the error product — the result never fails and collapses into the cluster, spelled `just` when the value sum stays one bare type and `choice` when the union is genuine. `fn::disjoin` is the n-ary fold of `|`, as `conjoin` is of the data `&`. The mixed `expected`/`optional` disjunction remains deliberately refused, as in the conjunction (there is no error type from `optional` - we might revisit this in the future).

The law battery pins associativity (including the flat error product and the unit round-trip across the collapse), left catch, the identity elements, and the constraint refusals. Verified on gcc and clang across C++20, the C++23 validation lanes and the `LIBFN_CXX26` mode, and on MSVC (VS 2026) — which along the way earned its keep twice, catching a candidate-formation trap in trailing return types and a platform-dependent canonical order in a test spelling.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0198ikYYxtCqwNG54SS1b249
