### PR TITLE
Add explicit element types to `as_pack`

### DIFF
--- a/include/fn/pack.hpp
+++ b/include/fn/pack.hpp
@@ -331,7 +331,7 @@ template <::std::size_t I, some_pack P>
  * @return TODO
  */
 [[nodiscard]] constexpr auto as_pack() noexcept -> pack<> { return {}; }
-// The unnamed leading pack absorbs explicit template arguments and the constraint rejects them:
+// The unused leading pack absorbs explicit template arguments and the constraint rejects them:
 // this overload is deduction-only (value-category preserving), the overload below serves spelled types
 template <typename... Explicit, typename T, typename... Args>
   requires(sizeof...(Explicit) == 0) && (not some_in_place_type<T>)

--- a/include/fn/pack.hpp
+++ b/include/fn/pack.hpp
@@ -331,9 +331,22 @@ template <::std::size_t I, some_pack P>
  * @return TODO
  */
 [[nodiscard]] constexpr auto as_pack() noexcept -> pack<> { return {}; }
+// The unnamed leading pack absorbs explicit template arguments and the constraint rejects them:
+// this overload is deduction-only (value-category preserving), the overload below serves spelled types
+template <typename... Explicit, typename T, typename... Args>
+  requires(sizeof...(Explicit) == 0) && (not some_in_place_type<T>)
+          && detail::_initializable<pack<T, Args...>, T, Args...>
+[[nodiscard]] constexpr auto as_pack(T &&src, Args &&...args) //
+    noexcept(detail::_nothrow_initializable<pack<T, Args...>, T, Args...>) -> pack<T, Args...>
+{
+  return pack<T, Args...>{FWD(src), FWD(args)...};
+}
+// No element type is deduced: the explicit form names ALL of pack<T, Args...> or is not viable
+// (a partial spelling fails on arity); by-value parameters admit conversion at the call boundary
+// (narrowing included) while still relocating rvalue arguments
 template <typename T, typename... Args>
   requires(not some_in_place_type<T>) && detail::_initializable<pack<T, Args...>, T, Args...>
-[[nodiscard]] constexpr auto as_pack(T &&src, Args &&...args) //
+[[nodiscard]] constexpr auto as_pack(::std::type_identity_t<T> src, ::std::type_identity_t<Args>... args) //
     noexcept(detail::_nothrow_initializable<pack<T, Args...>, T, Args...>) -> pack<T, Args...>
 {
   return pack<T, Args...>{FWD(src), FWD(args)...};

--- a/tests/fn/pack.cpp
+++ b/tests/fn/pack.cpp
@@ -52,6 +52,15 @@ using Throwing = helper_t<prop::throw_copy | prop::throw_move>;
 template <typename... Args>
 concept can_as_pack = requires(Args &&...args) { fn::as_pack(FWD(args)...); };
 
+template <typename... Ts>
+concept can_as_pack_explicit = requires(int &i, double &d) { fn::as_pack<Ts...>(i, d); };
+
+template <typename... Ts>
+concept can_as_pack_explicit_rvalue_head = requires(double &d) { fn::as_pack<Ts...>(42, d); };
+
+template <typename T>
+concept can_as_pack_explicit_lvalue = requires(T &v) { fn::as_pack<T>(v); };
+
 // pack declares no special member, so each one is implicit - composed from the _element bases which
 // hold the data. Ask the elements, not the element types: a holder of a reference or of a const
 // member answers assignment differently than the bare type would.
@@ -228,6 +237,44 @@ TEST_CASE("pack", "[pack]")
     else
       return false;
   }));
+
+  // the deduced form preserves value category; naming the types opts out into owned values,
+  // converting at the call boundary - and it is all-or-none: a partial spelling is not viable
+  int k = 42;
+  static_assert(std::same_as<decltype(fn::as_pack(k)), fn::pack<int &>>);
+  static_assert(std::same_as<decltype(fn::as_pack(std::as_const(k))), fn::pack<int const &>>);
+  static_assert(std::same_as<decltype(fn::as_pack<int>(k)), fn::pack<int>>);
+  static_assert(std::same_as<decltype(fn::as_pack<int>(std::as_const(k))), fn::pack<int>>);
+  static_assert(std::same_as<decltype(fn::as_pack<int &>(k)), fn::pack<int &>>); // the view, explicitly requested
+  static_assert(std::same_as<decltype(fn::as_pack<bool, long>(k, 12)), fn::pack<bool, long>>); // converts
+
+  static_assert(can_as_pack_explicit<int, double>); // the converses of the refusals below
+  static_assert(can_as_pack_explicit<bool, int>);   // conversion per element, narrowing included
+  static_assert(can_as_pack_explicit_rvalue_head<int, double>);
+  static_assert(not can_as_pack_explicit<int>);               // fewer types than arguments
+  static_assert(not can_as_pack_explicit<int, double, long>); // more types than arguments
+  static_assert(not can_as_pack_explicit<int, char *>);       // no conversion admits the argument
+  static_assert(not can_as_pack_explicit_rvalue_head<int>);   // an rvalue head cannot smuggle a partial
+                                                              // spelling through the deduced overload
+  auto owned = fn::as_pack<int>(k);
+  k += 1;
+  CHECK(owned.apply([](int v) { return v == 42; })); // an owned copy, not a view
+  double frac = 3.14; // a variable, not a literal - clang's -Wliteral-conversion polices literals
+  CHECK(fn::as_pack<bool, int>(k, frac).apply([](bool b, int i) { return b && i == 3; }));
+  static_assert([] { // constant-evaluation twin
+    double v = 12.5;
+    return fn::as_pack<int>(v).apply([](int i) { return i == 12; });
+  }());
+
+  // evaluated on purpose, head and tail: decltype never instantiates the body, so only an
+  // evaluated call proves the body FORWARDS - a move would leave pack<T&>{xvalue} ill-formed here
+  long l = 7;
+  auto view = fn::as_pack<int &, long &>(k, l);
+  CHECK(view.apply([&](int &a, long &b) { return &a == &k && &b == &l; }));
+  static_assert([] {
+    int q = 5;
+    return fn::as_pack<int &>(q).apply([&q](int &r) { return &r == &q; });
+  }());
 
   // pack is a structural type: a constexpr pack can be a template parameter, with
   // template-argument equivalence comparing element-wise
@@ -662,6 +709,19 @@ TEST_CASE("pack noexcept", "[pack][noexcept]")
     static_assert(not can_as_pack<NoMove>); // constrained on the same initialization ...
     static_assert(can_as_pack<NoMove &>);   // ... which a binding reference element satisfies
     CHECK(fn::as_pack(t, 12).apply([&t](Throwy const &x, int i) { return &x == &t && i == 12; }));
+
+    // the explicit form relocates through a by-value parameter: the lvalue that merely bound
+    // above now copies in, and the body's move into the pack can throw
+    static_assert(not noexcept(fn::as_pack<Throwy>(t)));
+    static_assert(noexcept(fn::as_pack<int>(1))); // ... where the element permits, it cannot
+    struct NoCopy {
+      NoCopy() = default;
+      NoCopy(NoCopy &&) = default;
+      NoCopy(NoCopy const &) = delete;
+    };
+    static_assert(not can_as_pack_explicit_lvalue<NoCopy>); // the by-value parameter needs the copy ...
+    static_assert(can_as_pack_explicit_lvalue<int>);        // ... converse
+    static_assert(std::same_as<decltype(fn::as_pack<NoCopy>(NoCopy{})), fn::pack<NoCopy>>); // rvalues relocate
   }
 
   SECTION("apply")


### PR DESCRIPTION
Extend `fn::as_pack` with an explicit-element-types form, complementing the deduced form's reference preservation with an opt-out into owned values.

**The rule is all-or-none**. The deduced form is unchanged: it preserves the argument's value category (`as_pack(x)` over an lvalue yields `pack<int&>`, an rvalue yields `pack<int>`). The new form names **every** element type at the call site — `as_pack<int, double>(i, d)` — and yields owned values of exactly the named types, converting each argument at the call boundary (narrowing included, by design); a same-type rvalue still relocates rather than copies. A partial spelling such as `as_pack<int>(x, 42)` is not viable: the explicit overload deduces no element type (`std::type_identity_t` on the whole list, so its arity is exactly the named types), and an unnamed leading template parameter pack with a `sizeof... == 0` constraint makes the forwarding overload deduction-only — an rvalue head cannot smuggle a partial spelling through it. `as_pack<int&>(x)` remains expressible: the reference, explicitly requested.

**Every rejection is substitution-visible**. Non-convertible arguments fail overload viability; non-copyable elements fail the `_initializable` constraint (or the deleted copy surfaces in the call expression) — so templated probes answer `false` cleanly for the arity, convertibility and constructibility refusals alike. The test battery pins each with its converse.

**The body forwards, deliberately.** With `T` explicit, a reference-typed element makes `FWD` and `::std::move` diverge: _move_ would turn the parameter into an xvalue that `pack<T&>` cannot bind — while the declared return type keeps every `decltype` probe green. The suite therefore carries an evaluated witness of the reference form (head and tail, runtime and constant-evaluated), demonstrated to reject a sabotaged _move_ spelling with the exact "cannot bind non-const lvalue reference to an rvalue" diagnostic.

Verified on gcc and clang across C++20, the C++23 validation lanes and the `LIBFN_CXX26` mode, and on MSVC (VS 2026). En route, clang's `-Wliteral-conversion` shaped the tests: value-changing conversions are exercised through variables, never literals.