### PR TITLE
Add carrier conversions through or_else and and_then

### DIFF
--- a/include/fn/and_then.hpp
+++ b/include/fn/and_then.hpp
@@ -22,15 +22,40 @@ namespace fn {
 inline namespace LIBFN_VERSION {
 
 namespace detail {
+// the first join that announces a `type` wins; neither is a hard error to ask
+template <typename A, typename B> struct _either_join : B {};
+template <typename A, typename B>
+  requires requires { typename A::type; }
+struct _either_join<A, B> : A {};
+
+template <typename Fn, typename Cp>
+constexpr inline bool _cluster_join_forms
+    = requires { typename _copack_apply_result<_joining_cluster_tag<::fn::choice>, Fn, Cp>::type; };
+
 // The engine's result over a bound payload, computed assert-free: a copack payload goes through
 // the cluster trait - all-choice branch results answer the superset choice, convergent ones the
-// select trait's answer, and every other set none at all - so asking about any divergent callback
-// answers instead of tripping select's convergence assert; a single value goes through
+// select trait's answer - and a branch set the cluster join does not own may still join as
+// optionals (the #376 bridge); every other set answers none at all, so asking about any divergent
+// callback answers instead of tripping select's convergence assert; a single value goes through
 // _apply_result as always.
 template <typename Fn, typename... V> struct _and_then_result : _apply_result<Fn, V...> {};
 template <typename Fn, typename V>
   requires _some_copack<::std::remove_cvref_t<V>>
-struct _and_then_result<Fn, V> : _typelist_joining_cluster<::fn::choice, Fn, V, ::std::remove_cvref_t<V>> {};
+struct _and_then_result<Fn, V>
+    : _either_join<_typelist_joining_cluster<::fn::choice, Fn, V, ::std::remove_cvref_t<V>>,
+                   _typelist_joining_optional<::fn::optional, Fn, V, ::std::remove_cvref_t<V>>> {};
+
+// the copack arm's promise, split on the same choice of tag its body makes
+template <typename Fn, typename Cp> struct _nothrow_and_then_join {
+  static constexpr bool value = [] {
+    if constexpr (_cluster_join_forms<Fn, Cp>)
+      return _is_nothrow_rts_applicable<typename _copack_apply_result<_joining_cluster_tag<::fn::choice>, Fn, Cp>::type,
+                                        Fn, Cp>;
+    else
+      return _is_nothrow_rts_applicable<
+          typename _copack_apply_result<_joining_optional_tag<::fn::optional>, Fn, Cp>::type, Fn, Cp>;
+  }();
+};
 } // namespace detail
 
 /**
@@ -64,10 +89,11 @@ concept applicable_and_then //
       }) || (some_optional<V> && requires(V &&v) {
         typename detail::_optional_and_then_dispatch<Fn, decltype(FWD(v).value())>::type;
         requires same_kind<V, typename detail::_optional_and_then_dispatch<Fn, decltype(FWD(v).value())>::type>;
-      }) || (some_choice<V> && requires(Fn &&fn, V &&v) {
-        {
-          FWD(v).and_then(FWD(fn))
-        } -> same_kind<V>;
+      }) || (some_choice<V> && requires(V &&v) {
+        // asked of the assert-free trait, never the member: a divergent branch set must answer
+        // false here, where naming the member would trip select's convergence assert
+        typename detail::_and_then_result<Fn, decltype(FWD(v).value())>::type;
+        requires same_kind<V, typename detail::_and_then_result<Fn, decltype(FWD(v).value())>::type>;
       }) || (some_just<V> && requires(Fn &&fn, V &&v) {
         {
           FWD(v).and_then(FWD(fn))
@@ -91,17 +117,23 @@ concept applicable_and_then_across //
     = some_identity<V>
       && ((some_choice<V> && (not applicable_and_then<Fn, V>) && requires(V &&v) {
             typename detail::_and_then_result<Fn, decltype(FWD(v).value())>::type;
-            requires some_identity<typename detail::_and_then_result<Fn, decltype(FWD(v).value())>::type>;
+            requires some_identity<typename detail::_and_then_result<Fn, decltype(FWD(v).value())>::type>
+                         || some_optional<typename detail::_and_then_result<Fn, decltype(FWD(v).value())>::type>
+                         || some_expected<typename detail::_and_then_result<Fn, decltype(FWD(v).value())>::type>;
           }) || (some_just<V> && (not applicable_and_then<Fn, V>) && (not ::std::is_void_v<typename ::std::remove_cvref_t<V>::value_type>) && requires(V &&v) {
             typename detail::_and_then_result<Fn, decltype(FWD(v).value())>::type;
-            requires some_identity<typename detail::_and_then_result<Fn, decltype(FWD(v).value())>::type>;
+            requires some_identity<typename detail::_and_then_result<Fn, decltype(FWD(v).value())>::type>
+                         || some_optional<typename detail::_and_then_result<Fn, decltype(FWD(v).value())>::type>
+                         || some_expected<typename detail::_and_then_result<Fn, decltype(FWD(v).value())>::type>;
           }) || (some_expected_non_void<V> && requires(V &&v) {
             typename detail::_and_then_result<Fn, decltype(FWD(v).value())>::type;
-            requires some_identity<typename detail::_and_then_result<Fn, decltype(FWD(v).value())>::type>;
+            requires some_identity<typename detail::_and_then_result<Fn, decltype(FWD(v).value())>::type>
+                         || some_optional<typename detail::_and_then_result<Fn, decltype(FWD(v).value())>::type>;
             requires not some_expected<typename detail::_and_then_result<Fn, decltype(FWD(v).value())>::type>;
           }) || ((some_expected_void<V> || (some_just<V> && ::std::is_void_v<typename ::std::remove_cvref_t<V>::value_type> && (not applicable_and_then<Fn, V>))) && requires {
             typename detail::_and_then_result<Fn>::type;
-            requires some_identity<typename detail::_and_then_result<Fn>::type>;
+            requires some_identity<typename detail::_and_then_result<Fn>::type>
+                         || some_optional<typename detail::_and_then_result<Fn>::type>;
             requires not some_expected<typename detail::_and_then_result<Fn>::type>;
           }));
 
@@ -158,21 +190,23 @@ struct and_then_t::apply final {
   // ride delegation, and the verb layer is the licensed cross-carrier place. Dropping the input's
   // channels forgets nothing: they are uninhabited, which is what admits the input here at all.
   template <some_monadic_type V, typename Fn>
-  [[nodiscard]] constexpr auto operator()(V &&v, Fn &&fn) const //
-      noexcept(noexcept(detail::_tagged_join_apply<detail::_joining_cluster_tag<choice>>(FWD(v).value(),
-                                                                                         FWD(fn)))) //
-      -> some_identity auto
+  [[nodiscard]] constexpr auto operator()(V &&v, Fn &&fn) const                                     //
+      noexcept(detail::_nothrow_and_then_join<Fn &&, decltype(::std::declval<V>().value())>::value) //
+      -> some_monadic_type auto
     requires applicable_and_then_across<Fn &&, V &&>
              && (not ::std::is_void_v<typename ::std::remove_cvref_t<V>::value_type>)
              && some_copack<::std::remove_cvref_t<decltype(::std::declval<V>().value())>>
   {
-    return detail::_tagged_join_apply<detail::_joining_cluster_tag<choice>>(FWD(v).value(), FWD(fn));
+    if constexpr (detail::_cluster_join_forms<Fn &&, decltype(FWD(v).value())>)
+      return detail::_tagged_join_apply<detail::_joining_cluster_tag<choice>>(FWD(v).value(), FWD(fn));
+    else
+      return detail::_tagged_join_apply<detail::_joining_optional_tag<::fn::optional>>(FWD(v).value(), FWD(fn));
   }
 
   template <some_monadic_type V, typename Fn>
   [[nodiscard]] constexpr auto operator()(V &&v, Fn &&fn) const //
       noexcept(noexcept(::fn::apply(FWD(fn), FWD(v).value())))  //
-      -> some_identity auto
+      -> some_monadic_type auto
     requires applicable_and_then_across<Fn &&, V &&>
              && (not ::std::is_void_v<typename ::std::remove_cvref_t<V>::value_type>)
              && (not some_copack<::std::remove_cvref_t<decltype(::std::declval<V>().value())>>)
@@ -183,7 +217,7 @@ struct and_then_t::apply final {
   template <some_monadic_type V, typename Fn>
   [[nodiscard]] constexpr auto operator()(V &&, Fn &&fn) const //
       noexcept(noexcept(::fn::apply(FWD(fn))))                 //
-      -> some_identity auto
+      -> some_monadic_type auto
     requires applicable_and_then_across<Fn &&, V &&> && ::std::is_void_v<typename ::std::remove_cvref_t<V>::value_type>
   {
     return ::fn::apply(FWD(fn));

--- a/include/fn/and_then.hpp
+++ b/include/fn/and_then.hpp
@@ -130,11 +130,18 @@ concept applicable_and_then_across //
             requires some_identity<typename detail::_and_then_result<Fn, decltype(FWD(v).value())>::type>
                          || some_optional<typename detail::_and_then_result<Fn, decltype(FWD(v).value())>::type>;
             requires not some_expected<typename detail::_and_then_result<Fn, decltype(FWD(v).value())>::type>;
-          }) || ((some_expected_void<V> || (some_just<V> && ::std::is_void_v<typename ::std::remove_cvref_t<V>::value_type> && (not applicable_and_then<Fn, V>))) && requires {
+          }) || (some_expected_void<V> && requires {
             typename detail::_and_then_result<Fn>::type;
             requires some_identity<typename detail::_and_then_result<Fn>::type>
                          || some_optional<typename detail::_and_then_result<Fn>::type>;
+            // expected results stay on the member: the void identity expected keeps its graded
+            // world (a copack<> grade acquiring the callback's error), never the bare carrier
             requires not some_expected<typename detail::_and_then_result<Fn>::type>;
+          }) || (some_just<V> && ::std::is_void_v<typename ::std::remove_cvref_t<V>::value_type> && (not applicable_and_then<Fn, V>) && requires {
+            typename detail::_and_then_result<Fn>::type;
+            requires some_identity<typename detail::_and_then_result<Fn>::type>
+                         || some_optional<typename detail::_and_then_result<Fn>::type>
+                         || some_expected<typename detail::_and_then_result<Fn>::type>;
           }));
 
 /**

--- a/include/fn/copack.hpp
+++ b/include/fn/copack.hpp
@@ -1329,6 +1329,7 @@ namespace detail {
 template <template <typename...> typename Tpl, typename E> struct _joining_expected_tag final {};
 template <template <typename...> typename Tpl, typename T> struct _joining_recovery_tag final {};
 template <template <typename...> typename Tpl> struct _joining_optional_tag final {};
+template <template <typename...> typename Tpl, typename T> struct _joining_optional_recovery_tag final {};
 
 namespace _joining_expected {
 template <typename T> struct parts;
@@ -1418,6 +1419,20 @@ struct _joined_optional<Tpl, Rs...> {
   using type = Tpl<typename _joining_expected::list_join<typename _joining_expected::parts_one<Rs>::type...>::type>;
 };
 
+// the recovery join into a one-parameter carrier: self's pass-through value joins every branch's
+// value under the grade-sticky rules; unlike the same-kind traits there is no select tier - self's
+// value must always enter the join, which handles exact convergence itself
+template <template <typename...> typename Tpl, typename T, typename... Rs> struct _joined_optional_recovery {};
+template <template <typename...> typename Tpl, typename T, typename... Rs>
+  requires requires {
+    typename _joining_expected::graded_join<T, typename _joining_expected::parts_one<Rs>::type...>::type;
+  }
+struct _joined_optional_recovery<Tpl, T, Rs...> {
+  static constexpr bool _hetero_join = true;
+  using type
+      = Tpl<typename _joining_expected::graded_join<T, typename _joining_expected::parts_one<Rs>::type...>::type>;
+};
+
 // a heterogeneous set that is not all-expected answers (no `type`), it does not assert: the join
 // owns every heterogeneous shape, and only convergent sets keep the select trait's diagnostics
 struct _no_join {};
@@ -1503,6 +1518,26 @@ struct _typelist_joining_optional<Tpl, Fn, Self, Tpl2<Ts...>, Args...>
 template <template <typename...> typename Tpl, typename Fn, typename Self, typename... Args>
 struct _copack_apply_result<_joining_optional_tag<Tpl>, Fn, Self, Args...>
     : _typelist_joining_optional<Tpl, Fn, Self, ::std::remove_cvref_t<Self>, Args...> {};
+
+template <template <typename...> typename Tpl, typename T, typename Fn, typename Self, typename U, typename... Args>
+struct _typelist_joining_optional_recovery;
+template <template <typename...> typename Tpl, typename T, typename Fn, typename Self,
+          template <typename...> typename Tpl2, typename... Ts, typename... Args>
+struct _typelist_joining_optional_recovery<Tpl, T, Fn, Self, Tpl2<Ts...>, Args...>
+    : ::std::conditional_t<
+          (sizeof...(Ts) == 0), _no_join,
+          ::std::conditional_t<
+              (...
+               && _joining_superset::is_kind<Tpl, ::std::remove_cvref_t<typename ::fn::detail::_apply_result<
+                                                      Fn, apply_const_lvalue_t<Self, Ts>, Args...>::type>>),
+              _joined_optional_recovery<Tpl, T,
+                                        ::std::remove_cvref_t<typename ::fn::detail::_apply_result<
+                                            Fn, apply_const_lvalue_t<Self, Ts>, Args...>::type>...>,
+              _no_join>> {};
+
+template <template <typename...> typename Tpl, typename T, typename Fn, typename Self, typename... Args>
+struct _copack_apply_result<_joining_optional_recovery_tag<Tpl, T>, Fn, Self, Args...>
+    : _typelist_joining_optional_recovery<Tpl, T, Fn, Self, ::std::remove_cvref_t<Self>, Args...> {};
 
 // The cluster bind's join - the verb layer's licensed cross-carrier dispatch over a bare copack
 // payload. The same superset join as the choice members', under the asking rule of the joining

--- a/include/fn/or_else.hpp
+++ b/include/fn/or_else.hpp
@@ -7,14 +7,85 @@
 #define INCLUDE_FN_OR_ELSE
 
 #include <fn/concepts.hpp>
+#include <fn/expected.hpp>
 #include <fn/functional.hpp>
 #include <fn/functor.hpp>
+#include <fn/optional.hpp>
 #include <libfn_version.hpp>
 
 #include <fn/detail/macro_begin.hpp>
 
 namespace fn {
 inline namespace LIBFN_VERSION {
+
+namespace detail {
+// optional -> expected: the empty state's nullary callback names the target carrier, and self's
+// value joins the target's value side under the grade-sticky rules
+template <typename T, typename Fn> struct _or_else_to_expected {};
+template <typename T, typename Fn>
+  requires(_is_applicable<Fn>::value)
+          && _joining_superset::is_kind<::fn::expected, ::std::remove_cvref_t<typename _apply_result<Fn>::type>>
+          && requires {
+               typename _joining_expected::graded_join<T, typename _joining_expected::parts<::std::remove_cvref_t<
+                                                              typename _apply_result<Fn>::type>>::value_type>::type;
+             }
+struct _or_else_to_expected<T, Fn> {
+  using _result = ::std::remove_cvref_t<typename _apply_result<Fn>::type>;
+  using type = ::fn::expected<
+      typename _joining_expected::graded_join<T, typename _joining_expected::parts<_result>::value_type>::type,
+      typename _joining_expected::parts<_result>::error_type>;
+};
+
+// expected -> optional: the error's callback (per alternative when graded) names the target;
+// the pass-through value joins every branch's value
+template <typename T, typename Fn, typename ErrArg> struct _or_else_to_optional {};
+template <typename T, typename Fn, typename ErrArg>
+  requires(not _some_copack<::std::remove_cvref_t<ErrArg>>) && (_is_applicable<Fn, ErrArg>::value)
+          && _joining_superset::is_kind<::fn::optional, ::std::remove_cvref_t<typename _apply_result<Fn, ErrArg>::type>>
+struct _or_else_to_optional<T, Fn, ErrArg>
+    : _joined_optional_recovery<::fn::optional, T, ::std::remove_cvref_t<typename _apply_result<Fn, ErrArg>::type>> {};
+template <typename T, typename Fn, typename ErrArg>
+  requires _some_copack<::std::remove_cvref_t<ErrArg>>
+struct _or_else_to_optional<T, Fn, ErrArg>
+    : _copack_apply_result<_joining_optional_recovery_tag<::fn::optional, T>, Fn, ErrArg> {};
+
+// the promises, computed per arm; a dead arm never weighs
+template <typename T, typename Fn, typename ValArg> struct _nothrow_or_else_to_expected {
+  using _result = ::std::remove_cvref_t<typename _apply_result<Fn>::type>;
+  using _type = typename _or_else_to_expected<T, Fn>::type;
+  static constexpr bool _convert
+      = ::std::is_same_v<_result, _type>
+        || ((empty_copack<typename _result::value_type>
+             || ::std::is_nothrow_constructible_v<_type, ::std::in_place_t, typename _result::value_type &&>)
+            && ::std::is_nothrow_constructible_v<_type, ::fn::unexpect_t, typename _result::error_type &&>);
+  static constexpr bool value
+      = _is_nothrow_applicable<Fn>::value && _convert
+        && (empty_copack<T> || ::std::is_nothrow_constructible_v<_type, ::std::in_place_t, ValArg>);
+};
+
+template <typename T, typename Fn, typename ErrArg, typename ValArg> struct _nothrow_or_else_to_optional;
+template <typename T, typename Fn, typename ErrArg, typename ValArg>
+  requires _some_copack<::std::remove_cvref_t<ErrArg>>
+struct _nothrow_or_else_to_optional<T, Fn, ErrArg, ValArg> {
+  using _type = typename _or_else_to_optional<T, Fn, ErrArg>::type;
+  static constexpr bool value
+      = _is_nothrow_rts_applicable<_type, Fn, ErrArg>
+        && (empty_copack<T> || ::std::is_nothrow_constructible_v<_type, ::std::in_place_t, ValArg>);
+};
+template <typename T, typename Fn, typename ErrArg, typename ValArg>
+  requires(not _some_copack<::std::remove_cvref_t<ErrArg>>)
+struct _nothrow_or_else_to_optional<T, Fn, ErrArg, ValArg> {
+  using _result = ::std::remove_cvref_t<typename _apply_result<Fn, ErrArg>::type>;
+  using _type = typename _or_else_to_optional<T, Fn, ErrArg>::type;
+  static constexpr bool _convert
+      = ::std::is_same_v<_result, _type>
+        || (empty_copack<typename _result::value_type>
+            || ::std::is_nothrow_constructible_v<_type, ::std::in_place_t, typename _result::value_type &&>);
+  static constexpr bool value
+      = _is_nothrow_applicable<Fn, ErrArg>::value && _convert
+        && (empty_copack<T> || ::std::is_nothrow_constructible_v<_type, ::std::in_place_t, ValArg>);
+};
+} // namespace detail
 /**
  * @brief TODO
  *
@@ -44,6 +115,36 @@ concept applicable_or_else //
           ::fn::apply(FWD(fn))
         } -> some_optional;
       });
+
+/**
+ * @brief Checks if the callback can be used with `or_else` recovering across the expected/optional
+ *        pair
+ *
+ * The callback witnesses the inhabited dead state - optional's empty state (nullary) or expected's
+ * error (per alternative) - and its declared carrier names the result kind; self's value joins the
+ * target's value side under the grade-sticky rules. An identity expected is excluded: the fold of
+ * the callback over zero error alternatives has no inputs, so those keep the vacuous identity.
+ *
+ * @tparam Fn The function to execute on the dead state
+ * @tparam V The monadic type
+ */
+template <typename Fn, typename V>
+concept applicable_or_else_across //
+    = (some_optional<V> && (not applicable_or_else<Fn, V>) && requires {
+        typename detail::_or_else_to_expected<typename ::std::remove_cvref_t<V>::value_type, Fn>::type;
+      } && (empty_copack<typename ::std::remove_cvref_t<V>::value_type> || requires(V &&v) {
+         requires ::std::is_constructible_v<
+             typename detail::_or_else_to_expected<typename ::std::remove_cvref_t<V>::value_type, Fn>::type,
+             ::std::in_place_t, decltype(*FWD(v))>;
+       })) || (some_expected<V> && (not some_identity<V>) && (not applicable_or_else<Fn, V>) && requires(V &&v) {
+        typename detail::_or_else_to_optional<typename ::std::remove_cvref_t<V>::value_type, Fn,
+                                              decltype(FWD(v).error())>::type;
+      } && (empty_copack<typename ::std::remove_cvref_t<V>::value_type> || requires(V &&v) {
+                 requires ::std::is_constructible_v<
+                     typename detail::_or_else_to_optional<typename ::std::remove_cvref_t<V>::value_type, Fn,
+                                                           decltype(FWD(v).error())>::type,
+                     ::std::in_place_t, decltype(FWD(v).value())>;
+               }));
 
 /**
  * @brief TODO
@@ -100,6 +201,70 @@ struct or_else_t::apply final {
     requires some_identity<V>
   {
     return FWD(v).or_else(FWD(fn));
+  }
+
+  // The cross arms: the callback witnesses the inhabited dead state and names the target carrier -
+  // or_else invokes on 1-states and is silent on 0-states, which is why an identity expected keeps
+  // the vacuous arm above. Engine-direct: the members are each carrier's own recovery, and the
+  // verb layer is the licensed cross-carrier place.
+  template <some_optional V, typename Fn>
+  [[nodiscard]] constexpr auto operator()(V &&v, Fn &&fn) const //
+      noexcept(detail::_nothrow_or_else_to_expected<typename ::std::remove_cvref_t<V>::value_type, Fn &&,
+                                                    decltype(*::std::declval<V>())>::value) //
+      -> some_expected auto
+    requires applicable_or_else_across<Fn &&, V &&>
+  {
+    using T = typename ::std::remove_cvref_t<V>::value_type;
+    using type = typename detail::_or_else_to_expected<T, Fn &&>::type;
+    if constexpr (not empty_copack<T>)
+      if (v.has_value())
+        return type{::std::in_place, *FWD(v)};
+    using result = ::std::remove_cvref_t<typename detail::_apply_result<Fn &&>::type>;
+    if constexpr (::std::is_same_v<result, type>)
+      return ::fn::detail::_apply(FWD(fn));
+    else {
+      auto t = ::fn::detail::_apply(FWD(fn));
+      if (t.has_value()) {
+        if constexpr (not empty_copack<typename result::value_type>)
+          return type{::std::in_place, ::std::move(t).value()};
+        else
+          ::pfn::unreachable(); // LCOV_EXCL_LINE
+      } else
+        return type{::fn::unexpect, ::std::move(t).error()};
+    }
+  }
+
+  template <some_expected V, typename Fn>
+  [[nodiscard]] constexpr auto operator()(V &&v, Fn &&fn) const //
+      noexcept(detail::_nothrow_or_else_to_optional<typename ::std::remove_cvref_t<V>::value_type, Fn &&,
+                                                    decltype(::std::declval<V>().error()),
+                                                    decltype(::std::declval<V>().value())>::value) //
+      -> some_optional auto
+    requires applicable_or_else_across<Fn &&, V &&>
+  {
+    using T = typename ::std::remove_cvref_t<V>::value_type;
+    using type = typename detail::_or_else_to_optional<T, Fn &&, decltype(FWD(v).error())>::type;
+    if constexpr (not empty_copack<T>)
+      if (v.has_value())
+        return type{::std::in_place, FWD(v).value()};
+    if constexpr (detail::_some_copack<::std::remove_cvref_t<decltype(v.error())>>)
+      return ::fn::detail::_tagged_join_apply<detail::_joining_optional_recovery_tag<::fn::optional, T>>(FWD(v).error(),
+                                                                                                         FWD(fn));
+    else {
+      using result = ::std::remove_cvref_t<typename detail::_apply_result<Fn &&, decltype(FWD(v).error())>::type>;
+      if constexpr (::std::is_same_v<result, type>)
+        return ::fn::detail::_apply(FWD(fn), FWD(v).error());
+      else {
+        auto t = ::fn::detail::_apply(FWD(fn), FWD(v).error());
+        if (t.has_value()) {
+          if constexpr (not empty_copack<typename result::value_type>)
+            return type{::std::in_place, ::std::move(t).value()};
+          else
+            ::pfn::unreachable(); // LCOV_EXCL_LINE
+        } else
+          return type{::std::nullopt};
+      }
+    }
   }
 };
 

--- a/tests/fn/and_then.cpp
+++ b/tests/fn/and_then.cpp
@@ -1102,7 +1102,8 @@ TEST_CASE("and_then across the identity cluster", "[and_then][just][choice][expe
     static_assert(noexcept(j | fn::and_then(nothrowCross)));
     static_assert(not noexcept(j | fn::and_then([](int) { return fn::choice<U>{U{}}; })));
 
-    // only an identity input crosses kinds, and only to an identity result
+    // only an identity input crosses kinds - to an identity result, or over the #376 bridge to
+    // optional and expected (their sections below)
     static_assert(fn::applicable_and_then_across<decltype(nothrowCross), fn::just<int> &>);
     constexpr auto fnJust = [](int) { return fn::just<int>{1}; };
     static_assert(not fn::applicable_and_then_across<decltype(fnJust), fn::expected<int, U> &>);
@@ -1118,6 +1119,60 @@ TEST_CASE("and_then across the identity cluster", "[and_then][just][choice][expe
     using is_across = monadic_static_check<fn::and_then_t, fn::just<int>>;
     static_assert(is_across::invocable_with_any([](int) { return fn::choice<U>{U{}}; }));
     static_assert(is_across::not_invocable_with_any([](int) { return 42; }));
+    SUCCEED();
+  }
+
+  SECTION("the bridge: identity inputs cross to optional and expected")
+  {
+    // the value channel is inhabited, so the callback genuinely runs and its kind is the result's
+    auto r1 = fn::just{1} | fn::and_then([](int i) { return fn::optional<int>{i}; });
+    static_assert(std::is_same_v<decltype(r1), fn::optional<int>>);
+    CHECK(r1.value() == 1);
+    auto r2 = fn::expected<int, E0>{1} | fn::and_then([](int i) { return fn::optional<int>{i + 1}; });
+    static_assert(std::is_same_v<decltype(r2), fn::optional<int>>);
+    CHECK(r2.value() == 2);
+    // fallibility introduced by the callback - just carries no grade, the result is as declared
+    auto r3 = fn::just{3} | fn::and_then([](int i) { return fn::expected<int, U>{i}; });
+    static_assert(std::is_same_v<decltype(r3), fn::expected<int, U>>);
+    CHECK(r3.value() == 3);
+    // choice dispatch with convergent optional branches ...
+    constexpr auto fnC = fn::overload{[](A) { return fn::optional<int>{1}; }, //
+                                      [](B) { return fn::optional<int>{2}; }};
+    auto r4 = fn::choice_for<A, B>{B{}} | fn::and_then(fnC);
+    static_assert(std::is_same_v<decltype(r4), fn::optional<int>>);
+    CHECK(r4.value() == 2);
+    CHECK((fn::choice_for<A, B>{A{}} | fn::and_then(fnC)).value() == 1);
+    // ... and heterogeneous ones joining under the #98 rules
+    constexpr auto fnH = fn::overload{[](A) { return fn::optional<U>{U{}}; }, //
+                                      [](B) { return fn::optional<V>{V{}}; }};
+    auto r5 = fn::choice_for<A, B>{A{}} | fn::and_then(fnH);
+    static_assert(std::is_same_v<decltype(r5), fn::optional<fn::copack_for<U, V>>>);
+    CHECK(r5.value() == fn::copack_for<U, V>{U{}});
+    CHECK((fn::choice_for<A, B>{B{}} | fn::and_then(fnH)).value() == fn::copack_for<U, V>{V{}});
+    // named sources: VS 2022 misreads a mid-expression prvalue's empty-class union member
+    constexpr fn::choice_for<A, B> cb{B{}};
+    static_assert((cb | fn::and_then(fnH)).value() == fn::copack_for<U, V>{V{}});
+    static_assert((fn::just{1} | fn::and_then([](int i) { return fn::optional<int>{i}; })).value() == 1);
+    constexpr fn::expected<int, E0> ce{8};
+    static_assert((ce | fn::and_then([](int i) { return fn::optional<int>{i + 1}; })).value() == 9);
+  }
+
+  SECTION("the bridge refusals answer, and their converses hold")
+  {
+    constexpr auto can = [](auto &&v, auto &&fn) { return requires { FWD(v) | fn::and_then(FWD(fn)); }; };
+    constexpr auto fnMixed = fn::overload{[](A) { return fn::optional<int>{}; }, //
+                                          [](B) { return fn::expected<int, U>{1}; }};
+    constexpr auto fnConv = fn::overload{[](A) { return fn::optional<int>{}; }, //
+                                         [](B) { return fn::optional<int>{1}; }};
+    // a branch set mixing the target kinds answers false - and asking no longer trips the select
+    // convergence assert, which naming the member used to do for every divergent non-choice set
+    static_assert(not can(fn::choice_for<A, B>{A{}}, fnMixed));
+    static_assert(can(fn::choice_for<A, B>{A{}}, fnConv)); // the converse
+    static_assert(not fn::applicable_and_then<decltype(fnMixed) &, fn::choice_for<A, B> &&>);
+    static_assert(not fn::applicable_and_then_across<decltype(fnMixed) &, fn::choice_for<A, B> &&>);
+    // a live-error expected still cannot switch kinds - its error would be dropped
+    static_assert(not can(fn::expected<int, U>{1}, [](int) { return fn::optional<int>{}; }));
+    static_assert(can(fn::expected<int, E0>{1}, [](int) { return fn::optional<int>{}; })); // converse
     SUCCEED();
   }
 }

--- a/tests/fn/and_then.cpp
+++ b/tests/fn/and_then.cpp
@@ -1155,6 +1155,20 @@ TEST_CASE("and_then across the identity cluster", "[and_then][just][choice][expe
     static_assert((fn::just{1} | fn::and_then([](int i) { return fn::optional<int>{i}; })).value() == 1);
     constexpr fn::expected<int, E0> ce{8};
     static_assert((ce | fn::and_then([](int i) { return fn::optional<int>{i + 1}; })).value() == 9);
+
+    // the void just bridges too - nullary callback, result exactly as declared (no grade to
+    // join); its iso-sibling keeps the member's graded world, a copack<> grade acquiring the
+    // callback's error - each carrier keeps its own vocabulary under one expression
+    auto r6 = fn::just{} | fn::and_then([] { return fn::expected<int, U>{6}; });
+    static_assert(std::is_same_v<decltype(r6), fn::expected<int, U>>);
+    CHECK(r6.value() == 6);
+    auto r7 = fn::just{} | fn::and_then([] { return fn::optional<int>{7}; });
+    static_assert(std::is_same_v<decltype(r7), fn::optional<int>>);
+    CHECK(r7.value() == 7);
+    auto r8 = fn::expected<void, E0>{} | fn::and_then([] { return fn::expected<int, U>{8}; });
+    static_assert(std::is_same_v<decltype(r8), fn::expected<int, fn::copack<U>>>);
+    CHECK(r8.value() == 8);
+    static_assert((fn::just{} | fn::and_then([] { return fn::expected<int, U>{6}; })).value() == 6);
   }
 
   SECTION("the bridge refusals answer, and their converses hold")

--- a/tests/fn/or_else.cpp
+++ b/tests/fn/or_else.cpp
@@ -815,6 +815,10 @@ TEST_CASE("or_else across expected and optional", "[or_else][expected][optional]
     CHECK(r1.value() == 5);
     auto r2 = fn::optional<int>{} | fn::or_else(fnE);
     CHECK(r2.error() == E1{});
+    // a mutable source defeats the front end's constant folding of the whole prvalue pipeline
+    // above, so the disengaged arm genuinely executes and gcov sees it
+    fn::optional<int> mut{};
+    CHECK((mut | fn::or_else(fnE)).error() == E1{});
     // the pass-through in every remaining value category
     fn::optional<int> vl{7};
     CHECK((vl | fn::or_else(fnE)).value() == 7);
@@ -859,7 +863,9 @@ TEST_CASE("or_else across expected and optional", "[or_else][expected][optional]
     CHECK(not r2.has_value());
     constexpr fn::expected<int, E1> ce{9};
     static_assert((ce | fn::or_else(fnO)).value() == 9);
-    static_assert(not(fn::expected<int, E1>{fn::unexpect, E1{}} | fn::or_else(fnO)).has_value());
+    // named source: VS 2022 misreads a mid-expression prvalue's empty-class union member
+    constexpr fn::expected<int, E1> cerr{fn::unexpect, E1{}};
+    static_assert(not(cerr | fn::or_else(fnO)).has_value());
     // graded dispatch reaches each branch; the value passes through
     constexpr auto fnB = fn::overload{[](E1) { return fn::optional<int>{}; }, //
                                       [](E2) { return fn::optional<int>{3}; }};

--- a/tests/fn/or_else.cpp
+++ b/tests/fn/or_else.cpp
@@ -5,6 +5,8 @@
 
 #include "util/static_check.hpp"
 
+#include <fn/choice.hpp>
+#include <fn/just.hpp>
 #include <fn/or_else.hpp>
 
 #include <catch2/catch_all.hpp>
@@ -569,6 +571,18 @@ TEST_CASE("or_else identity expected", "[or_else][expected][copack]")
   auto r2 = operand_t{7} | fn::or_else(Poison{});
   CHECK(r2.value() == 7);
   static_assert((operand_t{5} | fn::or_else(Poison{})).value() == 5);
+
+  // even a non-callable is accepted: every question this verb could ask of a callback is formed
+  // with an error alternative, and there are none - not invoked, type not consulted, callability
+  // not demanded
+  auto r3 = a | fn::or_else(42);
+  static_assert(std::is_same_v<decltype(r3), operand_t>);
+  CHECK(r3.value() == 5);
+  auto r4 = operand_t{9}.or_else(42);
+  static_assert(std::is_same_v<decltype(r4), operand_t>);
+  CHECK(r4.value() == 9);
+  static_assert(std::is_same_v<decltype(fn::expected<void, fn::copack<>>{} | fn::or_else(std::declval<int>())),
+                               fn::expected<void, fn::copack<>>>);
 }
 
 TEST_CASE("or_else joins heterogeneous expected branches", "[or_else][expected][copack]")
@@ -779,3 +793,143 @@ static_assert(not applicable_or_else<decltype(fn_int_rvalue<expected<int, int>>)
 static_assert(not applicable_or_else<decltype(fn_generic<expected<Value, copack<>>>), expected<Value, copack<>>>);
 // clang-format on
 } // namespace fn
+
+TEST_CASE("or_else across expected and optional", "[or_else][expected][optional][copack]")
+{
+  struct A final {
+    bool operator==(A const &) const = default;
+  };
+  struct E1 final {
+    bool operator==(E1 const &) const = default;
+  };
+  struct E2 final {
+    bool operator==(E2 const &) const = default;
+  };
+  constexpr auto can = [](auto &&v, auto &&fn) { return requires { FWD(v) | fn::or_else(FWD(fn)); }; };
+
+  SECTION("optional to expected: the empty state invokes, the value passes through")
+  {
+    constexpr auto fnE = []() { return fn::expected<int, E1>{fn::unexpect, E1{}}; };
+    auto r1 = fn::optional<int>{5} | fn::or_else(fnE);
+    static_assert(std::is_same_v<decltype(r1), fn::expected<int, E1>>);
+    CHECK(r1.value() == 5);
+    auto r2 = fn::optional<int>{} | fn::or_else(fnE);
+    CHECK(r2.error() == E1{});
+    // the pass-through in every remaining value category
+    fn::optional<int> vl{7};
+    CHECK((vl | fn::or_else(fnE)).value() == 7);
+    CHECK((std::as_const(vl) | fn::or_else(fnE)).value() == 7);
+    CHECK((std::move(std::as_const(vl)) | fn::or_else(fnE)).value() == 7);
+    CHECK((std::move(vl) | fn::or_else(fnE)).value() == 7);
+    // named source: VS 2022 misreads a mid-expression prvalue's empty-class union member
+    constexpr fn::optional<int> cv{5};
+    static_assert((cv | fn::or_else(fnE)).value() == 5);
+    static_assert((fn::optional<int>{} | fn::or_else(fnE)).error() == E1{});
+  }
+
+  SECTION("optional to expected: graded targets and the sticky value grade")
+  {
+    // the callback's graded error passes as spelled; recovery to identity is admitted
+    auto r1 = fn::optional<int>{1} | fn::or_else([]() { return fn::expected<int, fn::copack<E1>>{1}; });
+    static_assert(std::is_same_v<decltype(r1), fn::expected<int, fn::copack<E1>>>);
+    CHECK(r1.value() == 1);
+    auto r2 = fn::optional<int>{} | fn::or_else([]() { return fn::expected<int, fn::copack<>>{7}; });
+    static_assert(std::is_same_v<decltype(r2), fn::expected<int, fn::copack<>>>);
+    CHECK(r2.value() == 7);
+    // a graded self value acquires the branch value, in both states
+    constexpr auto fnA = []() { return fn::expected<A, E1>{A{}}; };
+    auto r3 = fn::optional<fn::copack<int>>{} | fn::or_else(fnA);
+    static_assert(std::is_same_v<decltype(r3), fn::expected<fn::copack_for<int, A>, E1>>);
+    CHECK(r3.value() == fn::copack_for<int, A>{A{}});
+    auto r4 = fn::optional<fn::copack<int>>{fn::copack<int>{3}} | fn::or_else(fnA);
+    CHECK(r4.value() == fn::copack_for<int, A>{3});
+    // the empty value grade converts outright - its callback always runs
+    auto r5 = fn::optional<fn::copack<>>{} | fn::or_else([]() { return fn::expected<int, E1>{2}; });
+    static_assert(std::is_same_v<decltype(r5), fn::expected<fn::copack<int>, E1>>);
+    CHECK(r5.value() == fn::copack<int>{2});
+  }
+
+  SECTION("expected to optional: the error invokes, per alternative when graded")
+  {
+    constexpr auto fnO = [](E1) { return fn::optional<int>{}; };
+    auto r1 = fn::expected<int, E1>{9} | fn::or_else(fnO);
+    static_assert(std::is_same_v<decltype(r1), fn::optional<int>>);
+    CHECK(r1.value() == 9);
+    auto r2 = fn::expected<int, E1>{fn::unexpect, E1{}} | fn::or_else(fnO);
+    CHECK(not r2.has_value());
+    constexpr fn::expected<int, E1> ce{9};
+    static_assert((ce | fn::or_else(fnO)).value() == 9);
+    static_assert(not(fn::expected<int, E1>{fn::unexpect, E1{}} | fn::or_else(fnO)).has_value());
+    // graded dispatch reaches each branch; the value passes through
+    constexpr auto fnB = fn::overload{[](E1) { return fn::optional<int>{}; }, //
+                                      [](E2) { return fn::optional<int>{3}; }};
+    using In = fn::expected<int, fn::copack_for<E1, E2>>;
+    CHECK(not(In{fn::unexpect, fn::copack_for<E1, E2>{E1{}}} | fn::or_else(fnB)).has_value());
+    CHECK((In{fn::unexpect, fn::copack_for<E1, E2>{E2{}}} | fn::or_else(fnB)).value() == 3);
+    CHECK((In{5} | fn::or_else(fnB)).value() == 5);
+    // the sticky grade crosses the kind switch
+    auto r3 = fn::expected<fn::copack<>, E1>{fn::unexpect, E1{}} | fn::or_else([](E1) { return fn::optional<int>{4}; });
+    static_assert(std::is_same_v<decltype(r3), fn::optional<fn::copack<int>>>);
+    CHECK(r3.value() == fn::copack<int>{4});
+    // heterogeneous branch values join under the sticky grade
+    using InG = fn::expected<fn::copack<A>, fn::copack_for<E1, E2>>;
+    constexpr auto fnH = fn::overload{[](E1) { return fn::optional<int>{1}; },
+                                      [](E2) { return fn::optional<fn::copack<int>>{fn::copack<int>{2}}; }};
+    auto r4 = InG{fn::unexpect, fn::copack_for<E1, E2>{E2{}}} | fn::or_else(fnH);
+    static_assert(std::is_same_v<decltype(r4), fn::optional<fn::copack_for<A, int>>>);
+    CHECK(r4.value() == fn::copack_for<A, int>{2});
+    CHECK((InG{fn::copack<A>{A{}}} | fn::or_else(fnH)).value() == fn::copack_for<A, int>{A{}});
+  }
+
+  SECTION("refusals answer, and their converses hold")
+  {
+    static_assert(can(fn::expected<int, E1>{1}, [](E1) { return fn::optional<int>{}; }));    // the converse
+    static_assert(not can(fn::expected<int, E1>{1}, [](E1) { return fn::just<int>{1}; }));   // cluster targets
+    static_assert(not can(fn::expected<int, E1>{1}, [](E1) { return fn::choice<int>{1}; })); // belong to and_then
+    static_assert(not can(fn::optional<int>{}, []() { return fn::just<int>{1}; }));
+    static_assert(not can(fn::optional<int>{}, []() { return 1; })); // bare values stay transform's
+    static_assert(not can(fn::optional<int>{}, 42));                 // the 1-state asks invocability - and refuses
+    // a plain self value must converge with the branch value exactly
+    static_assert(not can(fn::optional<int>{}, []() { return fn::expected<A, E1>{A{}}; }));
+    static_assert(
+        fn::applicable_or_else_across<decltype([](E1) { return fn::optional<int>{}; }) &&, fn::expected<int, E1> &&>);
+    static_assert(not fn::applicable_or_else_across<decltype([]() { return fn::optional<int>{}; }) &&,
+                                                    fn::expected<int, fn::copack<>> &&>);
+    SUCCEED();
+  }
+
+  SECTION("noexcept and exceptions")
+  {
+    constexpr auto fnE = []() noexcept { return fn::expected<int, E1>{fn::unexpect, E1{}}; };
+    static_assert(noexcept(std::declval<fn::optional<int> &>() | fn::or_else(fnE)));
+    constexpr auto fnT = []() { return fn::expected<int, E1>{fn::unexpect, E1{}}; };
+    static_assert(not noexcept(std::declval<fn::optional<int> &>() | fn::or_else(fnT))); // callback may throw
+    // the pass-through relocation weighs in, and throws at runtime when armed
+    struct Boom {
+      int fuse; // defined, not just declared
+      constexpr explicit Boom(int f) : fuse(f) {}
+      constexpr Boom(Boom &&o) noexcept(false) : fuse(o.fuse - 1)
+      {
+        if (fuse == 0)
+          throw 0;
+      }
+      constexpr Boom(Boom const &o) noexcept(false) : fuse(o.fuse - 1)
+      {
+        if (fuse == 0)
+          throw 0;
+      }
+    };
+    constexpr auto fnBm = []() { return fn::expected<Boom, E1>{fn::unexpect, E1{}}; };
+    static_assert(not noexcept(std::declval<fn::optional<Boom> &>() | fn::or_else(fnBm)));
+    fn::optional<Boom> src{std::in_place, Boom{2}}; // in-place relocation burns one: fuse is 1
+    CHECK_THROWS_AS((void)(std::move(src) | fn::or_else(fnBm)), int);
+    CHECK(src.has_value()); // the throw happened constructing the result; self still holds its state
+    fn::optional<Boom> ok{std::in_place, Boom{3}}; // fuse 2: the pass-through completes on 1
+    CHECK((std::move(ok) | fn::or_else(fnBm)).value().fuse == 1);
+    static_assert([] { // the completing twin, replayed in constant evaluation
+      fn::optional<Boom> o{std::in_place, Boom{3}};
+      return (std::move(o) | fn::or_else([]() { return fn::expected<Boom, E1>{fn::unexpect, E1{}}; })).value().fuse
+             == 1;
+    }());
+  }
+}


### PR DESCRIPTION
Fixes #377 and fixes #376, in two commits — the cross-carrier `or_else`, then the identity-cluster `and_then` bridge.

**`or_else` converts between `expected` and `optional`, both ways.** The pipeline verb (never the members) admits a callback returning the other carrier of the pair: the callback witnesses the inhabited dead state — optional's empty state (nullary) or expected's error (per alternative when graded) — and its declared carrier names the result kind, while the value passes through, joining the target's value side under the same grade-sticky rules the same-kind form already uses. The target kind is the only new degree of freedom: the join engine's target-parameterization serves unchanged, plus one new tag for the optional-target recovery join, which deliberately has no select tier — the pass-through value must always enter the join, and the join handles exact convergence itself. The rule in one sentence: **`or_else` invokes on 1-states and is silent on 0-states.** An identity expected keeps the vacuous arm — the fold of the callback over zero error alternatives has no inputs, so the result is self unchanged and no question about the callback is formable, not even invocability (pinned in the suite: the vacuous arm accepts a literal `42`, while optional's inhabited empty state refuses it). The extension is purely additive: live-error sources refused cross-kind callbacks before, and every ⊥-graded expression keeps its exact meaning.

**`and_then` binds identity inputs into `optional` and `expected`.** The cluster bind (#350) licensed an identity input's callback to return identity carriers; restricting the *target* to the cluster was conservative, not algebraic — the losslessness argument concerns only the input's uninhabited channels. The bridge admits `optional` and `expected` returns: `just` and identity-expected inputs follow the callback's kind directly, and `choice` inputs dispatch per alternative — convergent branch sets keep their exact type, while heterogeneous optional branches join into `optional<copack_for<...>>`, a result type derived by three arcs composing (the dispatch, bind-follows-the-callback, the #98 join) with none of them legislating it. Mixed-kind branch sets stay refused, and a live-error expected still cannot switch kinds — its error would be dropped.

En route, one pre-existing landmine defused: `applicable_and_then`'s choice disjunct named the member, so a heterogeneous non-choice branch set hard-fired the select trait's convergence assert during concept evaluation instead of answering — unobservable while such callbacks were universally refused, fatal once the bridge made them meaningful. The concept now asks the assert-free trait, and the suite pins that the question answers.

Together the pair closes the carrier-conversion space along its two natural axes — `or_else` converts on the dead channel (the callback witnesses exactly the state that does not map), `and_then` on the value channel (licensed exactly when nothing can be dropped) — and neither invents an implicit error spelling, so the operators' mixed-operand refusal (#368) stands: conversions are always spelled by a user callback. The batteries pin both features (grade-sticky joins, refusals with converses, the 0-state/1-state split down to the non-callable, exception rows, constexpr twins), and the blessed executable contract — including the round trip `optional → expected → just → choice → expected → optional` — holds end to end.

Verified on gcc and clang across C++20, the C++23 validation lanes and the `LIBFN_CXX26` mode, and on MSVC (VS 2026).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0198ikYYxtCqwNG54SS1b249
