### PR TITLE
Repin the CI images onto the refreshed build

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -81,7 +81,7 @@ jobs:
           - { mode: cxx23, configuration: Release, compiler: "clang-libstdcxx:22" }
           - { mode: cxx26, configuration: Debug,   compiler: "gcc:16" }
           - { mode: cxx26, configuration: Release, compiler: "gcc:16" }
-    container: libfn.azurecr.io/ci-build-${{ matrix.compiler }}-sha-08b1133
+    container: libfn.azurecr.io/ci-build-${{ matrix.compiler }}-sha-95f599d
     steps:
     - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -35,7 +35,7 @@ permissions:
 jobs:
   generate_docs:
     runs-on: ${{ github.repository == 'libfn/functional' && 'warp-ubuntu-latest-arm64-2x' || 'ubuntu-latest' }}
-    container: libfn.azurecr.io/ci-docs:sha-08b1133
+    container: libfn.azurecr.io/ci-docs:sha-95f599d
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 

--- a/.github/workflows/package-test-bazel.yml
+++ b/.github/workflows/package-test-bazel.yml
@@ -36,7 +36,7 @@ jobs:
         image:
           - ci-build-gcc-bazel:16
           - ci-build-clang-bazel:22
-    container: libfn.azurecr.io/${{ matrix.image }}-sha-08b1133
+    container: libfn.azurecr.io/${{ matrix.image }}-sha-95f599d
     defaults:
       run:
         working-directory: test_package

--- a/.github/workflows/package-test-conan.yml
+++ b/.github/workflows/package-test-conan.yml
@@ -25,7 +25,7 @@ jobs:
   test_conan_linux:
     # arm64: the amd64 warp fleet pulls images at 1-2 MB/s; the arm64 fleet serves them in seconds
     runs-on: ${{ github.repository == 'libfn/functional' && 'warp-ubuntu-latest-arm64-2x' || 'ubuntu-latest' }}
-    container: libfn.azurecr.io/ci-build-gcc:16-sha-08b1133
+    container: libfn.azurecr.io/ci-build-gcc:16-sha-95f599d
 
     steps:
     - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1

--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -12,7 +12,7 @@ on:
 jobs:
   checks:
     runs-on: ${{ github.repository == 'libfn/functional' && 'warp-ubuntu-latest-arm64-2x' || 'ubuntu-latest' }}
-    container: libfn.azurecr.io/ci-pre-commit:sha-08b1133
+    container: libfn.azurecr.io/ci-pre-commit:sha-95f599d
 
     steps:
     - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1

--- a/.github/workflows/sonarcloud-pr-scan.yml
+++ b/.github/workflows/sonarcloud-pr-scan.yml
@@ -37,7 +37,7 @@ jobs:
     # Runner and container must match sonarcloud.yml's: the compiler paths in the compile_commands.json
     # analysed below were recorded there, and must resolve to the same toolchain here.
     runs-on: ${{ github.repository == 'libfn/functional' && 'warp-ubuntu-latest-arm64-4x' || 'ubuntu-latest' }}
-    container: libfn.azurecr.io/ci-build-gcc:15-sha-08b1133
+    container: libfn.azurecr.io/ci-build-gcc:15-sha-95f599d
     env:
       SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
 

--- a/.github/workflows/sonarcloud.yml
+++ b/.github/workflows/sonarcloud.yml
@@ -13,7 +13,7 @@ jobs:
     # Runner and container must match sonarcloud-pr-scan's: it analyses the compile_commands.json
     # written here, and the compiler paths recorded in it must resolve to the same toolchain there.
     runs-on: ${{ github.repository == 'libfn/functional' && 'warp-ubuntu-latest-arm64-4x' || 'ubuntu-latest' }}
-    container: libfn.azurecr.io/ci-build-gcc:15-sha-08b1133
+    container: libfn.azurecr.io/ci-build-gcc:15-sha-95f599d
     env:
       # Gates the inline scan below (a fork without a token no-ops); see also resolve-sonar-project.
       SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}


### PR DESCRIPTION
Repin every CI image onto a freshly built set, converging the pins back onto a single sha.

## What moved

`ci-docs` was rebuilt by #389; `ci-build` (16 images) and `ci-pre-commit` were then dispatched against the same main commit, so all eighteen images carry the tag `sha-95f599d` and every consumer moves together:

| workflow | image |
| --- | --- |
| `build.yml` | `ci-build-<compiler>` — 14 matrix compilers |
| `package-test-bazel.yml` | `ci-build-gcc-bazel:16`, `ci-build-clang-bazel:22` |
| `package-test-conan.yml` | `ci-build-gcc:16` |
| `sonarcloud.yml`, `sonarcloud-pr-scan.yml` | `ci-build-gcc:15` |
| `pre-commit.yml` | `ci-pre-commit` |
| `docs.yml` | `ci-docs` |

The two sonarcloud workflows move together by necessity: the consumer analyses the `compile_commands.json` the producer wrote, so the compiler paths recorded there have to resolve to the same toolchain in both.

## What this is worth

The images were built 2026-06-21; the replacements were built today, so they carry five weeks of upstream drift — Debian trixie packages, and whatever moved in the gcc and clang base images. Note that the Docker official `gcc` image tracks upstream releases only, so the distro-produced 16.1.1 is not among the changes.

## Verification

Before repinning, every tag was probed in the registry: all fourteen `build.yml` matrix compilers, both bazel variants, `ci-pre-commit` and `ci-docs` — eighteen manifests, all present, each a multi-arch index carrying `linux/amd64` and `linux/arm64`.

Beyond that, this pull request is its own evidence: build across fourteen compilers, both packaging routes, coverage, sonarcloud, pre-commit and the docs site all run on the new images here. A regression in any of them is the point of doing this as one change rather than discovering it at the next scheduled rebuild.

Infrastructure-only change: no test accompanies it, as the workflows it repins are the test.

Assisted-by: Claude:claude-opus-5
