### PR TITLE
Restore the operator listings and drop the unneeded exemptions

### DIFF
--- a/docs/coverage-exemptions.txt
+++ b/docs/coverage-exemptions.txt
@@ -17,10 +17,3 @@ fn::recover_t::apply::operator(): as above
 fn::transform_error_t::apply::operator(): as above
 fn::transform_t::apply::operator(): as above
 fn::value_or_t::apply::operator(): as above
-
-fn::expected< void, Err >::copack_value: void specialization artifact, cannot have a copack of void
-fn::just< void >::emplace: void specialization artifact, cannot emplace void
-fn::just< void >::v_: void specialization artifact, has no payload
-fn::just< void >::~just: void specialization artifact, handled by primary template
-fn::optional< T & >::const_iterator: reference specialization artifact, only has iterator
-fn::optional< T & >::copack_value: reference specialization artifact, cannot copack a reference

--- a/docs/reference/conjoin.md
+++ b/docs/reference/conjoin.md
@@ -33,54 +33,50 @@ The binary conjunction each carrier declares; `conjoin` is its n-ary fold.
 
 ```cpp {title: "fn::operator&"}
 template <typename Lh, typename Rh>
-constexpr auto operator&(Lh &&lh, Rh &&rh);  // (1)
+constexpr auto operator&(Lh &&lh, Rh &&rh);                             // (1)
+constexpr auto operator&(Lh &&, Rh &&rh)   -> std::remove_cvref_t<Rh>;  // (2)
+constexpr auto operator&(Lh &&lh, Rh &&)   -> std::remove_cvref_t<Lh>;  // (3)
+constexpr auto operator&(Lh &&lh, Rh &&rh);                             // (4)
 
 template <typename Lh, some_expected Rh>
-constexpr auto operator&(Lh &&lh, Rh &&rh);  // (2)
+constexpr auto operator&(Lh &&lh, Rh &&rh);  // (5)
 
 template <some_expected Lh, typename Rh>
-constexpr auto operator&(Lh &&lh, Rh &&rh);  // (3)
+constexpr auto operator&(Lh &&lh, Rh &&rh);  // (6)
 
 template <typename Lh, some_expected_void Rh>
-constexpr auto operator&(Lh &&lh, Rh &&rh) -> expected<typename std::remove_cvref_t<Lh>::value_type, typename std::remove_cvref_t<Rh>::error_type>;  // (4)
+constexpr auto operator&(Lh &&lh, Rh &&rh) -> expected<typename std::remove_cvref_t<Lh>::value_type, typename std::remove_cvref_t<Rh>::error_type>;  // (7)
 
 template <some_expected_void Lh, typename Rh>
-constexpr auto operator&(Lh &&lh, Rh &&rh) -> expected<typename std::remove_cvref_t<Rh>::value_type, typename std::remove_cvref_t<Lh>::error_type>;  // (5)
+constexpr auto operator&(Lh &&lh, Rh &&rh) -> expected<typename std::remove_cvref_t<Rh>::value_type, typename std::remove_cvref_t<Lh>::error_type>;  // (8)
 
 template <typename Lh, some_expected Rh>
-constexpr auto operator&(Lh &&, Rh &&rh);  // (6)
+constexpr auto operator&(Lh &&, Rh &&rh);  // (9)
 
 template <some_expected Lh, typename Rh>
-constexpr auto operator&(Lh &&lh, Rh &&);  // (7)
+constexpr auto operator&(Lh &&lh, Rh &&);  // (10)
+
+template <typename Lh, typename Rh>
+constexpr auto operator&(Lh &&lh, Rh &&rh);                             // (11)
+constexpr auto operator&(Lh &&, Rh &&rh)   -> std::remove_cvref_t<Rh>;  // (12)
+constexpr auto operator&(Lh &&lh, Rh &&)   -> std::remove_cvref_t<Lh>;  // (13)
 
 template <some_optional Lh, some_optional Rh>
-constexpr auto operator&(Lh &&lh, Rh &&rh);  // (8)
-
-template <typename Lh, some_optional Rh>
-constexpr auto operator&(Lh &&lh, Rh &&rh);  // (9)
-
-template <some_optional Lh, typename Rh>
-constexpr auto operator&(Lh &&lh, Rh &&rh);  // (10)
-
-template <typename Lh, some_optional Rh>
-constexpr auto operator&(Lh &&, Rh &&rh);  // (11)
-
-template <some_optional Lh, typename Rh>
-constexpr auto operator&(Lh &&lh, Rh &&);  // (12)
-
-template <typename Lh, some_optional Rh>
-constexpr auto operator&(Lh &&lh, Rh &&rh);  // (13)
-
-template <some_optional Lh, typename Rh>
 constexpr auto operator&(Lh &&lh, Rh &&rh);  // (14)
 
 template <typename Lh, some_optional Rh>
-constexpr auto operator&(Lh &&, Rh &&rh);  // (15)
+constexpr auto operator&(Lh &&lh, Rh &&rh);  // (15)
 
 template <some_optional Lh, typename Rh>
-constexpr auto operator&(Lh &&lh, Rh &&);  // (16)
+constexpr auto operator&(Lh &&lh, Rh &&rh);  // (16)
 
-constexpr auto operator&(auto &&lh, auto &&rh);  // (17)
+template <typename Lh, some_optional Rh>
+constexpr auto operator&(Lh &&, Rh &&rh);  // (17)
+
+template <some_optional Lh, typename Rh>
+constexpr auto operator&(Lh &&lh, Rh &&);  // (18)
+
+constexpr auto operator&(auto &&lh, auto &&rh);  // (19)
 ```
 
 :include-doxygen-doc: fn::operator& { args: "Lh &&, Rh &&" }

--- a/docs/reference/disjoin.md
+++ b/docs/reference/disjoin.md
@@ -34,19 +34,24 @@ The binary disjunction each carrier declares; `disjoin` is its n-ary fold.
 
 ```cpp {title: "fn::operator|"}
 template <typename Lh, typename Rh>
-constexpr auto operator|(Lh &&lh, Rh &&rh);  // (1)
+constexpr auto operator|(Lh &&lh, Rh &&rh);                      // (1)
+constexpr auto operator|(Lh &&, Rh &&)     -> ::fn::just<void>;  // (2)
+constexpr auto operator|(Lh &&lh, Rh &&rh);                      // (3)
 
 template <some_expected_void Lh, some_expected_void Rh>
-constexpr auto operator|(Lh &&lh, Rh &&rh);  // (2)
-
-template <some_expected_void Lh, typename Rh>
-constexpr auto operator|(Lh &&lh, Rh &&rh);  // (3)
-
-template <typename Lh, some_expected_void Rh>
 constexpr auto operator|(Lh &&lh, Rh &&rh);  // (4)
 
-template <some_optional Lh, some_optional Rh>
+template <typename Lh, typename Rh>
 constexpr auto operator|(Lh &&lh, Rh &&rh);  // (5)
+
+template <some_expected_void Lh, typename Rh>
+constexpr auto operator|(Lh &&lh, Rh &&rh);  // (6)
+
+template <typename Lh, some_expected_void Rh>
+constexpr auto operator|(Lh &&lh, Rh &&rh);  // (7)
+
+template <some_optional Lh, some_optional Rh>
+constexpr auto operator|(Lh &&lh, Rh &&rh);  // (8)
 ```
 
 :include-doxygen-doc: fn::operator| { args: "Lh &&, Rh &&" }


### PR DESCRIPTION
`docs` has been red on `main` since the TYPE_ALGEBRA merge, which gates the Pages deploy — the published site stays stale until this lands.

The last commit on that PR's branch (`ee0fbd35`) took both docs checks red, and neither of its two stated goals holds:

- **The reference listings were not stale.** `docs_check_signatures` validates them against the doxygen XML of the real headers, and it passed on the preceding commit. The change dropped four `operator&` overloads — the short-circuit arms `-> std::remove_cvref_t<Rh>` and `-> std::remove_cvref_t<Lh>`, which appear in the `expected` and the `optional` group alike — and `operator|`'s `-> ::fn::just<void>` arm, duplicating four `some_optional` entries in their place.
- **`docs_check_coverage` did not need satisfying**: it was already passing. The six added exemptions name entities the check reaches, and it reports each one as unnecessary.

This restores the three files to their state before that commit, byte for byte.

Verified locally: `export_docs` exits 0 through all six steps, `docs_check_coverage` and `docs_check_signatures` included.

No new test is owed — the behaviour is gated by those two checks, which are what caught the regression.

Assisted-by: Claude:claude-opus-5
