### PR TITLE
Carry the C++26 requirement to conan consumers of fn_cxx26

### DIFF
--- a/.github/workflows/package-test-bazel.yml
+++ b/.github/workflows/package-test-bazel.yml
@@ -36,6 +36,11 @@ jobs:
         image:
           - ci-build-gcc-bazel:16
           - ci-build-clang-bazel:22
+        mode: [cxx20, cxx26]
+        # fn_cxx26 needs __cpp_lib_type_order; of the matrix images only gcc 16 has it.
+        exclude:
+          - image: ci-build-clang-bazel:22
+            mode: cxx26
     container: libfn.azurecr.io/${{ matrix.image }}-sha-95f599d
     defaults:
       run:
@@ -49,12 +54,12 @@ jobs:
 
     # main.cpp is a quine: each binary's stdout must reproduce the source exactly.
     - name: Test packaging
+      if: matrix.mode == 'cxx20'
       run: |
         bazel run --cxxopt=-std=c++20 //:main | diff - src/main.cpp
 
-    # fn_cxx26 needs __cpp_lib_type_order; of the matrix images only gcc 16 has it.
     # No --cxxopt here: the command line would override the target's -std=c++26 copt.
     - name: Test packaging (C++26 mode)
-      if: startsWith(matrix.image, 'ci-build-gcc')
+      if: matrix.mode == 'cxx26'
       run: |
         bazel run //:main_cxx26 | diff - src/main.cpp

--- a/.github/workflows/package-test-conan.yml
+++ b/.github/workflows/package-test-conan.yml
@@ -46,7 +46,7 @@ jobs:
 
     # The C++26 mode: extra_variables turns on the test_package's second executable,
     # and the test_package conanfile reads the same conf to quine-check it. cppstd
-    # stays 20: C++26 must arrive from linking libfn::fn_cxx26 alone.
+    # stays 20: C++26 build option must arrive from the libfn::fn_cxx26 dependency.
     - name: Test packaging (C++26 mode)
       if: matrix.mode == 'cxx26'
       run: |

--- a/.github/workflows/package-test-conan.yml
+++ b/.github/workflows/package-test-conan.yml
@@ -25,6 +25,10 @@ jobs:
   test_conan_linux:
     # arm64: the amd64 warp fleet pulls images at 1-2 MB/s; the arm64 fleet serves them in seconds
     runs-on: ${{ github.repository == 'libfn/functional' && 'warp-ubuntu-latest-arm64-2x' || 'ubuntu-latest' }}
+    strategy:
+      fail-fast: false
+      matrix:
+        mode: [cxx20, cxx26]
     container: libfn.azurecr.io/ci-build-gcc:16-sha-95f599d
 
     steps:
@@ -36,6 +40,7 @@ jobs:
         echo "tools.cmake.cmaketoolchain:generator=Ninja" >> ~/.conan2/global.conf
 
     - name: Test packaging
+      if: matrix.mode == 'cxx20'
       run: |
         conan create . --build=missing -s "compiler.cppstd=20"
 
@@ -43,6 +48,7 @@ jobs:
     # and the test_package conanfile reads the same conf to quine-check it. cppstd
     # stays 20: C++26 must arrive from linking libfn::fn_cxx26 alone.
     - name: Test packaging (C++26 mode)
+      if: matrix.mode == 'cxx26'
       run: |
         conan create . --build=missing -s "compiler.cppstd=20" \
           -c "tools.cmake.cmaketoolchain:extra_variables={'LIBFN_TEST_CXX26': 'ON'}"

--- a/.github/workflows/package-test-conan.yml
+++ b/.github/workflows/package-test-conan.yml
@@ -40,10 +40,11 @@ jobs:
         conan create . --build=missing -s "compiler.cppstd=20"
 
     # The C++26 mode: extra_variables turns on the test_package's second executable,
-    # and the test_package conanfile reads the same conf to quine-check it.
+    # and the test_package conanfile reads the same conf to quine-check it. cppstd
+    # stays 20: C++26 must arrive from linking libfn::fn_cxx26 alone.
     - name: Test packaging (C++26 mode)
       run: |
-        conan create . --build=missing -s "compiler.cppstd=26" \
+        conan create . --build=missing -s "compiler.cppstd=20" \
           -c "tools.cmake.cmaketoolchain:extra_variables={'LIBFN_TEST_CXX26': 'ON'}"
 
   test_conan_windows:

--- a/conanfile.py
+++ b/conanfile.py
@@ -1,7 +1,7 @@
 import os
 
 from conan import ConanFile
-from conan.tools.files import copy, load
+from conan.tools.files import copy, load, save
 from conan.tools.layout import basic_layout
 
 
@@ -48,12 +48,22 @@ class LibfnConan(ConanFile):
             src=self.source_folder,
             dst=os.path.join(self.package_folder, "licenses"),
         )
+        # CMakeDeps synthesizes its own targets and drops the compile features the CMake
+        # export carries; this build module restores fn_cxx26's language requirement.
+        save(
+            self,
+            os.path.join(self.package_folder, "cmake", "libfn-cxx26.cmake"),
+            "if(TARGET libfn::fn_cxx26)\n"
+            "  target_compile_features(libfn::fn_cxx26 INTERFACE cxx_std_26)\n"
+            "endif()\n",
+        )
 
     def package_info(self):
         # find_package(libfn) -> libfn::libfn aggregate target,
         # plus libfn::fn, libfn::fn_cxx26 and libfn::pfn component targets.
         self.cpp_info.set_property("cmake_file_name", "libfn")
         self.cpp_info.set_property("cmake_target_name", "libfn::libfn")
+        self.cpp_info.set_property("cmake_build_modules", [os.path.join("cmake", "libfn-cxx26.cmake")])
 
         # fn: the main component (headers under include/fn/); built on the pfn polyfills.
         fn = self.cpp_info.components["fn"]

--- a/test_package/CMakeLists.txt
+++ b/test_package/CMakeLists.txt
@@ -18,8 +18,7 @@ target_compile_options(main PRIVATE
 option(LIBFN_TEST_CXX26 "Build a second executable consuming libfn::fn_cxx26" OFF)
 if(LIBFN_TEST_CXX26)
     add_executable(main_cxx26 src/main.cpp)
-    # No explicit standard: C++26 must arrive as a usage requirement — the exported
-    # target's cxx_std_26, or (conan, whose CMakeDeps drops compile features) cppstd=26.
+    # No explicit standard: C++26 must arrive as a usage requirement from the linked target.
     target_link_libraries(main_cxx26 PRIVATE libfn::fn_cxx26)
     target_compile_options(main_cxx26 PRIVATE
         $<$<CXX_COMPILER_ID:GNU,Clang,AppleClang>:-Wall;-Werror>


### PR DESCRIPTION
Fixes #396.

**The fix.** CMakeDeps synthesizes its own targets and drops the compile features the CMake export carries, so linking `libfn::fn_cxx26` delivered the `LIBFN_CXX26` define but not the C++26 language version: the build stopped at the `#error` naming `__cpp_lib_type_order`. The package now ships a three-line CMake build module that restores `cxx_std_26` on `libfn::fn_cxx26` (guarded by `if(TARGET)`), registered through the `cmake_build_modules` property — the same mirroring the recipe already does for the exported compile options, extended to the compile feature.

**The test.** The conan C++26 CI lane no longer sets `compiler.cppstd=26`; it holds the consumer profile at `cppstd=20`, so C++26 can only arrive from the link line — which is the entry point's promise. Verified locally in both directions on gcc 16: without the build module the lane reproduces #396 (the `#error`, then the cascade); with it, `main` builds as C++20 and `main_cxx26` as C++26 in one build, both quine checks passing. The test_package needed no change beyond deleting a comment's now-false parenthetical — its `LIBFN_TEST_CXX26` machinery already links `libfn::fn_cxx26` with deliberately no explicit standard.

**One residual caveat.** The build module reaches CMake consumers only — effectively all conan consumers. One using another generator (Meson, MSBuild) still gets just the define, and the same loud `#error` as before; no silent path is opened or left open.

**Separate commit: one packaging mode per CI job.** CONTRIBUTING's one-concern-per-job rule, applied: the conan linux job gains a `mode: [cxx20, cxx26]` matrix, and bazel's new `mode` dimension replaces its step-level `if` with a clang×cxx26 exclude — gcc/cxx20, gcc/cxx26 and clang/cxx20 as separate checks. vcpkg and nix are already single-concern; their cxx26 consumers arrive with #352's follow-ups.

Assisted-by: Claude:claude-fable-5
